### PR TITLE
std::unique_ptr equivalent for C pointers that need to be free'd

### DIFF
--- a/history.txt
+++ b/history.txt
@@ -4,8 +4,10 @@ GPCC Implementation History and Current Activities
 
 Next to do:
 ===============================================================================
-
 - Use github's issue tracking instead of this file
+
+- Consider using prefix "std::" for types and functions from the C library
+
 - Remove machine's architecture from OS. The OS should hide any machine specific stuff.
 
 - Doxygen: No documentation generated for members of template classes (e.g. MultiCallback, IntegralFilter)
@@ -197,6 +199,9 @@ Next to do:
 
 History:
 ===============================================================================
+2025-01-14
+- Add gpcc::raii::unique_c_ptr
+
 2024-11-29
 - Fix StringComposer: Output for value 0 if show base is enabled
 

--- a/include/gpcc/raii/unique_c_ptr.hpp
+++ b/include/gpcc/raii/unique_c_ptr.hpp
@@ -1,0 +1,78 @@
+/*
+    General Purpose Class Collection (GPCC)
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    Copyright (C) 2025 Daniel Jerolm
+*/
+
+#ifndef UNIQUE_C_PTR_HPP_202501121951
+#define UNIQUE_C_PTR_HPP_202501121951
+
+#include <memory>
+#include <stdlib.h>
+
+namespace gpcc {
+namespace raii {
+
+namespace internal
+{
+  class DeleterUsingFree
+  {
+    public:
+      template <typename T>
+      void operator()(T* const p) const noexcept
+      {
+        std::free(const_cast<std::remove_const_t<T>*>(p));
+      }
+  };
+}
+
+/**
+ * \ingroup GPCC_RAII
+ * \brief Smart pointer managing ownership of storage that must be released via `free()`.
+ *
+ * If you have to invoke C APIs, then these APIs may allocate memory from the heap using `malloc()` and pass it back to
+ * the caller. Typically ownership also moves to the caller, so the caller is responsible to finally release the memory.
+ *
+ * Memory allocated via `malloc()` and friends must be released via `free()`. `std::unique_ptr` cannot be used as a
+ * container, because it finally passes the guarded memory to `delete`.
+ *
+ * However to allow for appliance of exception safe programming and RAII patterns, GPCC provides
+ * `gpcc::raii::unique_c_ptr` as a specialization of `std::unique_ptr` that uses `free()` to release guarded memory.
+ *
+ * `gpcc::raii::unique_c_ptr` can be used to manage ownership of memory allocated via `malloc()`. The usage is the same
+ * like `std::unique_ptr`:
+ * ~~~{.cpp}
+ * #include <gpcc/raii/unique_c_ptr.hpp>
+ *
+ * void SomeFunc(void)
+ * {
+ *   gpcc::raii::unique_c_ptr<uint32> spData(Library_written_in_C_CreateU32Data());
+ *
+ *   // spData can be used like an std::unique_ptr. E.g. get() can be used to obtain a raw pointer:
+ *   Library_written_in_C_Sum(spData.get());
+ *
+ *   // When leaving the scope, spData will release the managed memory using "free".
+ * }
+ * ~~~
+ * - - -
+ *
+ * \tparam T
+ * Data type referenced by the pointer.\n
+ * Example: Use `uint8_t` if `unique_c_ptr` shall behave like `uint8_t*`.
+ *
+ * - - -
+ *
+ * __Thread safety:__\n
+ * Not thread safe, but non-modifying concurrent access is safe.
+ */
+template <typename T>
+using unique_c_ptr = std::unique_ptr<T, internal::DeleterUsingFree>;
+
+} // namespace raii
+} // namespace gpcc
+
+#endif // UNIQUE_C_PTR_HPP_202501121951

--- a/src/raii/CMakeLists.txt
+++ b/src/raii/CMakeLists.txt
@@ -4,6 +4,8 @@
 # If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 #
-# Copyright (C) 2024 Daniel Jerolm
+# Copyright (C) 2024, 2025 Daniel Jerolm
 
-# empty
+target_sources(${PROJECT_NAME}
+               PRIVATE
+               unique_c_ptr.cpp)

--- a/src/raii/unique_c_ptr.cpp
+++ b/src/raii/unique_c_ptr.cpp
@@ -1,0 +1,20 @@
+/*
+    General Purpose Class Collection (GPCC)
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    Copyright (C) 2025 Daniel Jerolm
+*/
+
+#include <gpcc/raii/unique_c_ptr.hpp>
+#include <cassert>
+
+namespace gpcc {
+namespace raii {
+
+static_assert(sizeof(void*) == sizeof(unique_c_ptr<void>), "gpcc::raii::unique_c_ptr has unexpected size.");
+
+} // namespace raii
+} // namespace gpcc

--- a/testcases/raii/CMakeLists.txt
+++ b/testcases/raii/CMakeLists.txt
@@ -8,4 +8,5 @@
 
 target_sources(${PROJECT_NAME}_testcases
                PRIVATE
-               Test_scope_guard.cpp)
+               Test_scope_guard.cpp
+               Test_unique_c_ptr.cpp)

