### PR TITLE
Enhance API of class Thread regarding deferred cancellation

### DIFF
--- a/history.txt
+++ b/history.txt
@@ -180,6 +180,7 @@ History:
 ===============================================================================
 2024-07-12
 - Bugfix: Evaluation of return value of nanosleep().
+- Enhanced API of class Thread regarding deferred cancellation.
 
 2024-06-18
 - Enable rewriting the previous line in CLI

--- a/include/gpcc/osal/os/chibios_arm/Thread.hpp
+++ b/include/gpcc/osal/os/chibios_arm/Thread.hpp
@@ -57,10 +57,10 @@ namespace osal {
  * _running_ state when it starts executing the referenced thread entry function. As shown in the example below,
  * optional parameters can be passed to the thread entry function via the functor passed to @ref Start().
  *
- * After returning from the thread entry function or after thread cancellation, the thread has _terminated_.
- * _Terminated_ threads must be _joined_ via @ref Join() in order to release the resources occupied by the thread
- * (e.g. the thread's stack). After "joining" a thread, the @ref Thread object may be either destroyed or a new thread
- * may be started by invoking @ref Start().
+ * After returning from the thread entry function, or after invocation of @ref TerminateNow(), or after deferred thread
+ * cancellation, the thread has _terminated_. _Terminated_ threads must be _joined_ via @ref Join() in order to release
+ * the resources occupied by the thread (e.g. the thread's stack). After "joining" a thread, the @ref Thread object may
+ * be either destroyed or a new thread may be started by invoking @ref Start().
  *
  * The thread-entry function must always return `void*`. The return value of the thread entry function will be returned
  * by the @ref Join() method when the thread is later "joined". This mechanism can be used to transport results or
@@ -162,8 +162,7 @@ namespace osal {
  * ~~~
  *
  * The default configuration for any new thread is that deferred cancellation is _enabled_.\n
- * Threads can retrieve and change their own cancelabilty state by invoking @ref GetCancelabilityEnabled() and
- * @ref SetCancelabilityEnabled().
+ * Threads can retrieve and change their own cancelabilty state via @ref SetCancelabilityEnabled().
  *
  * Threads can invoke @ref IsCancellationPending() to figure out if a cancellation request is pending. The function
  * does not care if cancelabilty is currently enabled or disabled.
@@ -254,9 +253,9 @@ namespace osal {
  * ## Exception- and Cancellation-safety-notes
  * Each method of this class contains notes about the exception and thread-cancellation safety of the specific method.
  *
- * Note that these specifications often specify a lower guarantee than the actual implementation of this class does.
- * The reason is that this class is operating system specific and portable. The specifications must be so low that they
- * can be fulfilled by any implementation.
+ * Note that these specifications often specify a lower guarantee than the actual implementation of this class actually
+ * provides. The reason is that this class is operating system specific and portable. The specifications must be so low
+ * that they can be fulfilled by any implementation.
  *
  * - - -
  *
@@ -353,8 +352,7 @@ class Thread final
     void AdviceTFC_JoiningThreadWillNotBlockPermanently(void);
 
     // public methods allowed to be called ONLY by the thread managed by this object
-    void SetCancelabilityEnabled(bool const enable);
-    bool GetCancelabilityEnabled(void) const;
+    bool SetCancelabilityEnabled(bool const enable);
 
     bool IsCancellationPending(void) const;
     void TestForCancellation(void);

--- a/include/gpcc/osal/os/chibios_arm/Thread.hpp
+++ b/include/gpcc/osal/os/chibios_arm/Thread.hpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011 Daniel Jerolm
+    Copyright (C) 2011, 2024 Daniel Jerolm
 */
 
 #ifdef OS_CHIBIOS_ARM

--- a/include/gpcc/osal/os/linux_arm/Thread.hpp
+++ b/include/gpcc/osal/os/linux_arm/Thread.hpp
@@ -58,10 +58,10 @@ namespace osal {
  * _running_ state when it starts executing the referenced thread entry function. As shown in the example below,
  * optional parameters can be passed to the thread entry function via the functor passed to @ref Start().
  *
- * After returning from the thread entry function or after thread cancellation, the thread has _terminated_.
- * _Terminated_ threads must be _joined_ via @ref Join() in order to release the resources occupied by the thread
- * (e.g. the thread's stack). After "joining" a thread, the @ref Thread object may be either destroyed or a new thread
- * may be started by invoking @ref Start().
+ * After returning from the thread entry function, or after invocation of @ref TerminateNow(), or after deferred thread
+ * cancellation, the thread has _terminated_. _Terminated_ threads must be _joined_ via @ref Join() in order to release
+ * the resources occupied by the thread (e.g. the thread's stack). After "joining" a thread, the @ref Thread object may
+ * be either destroyed or a new thread may be started by invoking @ref Start().
  *
  * The thread-entry function must always return `void*`. The return value of the thread entry function will be returned
  * by the @ref Join() method when the thread is later "joined". This mechanism can be used to transport results or
@@ -163,8 +163,7 @@ namespace osal {
  * ~~~
  *
  * The default configuration for any new thread is that deferred cancellation is _enabled_.\n
- * Threads can retrieve and change their own cancelabilty state by invoking @ref GetCancelabilityEnabled() and
- * @ref SetCancelabilityEnabled().
+ * Threads can retrieve and change their own cancelabilty state via @ref SetCancelabilityEnabled().
  *
  * Threads can invoke @ref IsCancellationPending() to figure out if a cancellation request is pending. The function
  * does not care if cancelabilty is currently enabled or disabled.
@@ -255,9 +254,9 @@ namespace osal {
  * ## Exception- and Cancellation-safety-notes
  * Each method of this class contains notes about the exception and thread-cancellation safety of the specific method.
  *
- * Note that these specifications often specify a lower guarantee than the actual implementation of this class does.
- * The reason is that this class is operating system specific and portable. The specifications must be so low that they
- * can be fulfilled by any implementation.
+ * Note that these specifications often specify a lower guarantee than the actual implementation of this class actually
+ * provides. The reason is that this class is operating system specific and portable. The specifications must be so low
+ * that they can be fulfilled by any implementation.
  *
  * - - -
  *
@@ -354,8 +353,7 @@ class Thread final
     void AdviceTFC_JoiningThreadWillNotBlockPermanently(void);
 
     // public methods allowed to be called ONLY by the thread managed by this object
-    void SetCancelabilityEnabled(bool const enable);
-    bool GetCancelabilityEnabled(void) const;
+    bool SetCancelabilityEnabled(bool const enable);
 
     bool IsCancellationPending(void) const;
     void TestForCancellation(void);
@@ -403,12 +401,6 @@ class Thread final
     /** @ref mutex is required.\n
         This only contains a valid value if @ref threadState does not equal @ref ThreadState::noThreadOrJoined. */
     pthread_t thread_id;
-
-    /// Flag controlling if thread cancellation is currently enabled or disabled.
-    /** No mutex required: This is only accessed by the thread managed by this object and before thread start.\n
-        true  = enabled\n
-        false = disabled (note: cancellation requests are not ignored, but queued!) */
-    bool cancelabilityEnabled;
 
     /// Thread cancellation pending flag.
     /** true  = thread cancellation is pending\n

--- a/include/gpcc/osal/os/linux_arm/Thread.hpp
+++ b/include/gpcc/osal/os/linux_arm/Thread.hpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011 Daniel Jerolm
+    Copyright (C) 2011, 2024 Daniel Jerolm
 */
 
 #ifdef OS_LINUX_ARM

--- a/include/gpcc/osal/os/linux_arm_tfc/Thread.hpp
+++ b/include/gpcc/osal/os/linux_arm_tfc/Thread.hpp
@@ -70,10 +70,10 @@ class TFCCore;
  * _running_ state when it starts executing the referenced thread entry function. As shown in the example below,
  * optional parameters can be passed to the thread entry function via the functor passed to @ref Start().
  *
- * After returning from the thread entry function or after thread cancellation, the thread has _terminated_.
- * _Terminated_ threads must be _joined_ via @ref Join() in order to release the resources occupied by the thread
- * (e.g. the thread's stack). After "joining" a thread, the @ref Thread object may be either destroyed or a new thread
- * may be started by invoking @ref Start().
+ * After returning from the thread entry function, or after invocation of @ref TerminateNow(), or after deferred thread
+ * cancellation, the thread has _terminated_. _Terminated_ threads must be _joined_ via @ref Join() in order to release
+ * the resources occupied by the thread (e.g. the thread's stack). After "joining" a thread, the @ref Thread object may
+ * be either destroyed or a new thread may be started by invoking @ref Start().
  *
  * The thread-entry function must always return `void*`. The return value of the thread entry function will be returned
  * by the @ref Join() method when the thread is later "joined". This mechanism can be used to transport results or
@@ -175,8 +175,7 @@ class TFCCore;
  * ~~~
  *
  * The default configuration for any new thread is that deferred cancellation is _enabled_.\n
- * Threads can retrieve and change their own cancelabilty state by invoking @ref GetCancelabilityEnabled() and
- * @ref SetCancelabilityEnabled().
+ * Threads can retrieve and change their own cancelabilty state via @ref SetCancelabilityEnabled().
  *
  * Threads can invoke @ref IsCancellationPending() to figure out if a cancellation request is pending. The function
  * does not care if cancelabilty is currently enabled or disabled.
@@ -267,9 +266,9 @@ class TFCCore;
  * ## Exception- and Cancellation-safety-notes
  * Each method of this class contains notes about the exception and thread-cancellation safety of the specific method.
  *
- * Note that these specifications often specify a lower guarantee than the actual implementation of this class does.
- * The reason is that this class is operating system specific and portable. The specifications must be so low that they
- * can be fulfilled by any implementation.
+ * Note that these specifications often specify a lower guarantee than the actual implementation of this class actually
+ * provides. The reason is that this class is operating system specific and portable. The specifications must be so low
+ * that they can be fulfilled by any implementation.
  *
  * - - -
  *
@@ -366,8 +365,7 @@ class Thread final
     void AdviceTFC_JoiningThreadWillNotBlockPermanently(void);
 
     // public methods allowed to be called ONLY by the thread managed by this object
-    void SetCancelabilityEnabled(bool const enable);
-    bool GetCancelabilityEnabled(void) const;
+    bool SetCancelabilityEnabled(bool const enable);
 
     bool IsCancellationPending(void) const;
     void TestForCancellation(void);
@@ -424,12 +422,6 @@ class Thread final
     /// Flag indicating if a thread is waiting for joining with the managed thread.
     /** @ref spMutex is required. */
     bool threadWaitingForJoin;
-
-    /// Flag controlling if thread cancellation is currently enabled or disabled.
-    /** No mutex required: This is only accessed by the thread managed by this object and before thread start.\n
-        true  = enabled\n
-        false = disabled (note: cancellation requests are not ignored, but queued!) */
-    bool cancelabilityEnabled;
 
     /// Thread cancellation pending flag.
     /** true  = thread cancellation is pending\n

--- a/include/gpcc/osal/os/linux_arm_tfc/Thread.hpp
+++ b/include/gpcc/osal/os/linux_arm_tfc/Thread.hpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011 Daniel Jerolm
+    Copyright (C) 2011, 2024 Daniel Jerolm
 */
 
 #ifdef OS_LINUX_ARM_TFC

--- a/include/gpcc/osal/os/linux_x64/Thread.hpp
+++ b/include/gpcc/osal/os/linux_x64/Thread.hpp
@@ -58,10 +58,10 @@ namespace osal {
  * _running_ state when it starts executing the referenced thread entry function. As shown in the example below,
  * optional parameters can be passed to the thread entry function via the functor passed to @ref Start().
  *
- * After returning from the thread entry function or after thread cancellation, the thread has _terminated_.
- * _Terminated_ threads must be _joined_ via @ref Join() in order to release the resources occupied by the thread
- * (e.g. the thread's stack). After "joining" a thread, the @ref Thread object may be either destroyed or a new thread
- * may be started by invoking @ref Start().
+ * After returning from the thread entry function, or after invocation of @ref TerminateNow(), or after deferred thread
+ * cancellation, the thread has _terminated_. _Terminated_ threads must be _joined_ via @ref Join() in order to release
+ * the resources occupied by the thread (e.g. the thread's stack). After "joining" a thread, the @ref Thread object may
+ * be either destroyed or a new thread may be started by invoking @ref Start().
  *
  * The thread-entry function must always return `void*`. The return value of the thread entry function will be returned
  * by the @ref Join() method when the thread is later "joined". This mechanism can be used to transport results or
@@ -163,8 +163,7 @@ namespace osal {
  * ~~~
  *
  * The default configuration for any new thread is that deferred cancellation is _enabled_.\n
- * Threads can retrieve and change their own cancelabilty state by invoking @ref GetCancelabilityEnabled() and
- * @ref SetCancelabilityEnabled().
+ * Threads can retrieve and change their own cancelabilty state via @ref SetCancelabilityEnabled().
  *
  * Threads can invoke @ref IsCancellationPending() to figure out if a cancellation request is pending. The function
  * does not care if cancelabilty is currently enabled or disabled.
@@ -255,9 +254,9 @@ namespace osal {
  * ## Exception- and Cancellation-safety-notes
  * Each method of this class contains notes about the exception and thread-cancellation safety of the specific method.
  *
- * Note that these specifications often specify a lower guarantee than the actual implementation of this class does.
- * The reason is that this class is operating system specific and portable. The specifications must be so low that they
- * can be fulfilled by any implementation.
+ * Note that these specifications often specify a lower guarantee than the actual implementation of this class actually
+ * provides. The reason is that this class is operating system specific and portable. The specifications must be so low
+ * that they can be fulfilled by any implementation.
  *
  * - - -
  *
@@ -354,8 +353,7 @@ class Thread final
     void AdviceTFC_JoiningThreadWillNotBlockPermanently(void);
 
     // public methods allowed to be called ONLY by the thread managed by this object
-    void SetCancelabilityEnabled(bool const enable);
-    bool GetCancelabilityEnabled(void) const;
+    bool SetCancelabilityEnabled(bool const enable);
 
     bool IsCancellationPending(void) const;
     void TestForCancellation(void);
@@ -403,12 +401,6 @@ class Thread final
     /** @ref mutex is required.\n
         This only contains a valid value if @ref threadState does not equal @ref ThreadState::noThreadOrJoined. */
     pthread_t thread_id;
-
-    /// Flag controlling if thread cancellation is currently enabled or disabled.
-    /** No mutex required: This is only accessed by the thread managed by this object and before thread start.\n
-        true  = enabled\n
-        false = disabled (note: cancellation requests are not ignored, but queued!) */
-    bool cancelabilityEnabled;
 
     /// Thread cancellation pending flag.
     /** true  = thread cancellation is pending\n

--- a/include/gpcc/osal/os/linux_x64/Thread.hpp
+++ b/include/gpcc/osal/os/linux_x64/Thread.hpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011 Daniel Jerolm
+    Copyright (C) 2011, 2024 Daniel Jerolm
 */
 
 #ifdef OS_LINUX_X64

--- a/include/gpcc/osal/os/linux_x64_tfc/Thread.hpp
+++ b/include/gpcc/osal/os/linux_x64_tfc/Thread.hpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011 Daniel Jerolm
+    Copyright (C) 2011, 2024 Daniel Jerolm
 */
 
 #ifdef OS_LINUX_X64_TFC

--- a/include/gpcc/osal/os/linux_x64_tfc/Thread.hpp
+++ b/include/gpcc/osal/os/linux_x64_tfc/Thread.hpp
@@ -70,10 +70,10 @@ class TFCCore;
  * _running_ state when it starts executing the referenced thread entry function. As shown in the example below,
  * optional parameters can be passed to the thread entry function via the functor passed to @ref Start().
  *
- * After returning from the thread entry function or after thread cancellation, the thread has _terminated_.
- * _Terminated_ threads must be _joined_ via @ref Join() in order to release the resources occupied by the thread
- * (e.g. the thread's stack). After "joining" a thread, the @ref Thread object may be either destroyed or a new thread
- * may be started by invoking @ref Start().
+ * After returning from the thread entry function, or after invocation of @ref TerminateNow(), or after deferred thread
+ * cancellation, the thread has _terminated_. _Terminated_ threads must be _joined_ via @ref Join() in order to release
+ * the resources occupied by the thread (e.g. the thread's stack). After "joining" a thread, the @ref Thread object may
+ * be either destroyed or a new thread may be started by invoking @ref Start().
  *
  * The thread-entry function must always return `void*`. The return value of the thread entry function will be returned
  * by the @ref Join() method when the thread is later "joined". This mechanism can be used to transport results or
@@ -175,8 +175,7 @@ class TFCCore;
  * ~~~
  *
  * The default configuration for any new thread is that deferred cancellation is _enabled_.\n
- * Threads can retrieve and change their own cancelabilty state by invoking @ref GetCancelabilityEnabled() and
- * @ref SetCancelabilityEnabled().
+ * Threads can retrieve and change their own cancelabilty state via @ref SetCancelabilityEnabled().
  *
  * Threads can invoke @ref IsCancellationPending() to figure out if a cancellation request is pending. The function
  * does not care if cancelabilty is currently enabled or disabled.
@@ -267,9 +266,9 @@ class TFCCore;
  * ## Exception- and Cancellation-safety-notes
  * Each method of this class contains notes about the exception and thread-cancellation safety of the specific method.
  *
- * Note that these specifications often specify a lower guarantee than the actual implementation of this class does.
- * The reason is that this class is operating system specific and portable. The specifications must be so low that they
- * can be fulfilled by any implementation.
+ * Note that these specifications often specify a lower guarantee than the actual implementation of this class actually
+ * provides. The reason is that this class is operating system specific and portable. The specifications must be so low
+ * that they can be fulfilled by any implementation.
  *
  * - - -
  *
@@ -366,8 +365,7 @@ class Thread final
     void AdviceTFC_JoiningThreadWillNotBlockPermanently(void);
 
     // public methods allowed to be called ONLY by the thread managed by this object
-    void SetCancelabilityEnabled(bool const enable);
-    bool GetCancelabilityEnabled(void) const;
+    bool SetCancelabilityEnabled(bool const enable);
 
     bool IsCancellationPending(void) const;
     void TestForCancellation(void);
@@ -424,12 +422,6 @@ class Thread final
     /// Flag indicating if a thread is waiting for joining with the managed thread.
     /** @ref spMutex is required. */
     bool threadWaitingForJoin;
-
-    /// Flag controlling if thread cancellation is currently enabled or disabled.
-    /** No mutex required: This is only accessed by the thread managed by this object and before thread start.\n
-        true  = enabled\n
-        false = disabled (note: cancellation requests are not ignored, but queued!) */
-    bool cancelabilityEnabled;
 
     /// Thread cancellation pending flag.
     /** true  = thread cancellation is pending\n

--- a/src/cli/CLI.cpp
+++ b/src/cli/CLI.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011 Daniel Jerolm
+    Copyright (C) 2011, 2024 Daniel Jerolm
 */
 
 #include <gpcc/cli/CLI.hpp>

--- a/src/cli/CLI.cpp
+++ b/src/cli/CLI.cpp
@@ -2083,7 +2083,7 @@ void CLI::LogIn(void)
  */
 void* CLI::InternalThreadEntry(void)
 {
-  thread.SetCancelabilityEnabled(false);
+  (void)thread.SetCancelabilityEnabled(false);
 
   loggedIn = false;
 

--- a/src/cood/remote_access/infrastructure/ThreadBasedRemoteAccessServer.cpp
+++ b/src/cood/remote_access/infrastructure/ThreadBasedRemoteAccessServer.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2021 Daniel Jerolm
+    Copyright (C) 2021, 2024 Daniel Jerolm
 */
 
 #include <gpcc/cood/remote_access/infrastructure/ThreadBasedRemoteAccessServer.hpp>

--- a/src/cood/remote_access/infrastructure/ThreadBasedRemoteAccessServer.cpp
+++ b/src/cood/remote_access/infrastructure/ThreadBasedRemoteAccessServer.cpp
@@ -222,7 +222,7 @@ void* ThreadBasedRemoteAccessServer::ThreadEntry(void) noexcept
   try
   {
     // Disable deferred thread cancellation. We cancel gracefully using our own logic.
-    thread.SetCancelabilityEnabled(false);
+    (void)thread.SetCancelabilityEnabled(false);
 
     OnStart();
     ServeRequests();

--- a/src/execution/async/DWQwithThread.cpp
+++ b/src/execution/async/DWQwithThread.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2023 Daniel Jerolm
+    Copyright (C) 2023, 2024 Daniel Jerolm
 */
 
 #include <gpcc/execution/async/DWQwithThread.hpp>

--- a/src/execution/async/DWQwithThread.cpp
+++ b/src/execution/async/DWQwithThread.cpp
@@ -139,7 +139,7 @@ void DWQwithThread::Stop(void) noexcept
  */
 void* DWQwithThread::ThreadEntry(void)
 {
-  thread.SetCancelabilityEnabled(false);
+  (void)thread.SetCancelabilityEnabled(false);
 
   try
   {

--- a/src/execution/async/SuspendableDWQwithThread.cpp
+++ b/src/execution/async/SuspendableDWQwithThread.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2023 Daniel Jerolm
+    Copyright (C) 2023, 2024 Daniel Jerolm
 */
 
 #include <gpcc/execution/async/SuspendableDWQwithThread.hpp>

--- a/src/execution/async/SuspendableDWQwithThread.cpp
+++ b/src/execution/async/SuspendableDWQwithThread.cpp
@@ -294,7 +294,7 @@ void SuspendableDWQwithThread::Resume(void)
  */
 void* SuspendableDWQwithThread::ThreadEntry(void) noexcept
 {
-  thread.SetCancelabilityEnabled(false);
+  (void)thread.SetCancelabilityEnabled(false);
 
   while (true)
   {

--- a/src/log/logfacilities/ThreadedLogFacility.cpp
+++ b/src/log/logfacilities/ThreadedLogFacility.cpp
@@ -564,7 +564,7 @@ void* ThreadedLogFacility::InternalThreadEntry(void) noexcept
 {
   try
   {
-    thread.SetCancelabilityEnabled(false);
+    (void)thread.SetCancelabilityEnabled(false);
 
     gpcc::osal::AdvancedMutexLocker msgListMutexLocker(msgListMutex);
     while (!thread.IsCancellationPending())

--- a/src/log/logfacilities/ThreadedLogFacility.cpp
+++ b/src/log/logfacilities/ThreadedLogFacility.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011 Daniel Jerolm
+    Copyright (C) 2011, 2024 Daniel Jerolm
 */
 
 #include <gpcc/log/logfacilities/ThreadedLogFacility.hpp>

--- a/src/osal/os/chibios_arm/Thread.cpp
+++ b/src/osal/os/chibios_arm/Thread.cpp
@@ -710,7 +710,12 @@ void* Thread::Join(bool* const pCancelled)
 }
 
 /**
- * \brief Enables/disables cancelability.
+ * \brief Enables/disables cancelability and retrieves the previous state.
+ *
+ * This function has no effect, if the current cancelability state already equals @p enable.
+ *
+ * Note that if cancelability is disabled, any cancellation request will _not be dropped_ but _queued_ until
+ * cancellation is enabled again or until the thread terminates.
  *
  * - - -
  *
@@ -728,11 +733,14 @@ void* Thread::Join(bool* const pCancelled)
  * \param enable
  * New cancelability state:\n
  * true = cancellation shall be enabled\n
- * false = cancellation shall be disabled\n
- * Note that if cancelability is disabled, any cancellation request will _not be dropped_ but _queued_ until
- * cancellation is enabled again or until the thread terminates.
+ * false = cancellation shall be disabled
+ *
+ * \return
+ * Previous cancelability state.\n
+ * This could be stored and used to recover the previous state at a later point in time, e.g. if cancelability shall
+ * be disabled temporarily only.
  */
-void Thread::SetCancelabilityEnabled(bool const enable)
+bool Thread::SetCancelabilityEnabled(bool const enable)
 {
   MutexLocker mutexLocker(mutex);
 
@@ -740,39 +748,9 @@ void Thread::SetCancelabilityEnabled(bool const enable)
   if ((threadState != ThreadState::running) || (chThdGetSelfX() != pThread))
     throw std::logic_error("Thread::SetCancelabilityEnabled: Not invoked by the managed thread");
 
+  bool const oldState = cancelabilityEnabled;
   cancelabilityEnabled = enable;
-}
-
-/**
- * \brief Retrieves if cancelability is enabled or disabled.
- *
- * - - -
- *
- * __Thread safety:__\n
- * Only the thread managed by this object is allowed to call this method.
- *
- * __Exception safety:__\n
- * Strong guarantee.
- *
- * __Thread cancellation safety:__\n
- * No cancellation point included.
- *
- * - - -
- *
- * \return
- * Current cancelability state:\n
- * true  = cancellation enabled\n
- * false = cancellation disabled
- */
-bool Thread::GetCancelabilityEnabled(void) const
-{
-  MutexLocker mutexLocker(mutex);
-
-  // verify that the current thread is the one managed by this object
-  if ((threadState != ThreadState::running) || (chThdGetSelfX() != pThread))
-    throw std::logic_error("Thread::GetCancelabilityEnabled: Not invoked by the managed thread");
-
-  return cancelabilityEnabled;
+  return oldState;
 }
 
 /**

--- a/src/osal/os/chibios_arm/Thread.cpp
+++ b/src/osal/os/chibios_arm/Thread.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011 Daniel Jerolm
+    Copyright (C) 2011, 2024 Daniel Jerolm
 */
 
 #ifdef OS_CHIBIOS_ARM

--- a/src/osal/os/linux_arm/Thread.cpp
+++ b/src/osal/os/linux_arm/Thread.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011 Daniel Jerolm
+    Copyright (C) 2011, 2024 Daniel Jerolm
 */
 
 #ifdef OS_LINUX_ARM

--- a/src/osal/os/linux_arm_tfc/Thread.cpp
+++ b/src/osal/os/linux_arm_tfc/Thread.cpp
@@ -207,7 +207,6 @@ Thread::Thread(std::string const & _name)
 , spThreadStateRunningCondVar(std::make_unique<internal::UnmanagedConditionVariable>())
 , thread_id()
 , threadWaitingForJoin(false)
-, cancelabilityEnabled(false)
 , cancellationPending(false)
 , joiningThreadWillNotBlockPerm(false)
 {
@@ -711,7 +710,6 @@ void Thread::Start(tEntryFunction const & _entryFunction,
   entryFunction                 = _entryFunction;
   threadState                   = ThreadState::starting;
   threadWaitingForJoin          = false;
-  cancelabilityEnabled          = true;
   cancellationPending           = false;
   joiningThreadWillNotBlockPerm = false;
 
@@ -1072,7 +1070,12 @@ void Thread::AdviceTFC_JoiningThreadWillNotBlockPermanently(void)
 }
 
 /**
- * \brief Enables/disables cancelability.
+ * \brief Enables/disables cancelability and retrieves the previous state.
+ *
+ * This function has no effect, if the current cancelability state already equals @p enable.
+ *
+ * Note that if cancelability is disabled, any cancellation request will _not be dropped_ but _queued_ until
+ * cancellation is enabled again or until the thread terminates.
  *
  * - - -
  *
@@ -1090,11 +1093,14 @@ void Thread::AdviceTFC_JoiningThreadWillNotBlockPermanently(void)
  * \param enable
  * New cancelability state:\n
  * true = cancellation shall be enabled\n
- * false = cancellation shall be disabled\n
- * Note that if cancelability is disabled, any cancellation request will _not be dropped_ but _queued_ until
- * cancellation is enabled again or until the thread terminates.
+ * false = cancellation shall be disabled
+ *
+ * \return
+ * Previous cancelability state.\n
+ * This could be stored and used to recover the previous state at a later point in time, e.g. if cancelability shall
+ * be disabled temporarily only.
  */
-void Thread::SetCancelabilityEnabled(bool const enable)
+bool Thread::SetCancelabilityEnabled(bool const enable)
 {
   // verify that the current thread is the one managed by this object
   {
@@ -1103,54 +1109,13 @@ void Thread::SetCancelabilityEnabled(bool const enable)
       throw std::logic_error("Thread::SetCancelabilityEnabled: Not invoked by the managed thread");
   }
 
-  // requested value different from current one?
-  if (cancelabilityEnabled != enable)
-  {
-    cancelabilityEnabled = enable;
+  int oldstate;
+  int const status = pthread_setcancelstate(enable ? PTHREAD_CANCEL_ENABLE : PTHREAD_CANCEL_DISABLE, &oldstate);
 
-    int status;
-    if (enable)
-      status = pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, nullptr);
-    else
-      status = pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, nullptr);
-    if (status != 0)
-    {
-      cancelabilityEnabled = !cancelabilityEnabled;
-      throw std::system_error(status, std::generic_category(), "Thread::SetCancelabilityEnabled: pthread_setcancelstate() failed");
-    }
-  }
-}
+  if (status != 0)
+    throw std::system_error(status, std::generic_category(), "Thread::SetCancelabilityEnabled: pthread_setcancelstate() failed");
 
-/**
- * \brief Retrieves if cancelability is enabled or disabled.
- *
- * - - -
- *
- * __Thread safety:__\n
- * Only the thread managed by this object is allowed to call this method.
- *
- * __Exception safety:__\n
- * Strong guarantee.
- *
- * __Thread cancellation safety:__\n
- * No cancellation point included.
- *
- * - - -
- *
- * \return
- * Current cancelability state:\n
- * true  = cancellation enabled\n
- * false = cancellation disabled
- */
-bool Thread::GetCancelabilityEnabled(void) const
-{
-  internal::UnmanagedMutexLocker mutexLocker(*spMutex);
-
-  // verify that the current thread is the one managed by this object
-  if ((threadState != ThreadState::running) || (pthread_equal(thread_id, pthread_self()) == 0))
-    throw std::logic_error("Thread::GetCancelabilityEnabled: Not invoked by the managed thread");
-
-  return cancelabilityEnabled;
+  return (oldstate == PTHREAD_CANCEL_ENABLE);
 }
 
 /**

--- a/src/osal/os/linux_arm_tfc/Thread.cpp
+++ b/src/osal/os/linux_arm_tfc/Thread.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011 Daniel Jerolm
+    Copyright (C) 2011, 2024 Daniel Jerolm
 */
 
 #ifdef OS_LINUX_ARM_TFC

--- a/src/osal/os/linux_x64/Thread.cpp
+++ b/src/osal/os/linux_x64/Thread.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011 Daniel Jerolm
+    Copyright (C) 2011, 2024 Daniel Jerolm
 */
 
 #ifdef OS_LINUX_X64

--- a/src/osal/os/linux_x64_tfc/Thread.cpp
+++ b/src/osal/os/linux_x64_tfc/Thread.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011 Daniel Jerolm
+    Copyright (C) 2011, 2024 Daniel Jerolm
 */
 
 #ifdef OS_LINUX_X64_TFC

--- a/src/osal/os/linux_x64_tfc/Thread.cpp
+++ b/src/osal/os/linux_x64_tfc/Thread.cpp
@@ -207,7 +207,6 @@ Thread::Thread(std::string const & _name)
 , spThreadStateRunningCondVar(std::make_unique<internal::UnmanagedConditionVariable>())
 , thread_id()
 , threadWaitingForJoin(false)
-, cancelabilityEnabled(false)
 , cancellationPending(false)
 , joiningThreadWillNotBlockPerm(false)
 {
@@ -711,7 +710,6 @@ void Thread::Start(tEntryFunction const & _entryFunction,
   entryFunction                 = _entryFunction;
   threadState                   = ThreadState::starting;
   threadWaitingForJoin          = false;
-  cancelabilityEnabled          = true;
   cancellationPending           = false;
   joiningThreadWillNotBlockPerm = false;
 
@@ -1072,7 +1070,12 @@ void Thread::AdviceTFC_JoiningThreadWillNotBlockPermanently(void)
 }
 
 /**
- * \brief Enables/disables cancelability.
+ * \brief Enables/disables cancelability and retrieves the previous state.
+ *
+ * This function has no effect, if the current cancelability state already equals @p enable.
+ *
+ * Note that if cancelability is disabled, any cancellation request will _not be dropped_ but _queued_ until
+ * cancellation is enabled again or until the thread terminates.
  *
  * - - -
  *
@@ -1090,11 +1093,14 @@ void Thread::AdviceTFC_JoiningThreadWillNotBlockPermanently(void)
  * \param enable
  * New cancelability state:\n
  * true = cancellation shall be enabled\n
- * false = cancellation shall be disabled\n
- * Note that if cancelability is disabled, any cancellation request will _not be dropped_ but _queued_ until
- * cancellation is enabled again or until the thread terminates.
+ * false = cancellation shall be disabled
+ *
+ * \return
+ * Previous cancelability state.\n
+ * This could be stored and used to recover the previous state at a later point in time, e.g. if cancelability shall
+ * be disabled temporarily only.
  */
-void Thread::SetCancelabilityEnabled(bool const enable)
+bool Thread::SetCancelabilityEnabled(bool const enable)
 {
   // verify that the current thread is the one managed by this object
   {
@@ -1103,54 +1109,13 @@ void Thread::SetCancelabilityEnabled(bool const enable)
       throw std::logic_error("Thread::SetCancelabilityEnabled: Not invoked by the managed thread");
   }
 
-  // requested value different from current one?
-  if (cancelabilityEnabled != enable)
-  {
-    cancelabilityEnabled = enable;
+  int oldstate;
+  int const status = pthread_setcancelstate(enable ? PTHREAD_CANCEL_ENABLE : PTHREAD_CANCEL_DISABLE, &oldstate);
 
-    int status;
-    if (enable)
-      status = pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, nullptr);
-    else
-      status = pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, nullptr);
-    if (status != 0)
-    {
-      cancelabilityEnabled = !cancelabilityEnabled;
-      throw std::system_error(status, std::generic_category(), "Thread::SetCancelabilityEnabled: pthread_setcancelstate() failed");
-    }
-  }
-}
+  if (status != 0)
+    throw std::system_error(status, std::generic_category(), "Thread::SetCancelabilityEnabled: pthread_setcancelstate() failed");
 
-/**
- * \brief Retrieves if cancelability is enabled or disabled.
- *
- * - - -
- *
- * __Thread safety:__\n
- * Only the thread managed by this object is allowed to call this method.
- *
- * __Exception safety:__\n
- * Strong guarantee.
- *
- * __Thread cancellation safety:__\n
- * No cancellation point included.
- *
- * - - -
- *
- * \return
- * Current cancelability state:\n
- * true  = cancellation enabled\n
- * false = cancellation disabled
- */
-bool Thread::GetCancelabilityEnabled(void) const
-{
-  internal::UnmanagedMutexLocker mutexLocker(*spMutex);
-
-  // verify that the current thread is the one managed by this object
-  if ((threadState != ThreadState::running) || (pthread_equal(thread_id, pthread_self()) == 0))
-    throw std::logic_error("Thread::GetCancelabilityEnabled: Not invoked by the managed thread");
-
-  return cancelabilityEnabled;
+  return (oldstate == PTHREAD_CANCEL_ENABLE);
 }
 
 /**

--- a/testcases/osal/TestThread.cpp
+++ b/testcases/osal/TestThread.cpp
@@ -75,7 +75,7 @@ class gpcc_osal_Thread_TestsF: public Test
     void* ThreadEntry_Throw(void);
     void* ThreadEntry_AttemptToJoinSelf(Thread* const pThread);
     void* ThreadEntry_JoinOtherThread(Thread* const pThread);
-    void* ThreadEntry_GetSetCancelabilityEnabled(Thread* const pThread);
+    void* ThreadEntry_SetCancelabilityEnabled(Thread* const pThread);
     void* ThreadEntry_DisableCancelability(Thread* const pThread);
     void* ThreadEntry_DisableAndEnableCancelability(Thread* const pThread);
     void* ThreadEntry_CancelOnTestForCancellation(Thread* const pThread);
@@ -207,39 +207,30 @@ void* gpcc_osal_Thread_TestsF::ThreadEntry_JoinOtherThread(Thread* const pThread
   return nullptr;
 }
 
-void* gpcc_osal_Thread_TestsF::ThreadEntry_GetSetCancelabilityEnabled(Thread* const pThread)
+void* gpcc_osal_Thread_TestsF::ThreadEntry_SetCancelabilityEnabled(Thread* const pThread)
 {
   std::unique_ptr<bool> spRetVal(new bool);
 
   *spRetVal = true;
 
-  // must be initially true
-  if (!pThread->GetCancelabilityEnabled())
-    *spRetVal = false;
-
-  // set must be ignored
-  pThread->SetCancelabilityEnabled(true);
-  if (!pThread->GetCancelabilityEnabled())
+  // must be initially true and set must be ignored
+  if (!pThread->SetCancelabilityEnabled(true))
     *spRetVal = false;
 
   // set to false
-  pThread->SetCancelabilityEnabled(false);
-  if (pThread->GetCancelabilityEnabled())
+  if (!pThread->SetCancelabilityEnabled(false))
     *spRetVal = false;
 
   // 2nd set to false must be ignored
-  pThread->SetCancelabilityEnabled(false);
-  if (pThread->GetCancelabilityEnabled())
+  if (pThread->SetCancelabilityEnabled(false))
     *spRetVal = false;
 
   // set back to true
-  pThread->SetCancelabilityEnabled(true);
-  if (!pThread->GetCancelabilityEnabled())
+  if (pThread->SetCancelabilityEnabled(true))
     *spRetVal = false;
 
   // 2nd set to true must be ignored
-  pThread->SetCancelabilityEnabled(true);
-  if (!pThread->GetCancelabilityEnabled())
+  if (!pThread->SetCancelabilityEnabled(true))
     *spRetVal = false;
 
   return spRetVal.release();
@@ -971,11 +962,11 @@ TEST_F(gpcc_osal_Thread_TestsF, SetCancelabilityEnabled_WrongThread)
   ASSERT_THROW(uut.SetCancelabilityEnabled(true), std::logic_error);
 }
 
-TEST_F(gpcc_osal_Thread_TestsF, GetSetCancelabilityEnabled)
+TEST_F(gpcc_osal_Thread_TestsF, SetCancelabilityEnabled)
 {
   Thread uut("Test");
 
-  uut.Start(std::bind(&GTEST_TEST_CLASS_NAME_(gpcc_osal_Thread_TestsF, GetSetCancelabilityEnabled)::ThreadEntry_GetSetCancelabilityEnabled, this, &uut),
+  uut.Start(std::bind(&GTEST_TEST_CLASS_NAME_(gpcc_osal_Thread_TestsF, SetCancelabilityEnabled)::ThreadEntry_SetCancelabilityEnabled, this, &uut),
             Thread::SchedPolicy::Other, 0, Thread::GetDefaultStackSize());
 
   std::unique_ptr<bool> spRetVal(static_cast<bool*>(uut.Join()));

--- a/testcases/osal/TestThread.cpp
+++ b/testcases/osal/TestThread.cpp
@@ -238,7 +238,7 @@ void* gpcc_osal_Thread_TestsF::ThreadEntry_SetCancelabilityEnabled(Thread* const
 
 void* gpcc_osal_Thread_TestsF::ThreadEntry_DisableCancelability(Thread* const pThread)
 {
-  pThread->SetCancelabilityEnabled(false);
+  (void)pThread->SetCancelabilityEnabled(false);
 
   do
   {
@@ -255,7 +255,7 @@ void* gpcc_osal_Thread_TestsF::ThreadEntry_DisableCancelability(Thread* const pT
 
 void* gpcc_osal_Thread_TestsF::ThreadEntry_DisableAndEnableCancelability(Thread* const pThread)
 {
-  pThread->SetCancelabilityEnabled(false);
+  (void)pThread->SetCancelabilityEnabled(false);
 
   do
   {
@@ -267,7 +267,7 @@ void* gpcc_osal_Thread_TestsF::ThreadEntry_DisableAndEnableCancelability(Thread*
   pThread->TestForCancellation();
 
   // this must have no effect
-  pThread->SetCancelabilityEnabled(true);
+  (void)pThread->SetCancelabilityEnabled(true);
 
   // return something that is not nullptr
   return this;
@@ -275,7 +275,7 @@ void* gpcc_osal_Thread_TestsF::ThreadEntry_DisableAndEnableCancelability(Thread*
 
 void* gpcc_osal_Thread_TestsF::ThreadEntry_CancelOnTestForCancellation(Thread* const pThread)
 {
-  pThread->SetCancelabilityEnabled(false);
+  (void)pThread->SetCancelabilityEnabled(false);
 
   do
   {
@@ -286,7 +286,7 @@ void* gpcc_osal_Thread_TestsF::ThreadEntry_CancelOnTestForCancellation(Thread* c
   // this must have no effect
   pThread->TestForCancellation();
 
-  pThread->SetCancelabilityEnabled(true);
+  (void)pThread->SetCancelabilityEnabled(true);
 
   flag = true;
 
@@ -959,7 +959,7 @@ TEST_F(gpcc_osal_Thread_DeathTestsF, UncaughtException)
 TEST_F(gpcc_osal_Thread_TestsF, SetCancelabilityEnabled_WrongThread)
 {
   Thread uut("Test");
-  ASSERT_THROW(uut.SetCancelabilityEnabled(true), std::logic_error);
+  ASSERT_THROW((void)uut.SetCancelabilityEnabled(true), std::logic_error);
 }
 
 TEST_F(gpcc_osal_Thread_TestsF, SetCancelabilityEnabled)

--- a/testcases/osal/TestThread.cpp
+++ b/testcases/osal/TestThread.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011 Daniel Jerolm
+    Copyright (C) 2011, 2024 Daniel Jerolm
 */
 
 #include <gpcc/osal/Thread.hpp>


### PR DESCRIPTION
Class gpcc::osal::Thread used to offer Thread::SetCancelabilityEnabled() and Thread::GetCancelabilityEnabled() to enable and disable deferred cancelability and to query the current state of cancelability (enabled or disabled).

To simplify porting GPCC's OSAL to other operating systems and to increase interoperability with other APIs present on the platform (e.g. pthread), the following changes have been made:
- Thread::GetCancelabilityEnabled() has been removed
- Thread::SetCancelabilityEnabled() now returns the previous enabled-state of cancelability

Removal of Thread::GetCancelabilityEnabled() is an incompatible change of GPCC's API. However, there is little or no use for this function. Only a thread itself can enable and disable its cancelability state, so each thread should now its current state. Further, other threading APIs (like pthread) do not offer such a function. This is a major drawback regarding interoperability of GPCC's OSAL with other threading APIs if code based on pthread but executed by a GPCC thread wants to disable deferred thread cancellation via pthread_setcancelstate().

Functionality of Thread::SetCancelabilityEnabled() has been extended so that it returns the previous cancelability state. This allows to disable cancelability temporarily without knowing the previous state and aligns to POSIX threads.