### PR TITLE
Add Log-methods accepting an va_list object

### DIFF
--- a/history.txt
+++ b/history.txt
@@ -202,6 +202,9 @@ Next to do:
 
 History:
 ===============================================================================
+2029-01-29
+- Add Log-methods accepting an va_list object
+
 2025-01-25
 - Add string conversion for 64bit types
 - Add class BinaryDumper

--- a/include/gpcc/log/Logger.hpp
+++ b/include/gpcc/log/Logger.hpp
@@ -195,6 +195,7 @@ class Logger final
     void Log(LogType const type, std::string const & msg, std::exception_ptr const & ePtr) noexcept;
     void Log(LogType const type, std::string && msg, std::exception_ptr const & ePtr) noexcept;
     void LogV(LogType const type, char const * const pFmt, ...) noexcept;
+    void LogV(LogType const type, char const * const pFmt, va_list args) noexcept;
     void LogTS(LogType const type, char const * const pMsg) noexcept;
     void LogTS(LogType const type, char const * const pMsg, std::exception_ptr const & ePtr) noexcept;
     void LogTS(LogType const type, std::string const & msg) noexcept;
@@ -202,6 +203,7 @@ class Logger final
     void LogTS(LogType const type, std::string const & msg, std::exception_ptr const & ePtr) noexcept;
     void LogTS(LogType const type, std::string && msg, std::exception_ptr const & ePtr) noexcept;
     void LogVTS(LogType const type, char const * const pFmt, ...) noexcept;
+    void LogVTS(LogType const type, char const * const pFmt, va_list args) noexcept;
     void LogFailed(void) noexcept;
 
   private:

--- a/src/log/Logger.cpp
+++ b/src/log/Logger.cpp
@@ -615,6 +615,47 @@ void Logger::LogV(LogType const type, char const * const pFmt, ...) noexcept
   va_start(args, pFmt);
   ON_SCOPE_EXIT(end_args) { va_end(args); };
 
+  LogV(type, pFmt, args);
+}
+
+/**
+ * \brief Logs a message. The message is created from a `va_list` object and a printf-style format string.
+ *
+ * In contrast to the other Log()-methods, this method creates the log message text in the context of the calling
+ * thread instead of off-loading log message creation to the thread of the log facility. This method therefore offers
+ * high flexibility, but uses the calling thread to create the log message string.
+ *
+ * - - -
+ *
+ * __Thread safety:__\n
+ * This is thread-safe.
+ *
+ * __Exception safety:__\n
+ * No-throw guarantee.
+ *
+ * __Thread cancellation safety:__\n
+ * No cancellation point included.
+ *
+ * - - -
+ *
+ * \param type
+ * Type of log message. See @ref LogType for details.\n
+ * If this is below the log level configured at this @ref Logger instance, then this method will do nothing.
+ *
+ * \param pFmt
+ * Pointer to a null-terminated c-string containing the log message text and printf-style conversion specifications that
+ * control how the variable arguments shall be converted and integrated into the log message text.\n
+ * Details about format specifiers are [here](@ref gpcc::string::VASPrintf).
+ *
+ * \param args
+ * `va_list` object offering access to the arguments that shall be printed. The number and type of arguments must match
+ * the conversion specifiers embedded in `pFmt`.
+ */
+void Logger::LogV(LogType const type, char const * const pFmt, va_list args) noexcept
+{
+  if (!IsAboveLevel(type))
+    return;
+
   osal::MutexLocker locker(mutex);
   if (pLogFacility != nullptr)
   {
@@ -1075,6 +1116,48 @@ void Logger::LogVTS(LogType const type, char const * const pFmt, ...) noexcept
   va_list args;
   va_start(args, pFmt);
   ON_SCOPE_EXIT(end_args) { va_end(args); };
+
+  LogVTS(type, pFmt, args);
+}
+
+/**
+ * \brief Logs a message. The message is created from a `va_list` object and a printf-style format string
+ *        plus timestamp.
+ *
+ * In contrast to the other Log()-methods, this method creates the log message text in the context of the calling
+ * thread instead of off-loading log message creation to the thread of the log facility. This method therefore offers
+ * high flexibility, but uses the calling thread to create the log message string.
+ *
+ * - - -
+ *
+ * __Thread safety:__\n
+ * This is thread-safe.
+ *
+ * __Exception safety:__\n
+ * No-throw guarantee.
+ *
+ * __Thread cancellation safety:__\n
+ * No cancellation point included.
+ *
+ * - - -
+ *
+ * \param type
+ * Type of log message. See @ref LogType for details.\n
+ * If this is below the log level configured at this @ref Logger instance, then this method will do nothing.
+ *
+ * \param pFmt
+ * Pointer to a null-terminated c-string containing the log message text and printf-style conversion specifications that
+ * control how the variable arguments shall be converted and integrated into the log message text.\n
+ * Details about format specifiers are [here](@ref gpcc::string::VASPrintf).
+ *
+ * \param args
+ * `va_list` object offering access to the arguments that shall be printed. The number and type of arguments must match
+ * the conversion specifiers embedded in `pFmt`.
+ */
+void Logger::LogVTS(LogType const type, char const * const pFmt, va_list args) noexcept
+{
+  if (!IsAboveLevel(type))
+    return;
 
   osal::MutexLocker locker(mutex);
   if (pLogFacility != nullptr)

--- a/src/string/tools.cpp
+++ b/src/string/tools.cpp
@@ -3206,8 +3206,8 @@ std::vector<std::pair<std::string,std::string>> ExtractFieldAndValue(std::string
  * nullptr is not allowed.
  *
  * \param args
- * Variable number of arguments that shall be printed. The number and type of arguments must match the conversion
- * specifiers embedded in `pFmt`.
+ * `va_list` object offering access to the arguments that shall be printed. The number and type of arguments must match
+ * the conversion specifiers embedded in `pFmt`.
  *
  * \return
  * Pointer to the created null-terminated c-string.
@@ -3269,6 +3269,7 @@ std::unique_ptr<char[]> VASPrintf(char const * const pFmt, va_list args)
  * \param pFmt
  * Pointer to a null-terminated c-string containing the text that shall be printed and printf-style conversion
  * specifications that control how the `args` shall be converted and integrated into the text.\n
+ * For details about format specifiers, please refer to @ref VASPrintf().\n
  * nullptr is not allowed.
  *
  * \param ...


### PR DESCRIPTION
This PR adds the following methods to `gpcc::log::Logger`:
- `void LogV(LogType const type, char const * const pFmt, va_list args) noexcept`
- `void LogVTS(LogType const type, char const * const pFmt, va_list args) noexcept`