--- a/testcases/raii/Test_unique_c_ptr.cpp
+++ b/testcases/raii/Test_unique_c_ptr.cpp
@@ -104,8 +104,8 @@ TEST(gpcc_raii_unique_c_ptr_Tests, Release)
 {
   gpcc::raii::unique_c_ptr<char> spUUT(CreateHelloString());
 
-  // memcheck should not find a leak
   char* const p = spUUT.release();
+  ASSERT_EQ(spUUT.get(), nullptr);
 
   // memcheck should not find use-after-free
   EXPECT_STREQ(p, "Hello!");

--- a/testcases/raii/Test_unique_c_ptr.cpp
+++ b/testcases/raii/Test_unique_c_ptr.cpp
@@ -1,0 +1,125 @@
+/*
+    General Purpose Class Collection (GPCC)
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    Copyright (C) 2025 Daniel Jerolm
+*/
+
+#include <gpcc/raii/unique_c_ptr.hpp>
+#include <gtest/gtest.h>
+#include <new>
+#include <cstdlib>
+#include <cstring>
+
+namespace
+{
+  char* CreateHelloString(void)
+  {
+    char* const p = reinterpret_cast<char*>(malloc(7U));
+    if (p == nullptr)
+      throw std::bad_alloc();
+
+    std::strcpy(p, "Hello!");
+
+    return p;
+  }
+
+  char* CreateByeString(void)
+  {
+    char* const p = reinterpret_cast<char*>(malloc(5U));
+    if (p == nullptr)
+      throw std::bad_alloc();
+
+    std::strcpy(p, "Bye!");
+
+    return p;
+  }
+
+  uint8_t* Create1to4(void)
+  {
+    uint8_t* const p = reinterpret_cast<uint8_t*>(malloc(4U));
+    if (p == nullptr)
+      throw std::bad_alloc();
+
+    p[0] = 1U;
+    p[1] = 2U;
+    p[2] = 3U;
+    p[3] = 4U;
+
+    return p;
+  }
+}
+
+namespace gpcc_tests {
+namespace raii       {
+
+TEST(gpcc_raii_unique_c_ptr_Tests, Init_without_data)
+{
+  gpcc::raii::unique_c_ptr<char> spUUT;
+  EXPECT_TRUE(spUUT.get() == nullptr);
+}
+
+TEST(gpcc_raii_unique_c_ptr_Tests, Init_nullptr)
+{
+  gpcc::raii::unique_c_ptr<char> spUUT(nullptr);
+  EXPECT_TRUE(spUUT.get() == nullptr);
+}
+
+TEST(gpcc_raii_unique_c_ptr_Tests, Init_withNonConstData)
+{
+  gpcc::raii::unique_c_ptr<char> spUUT(CreateHelloString());
+
+  EXPECT_STREQ(spUUT.get(), "Hello!");
+}
+
+TEST(gpcc_raii_unique_c_ptr_Tests, Init_withConstData)
+{
+  gpcc::raii::unique_c_ptr<char const> spUUT(CreateHelloString());
+
+  EXPECT_STREQ(spUUT.get(), "Hello!");
+}
+
+TEST(gpcc_raii_unique_c_ptr_Tests, Reset)
+{
+  gpcc::raii::unique_c_ptr<char> spUUT(CreateHelloString());
+
+  // memcheck should not find a leak
+  spUUT.reset();
+}
+
+TEST(gpcc_raii_unique_c_ptr_Tests, Reset_withNewData)
+{
+  gpcc::raii::unique_c_ptr<char> spUUT(CreateHelloString());
+
+  // memcheck should not find a leak
+  spUUT.reset(CreateByeString());
+
+  EXPECT_STREQ(spUUT.get(), "Bye!");
+}
+
+TEST(gpcc_raii_unique_c_ptr_Tests, Release)
+{
+  gpcc::raii::unique_c_ptr<char> spUUT(CreateHelloString());
+
+  // memcheck should not find a leak
+  char* const p = spUUT.release();
+
+  // memcheck should not find use-after-free
+  EXPECT_STREQ(p, "Hello!");
+
+  std::free(p);
+}
+
+TEST(gpcc_raii_unique_c_ptr_Tests, Dereference)
+{
+  gpcc::raii::unique_c_ptr<uint8_t> spUUT(Create1to4());
+
+  EXPECT_EQ(*spUUT, 1U);
+  EXPECT_EQ(spUUT.get()[2], 3U);
+}
+
+} // namespace raii
+} // namespace gpcc_tests


### PR DESCRIPTION
This pull request adds `gpcc::raii::unique_c_ptr` to GPCC.

The new class is a smart pointer based on `std::unique_ptr`. It allows to manage ownership of memory obtained from C APIs which typically use `malloc()` to allocate the memory. Memory allocated via `malloc()` must be released via `free()`.