### PR TITLE
fix(osal)!: Clock granularity in convar timed wait

### DIFF
--- a/include/gpcc/time/clock.hpp
+++ b/include/gpcc/time/clock.hpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011 Daniel Jerolm
+    Copyright (C) 2011, 2025 Daniel Jerolm
 */
 
 #ifndef CLOCK_HPP_201701162120
@@ -25,25 +25,21 @@ namespace time {
  * - On some platforms, the precise variants of the clocks are more expensive to read.\n
  *   If you do not need a high-precision clock reading, then the non-precise variants should be preferred.
  * - The precision of a clock can be queried via @ref gpcc::time::GetPrecision_ns(). \n
- *   On systems with a periodic system tick, the non-precise variant typically has a precision of one system tick period.
- * - If the precise (non-precise) variant is not available on a platform, then the non-precise (precise) variant will be
- *   used implicitly as a substitution.
- * - The precise and non-precise variants of a clock have the same base. It is safe to compare them against each other,
- *   __but note:__\n
+ *   On systems with a periodic system tick, the non-precise variant typically has a precision of one tick period.
+ * - If the precise (non-precise) variant of a clock is not available on a platform, then GPCC will use the non-precise
+ *   (precise) variant as a substitution.
+ * - The precise and non-precise variants of a clock have the same base.\n
+ *   It is safe to compare them against each other and to calculate time-spans from a mix of both, __but note:__\n
  *   There is a delta between the precise variant and the non-precise variant:\n
- *   delta = precise time - non-precise time\n
- *   The delta is always positive. Its worst-case maximum value across all platforms is:\n
- *   max(delta) = 2 x (precision of precise variant + precision of non-precise variant).\n
- *   \n
- *   On Ubuntu 22.04, the delta is composed of a high frequency component and a low frequency component. The magnitude
- *   of each component is max/2.
+ *   `delta = precise time - non-precise time`\n
+ *   The delta is always positive. Its maximum value is the precision of the non-precise variant of the clock.
  */
 enum class Clocks
 {
   realtimeCoarse,   ///<UTC system time.
   realtimePrecise,  ///<Like @ref Clocks::realtimeCoarse, but with highest available precision.
   monotonicCoarse,  ///<Monotonic rising time (not any jumps) starting at some arbitrary point in time.
-                    /**<It has no jumps, but may change in frequency (speed) due to NTP on some systems. */
+                    /**<It has no jumps, but may change in speed due to NTP on some systems. */
   monotonicPrecise  ///<Like @ref Clocks::monotonicCoarse, but with highest available precision.
 };
 

--- a/src/osal/os/chibios_arm/ConditionVariable.cpp
+++ b/src/osal/os/chibios_arm/ConditionVariable.cpp
@@ -136,14 +136,11 @@ void ConditionVariable::Wait(Mutex & mutex)
  * ~~~{.cpp}
  * using gpcc::time::TimePoint;
  * using gpcc::time::TimeSpan;
- * using gpcc::time::GetPrecision_ns;
  *
  * gpcc::osal::MutexLocker locker(myMutex);
  *
  * // calculate timeout (here: 1 second from now)
- * TimePoint const tp = TimePoint::FromSystemClock(ConditionVariable::clockID);
- *                    + TimeSpan::sec(1);
- *                    + TimeSpan::ns(GetPrecision_ns(ConditionVariable::clockID));
+ * TimePoint const tp = TimePoint::FromSystemClock(ConditionVariable::clockID) + TimeSpan::sec(1);
  *
  * bool timeout = false;
  * while ((condition == false) && (timeout == false))
@@ -184,6 +181,7 @@ void ConditionVariable::Wait(Mutex & mutex)
  * The mutex will be locked again when the method returns due to a timeout condition.\n
  * The time must be specified using the clock @ref ConditionVariable::clockID. \n
  * If a minimum timespan until timeout shall be guaranteed, then the clock's precision should be added to the timespan.
+ * It can be queried via @ref gpcc::time::GetPrecision_ns().
  *
  * \retval true
  *   Woke up due to timeout.

--- a/src/osal/os/chibios_arm/ConditionVariable.cpp
+++ b/src/osal/os/chibios_arm/ConditionVariable.cpp
@@ -213,8 +213,10 @@ bool ConditionVariable::TimeLimitedWait(Mutex & mutex, time::TimePoint const & a
       PANIC(); // Arithmetic error
 
     // Calculate number of system timer ticks until timeout.
-    // We round up to next tick and add 1 tick extra for uncertainty due to granularity of system tick interrupt)
-    uint64_t const ticks_till_timeout = ((static_cast<uint64_t>(remaining_time.ns()) + (NS_PER_SYSTICK - 1U)) / NS_PER_SYSTICK) + 1U;
+    // We round up to the next tick. If the user wants to consider the granularity of the system tick interrupt, then
+    // he/she has to add the clock's precision to the timespan as mentioned in doxygen of parameter "absoluteTimeout".
+    uint64_t const ticks_till_timeout =
+      (static_cast<uint64_t>(remaining_time.ns()) + (NS_PER_SYSTICK - 1U)) / NS_PER_SYSTICK;
 
     // wait in chunks of TIME_MAX_INTERVAL if ticks_till_timeout is too large to handle
     if (ticks_till_timeout > TIME_MAX_INTERVAL)

--- a/src/osal/os/chibios_arm/ConditionVariable.cpp
+++ b/src/osal/os/chibios_arm/ConditionVariable.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011 Daniel Jerolm
+    Copyright (C) 2011, 2025 Daniel Jerolm
 */
 
 #ifdef OS_CHIBIOS_ARM
@@ -131,13 +131,19 @@ void ConditionVariable::Wait(Mutex & mutex)
  *   Do not assume, that the condition is always true on wake up!\n
  *   Always double check the condition (before calling @ref Wait() and after @ref Wait() returns).\n
  *   Always wait for a condition variable in a tight loop.
+ * - Beware of corner cases: The condition might have come true even though a timeout is reported.
  *
  * ~~~{.cpp}
+ * using gpcc::time::TimePoint;
+ * using gpcc::time::TimeSpan;
+ * using gpcc::time::GetPrecision_ns;
+ *
  * gpcc::osal::MutexLocker locker(myMutex);
  *
  * // calculate timeout (here: 1 second from now)
- * gpcc::time::TimePoint tp = gpcc::time::TimePoint::FromSystemClock(ConditionVariable::clockID);
- * tp += gpcc::time::TimeSpan::sec(1);
+ * TimePoint const tp = TimePoint::FromSystemClock(ConditionVariable::clockID);
+ *                    + TimeSpan::sec(1);
+ *                    + TimeSpan::ns(GetPrecision_ns(ConditionVariable::clockID));
  *
  * bool timeout = false;
  * while ((condition == false) && (timeout == false))
@@ -172,11 +178,12 @@ void ConditionVariable::Wait(Mutex & mutex)
  *
  * \param absoluteTimeout
  * Absolute point in time when the timeout for waiting for the condition being signalled or broadcasted expires.\n
- * This method will return if the specified absolute point in time passes (= the system time equals or exceeds
+ * This method will return if the specified absolute point in time passes by (= the system time equals or exceeds
  * `absoluteTimeout`) regardless whether the condition has been signaled or not. This method will also return
- * immediately, if the specified point in time has already been passed when the call to this method is made.\n
+ * immediately, if the specified point in time has already passed by when the call to this method is made.\n
  * The mutex will be locked again when the method returns due to a timeout condition.\n
- * The time must be specified using the clock @ref ConditionVariable::clockID.
+ * The time must be specified using the clock @ref ConditionVariable::clockID. \n
+ * If a minimum timespan until timeout shall be guaranteed, then the clock's precision should be added to the timespan.
  *
  * \retval true
  *   Woke up due to timeout.

--- a/src/osal/os/epos_arm/ConditionVariable.cpp
+++ b/src/osal/os/epos_arm/ConditionVariable.cpp
@@ -190,9 +190,6 @@ bool ConditionVariable::TimeLimitedWait(Mutex & mutex, time::TimePoint const & a
   if (!epos_time_TimespecToU64_ns(&absTimeout_ns, absoluteTimeout.Get_timespec_ptr()))
     throw std::overflow_error("Timeout too large");
 
-  // compensate the clock granularity to ensure that the desired timespan is not underrun
-  absTimeout_ns = epos_time_EnsureMinTimeSpanMonotonic_u64(absTimeout_ns);
-
   return epos_convar_TimeLimitedWait(&condVar, &mutex.mutex, absTimeout_ns);
 }
 

--- a/src/osal/os/epos_arm/ConditionVariable.cpp
+++ b/src/osal/os/epos_arm/ConditionVariable.cpp
@@ -130,14 +130,11 @@ void ConditionVariable::Wait(Mutex & mutex)
  * ~~~{.cpp}
  * using gpcc::time::TimePoint;
  * using gpcc::time::TimeSpan;
- * using gpcc::time::GetPrecision_ns;
  *
  * gpcc::osal::MutexLocker locker(myMutex);
  *
  * // calculate timeout (here: 1 second from now)
- * TimePoint const tp = TimePoint::FromSystemClock(ConditionVariable::clockID);
- *                    + TimeSpan::sec(1);
- *                    + TimeSpan::ns(GetPrecision_ns(ConditionVariable::clockID));
+ * TimePoint const tp = TimePoint::FromSystemClock(ConditionVariable::clockID) + TimeSpan::sec(1);
  *
  * bool timeout = false;
  * while ((condition == false) && (timeout == false))
@@ -178,6 +175,7 @@ void ConditionVariable::Wait(Mutex & mutex)
  * The mutex will be locked again when the method returns due to a timeout condition.\n
  * The time must be specified using the clock @ref ConditionVariable::clockID. \n
  * If a minimum timespan until timeout shall be guaranteed, then the clock's precision should be added to the timespan.
+ * It can be queried via @ref gpcc::time::GetPrecision_ns().
  *
  * \retval true
  *   Woke up due to timeout.

--- a/src/osal/os/epos_arm/ConditionVariable.cpp
+++ b/src/osal/os/epos_arm/ConditionVariable.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2024 Daniel Jerolm
+    Copyright (C) 2024, 2025 Daniel Jerolm
 */
 
 #ifdef OS_EPOS_ARM
@@ -125,13 +125,19 @@ void ConditionVariable::Wait(Mutex & mutex)
  *   Do not assume, that the condition is always true on wake up!\n
  *   Always double check the condition (before calling @ref Wait() and after @ref Wait() returns).\n
  *   Always wait for a condition variable in a tight loop.
+ * - Beware of corner cases: The condition might have come true even though a timeout is reported.
  *
  * ~~~{.cpp}
+ * using gpcc::time::TimePoint;
+ * using gpcc::time::TimeSpan;
+ * using gpcc::time::GetPrecision_ns;
+ *
  * gpcc::osal::MutexLocker locker(myMutex);
  *
  * // calculate timeout (here: 1 second from now)
- * gpcc::time::TimePoint tp = gpcc::time::TimePoint::FromSystemClock(ConditionVariable::clockID);
- * tp += gpcc::time::TimeSpan::sec(1);
+ * TimePoint const tp = TimePoint::FromSystemClock(ConditionVariable::clockID);
+ *                    + TimeSpan::sec(1);
+ *                    + TimeSpan::ns(GetPrecision_ns(ConditionVariable::clockID));
  *
  * bool timeout = false;
  * while ((condition == false) && (timeout == false))
@@ -166,11 +172,12 @@ void ConditionVariable::Wait(Mutex & mutex)
  *
  * \param absoluteTimeout
  * Absolute point in time when the timeout for waiting for the condition being signalled or broadcasted expires.\n
- * This method will return if the specified absolute point in time passes (= the system time equals or exceeds
+ * This method will return if the specified absolute point in time passes by (= the system time equals or exceeds
  * `absoluteTimeout`) regardless whether the condition has been signaled or not. This method will also return
- * immediately, if the specified point in time has already been passed when the call to this method is made.\n
+ * immediately, if the specified point in time has already passed by when the call to this method is made.\n
  * The mutex will be locked again when the method returns due to a timeout condition.\n
- * The time must be specified using the clock @ref ConditionVariable::clockID.
+ * The time must be specified using the clock @ref ConditionVariable::clockID. \n
+ * If a minimum timespan until timeout shall be guaranteed, then the clock's precision should be added to the timespan.
  *
  * \retval true
  *   Woke up due to timeout.

--- a/src/osal/os/epos_arm/Thread.cpp
+++ b/src/osal/os/epos_arm/Thread.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2024 Daniel Jerolm
+    Copyright (C) 2024, 2025 Daniel Jerolm
 */
 
 #ifdef OS_EPOS_ARM
@@ -388,7 +388,8 @@ void Thread::Start(tEntryFunction const & _entryFunction,
       throw std::system_error(errno, std::generic_category(), "epos_thread_Create() failed");
   }
 
-  // Increment the reference count. This way the thread object will not be used immediately when the thread is joined.
+  // Increment the reference count. This way the thread object will not be released immediately when the thread is
+  // joined.
   epos_thread_IncRefCnt(pThread);
 
   // Wait until the new thread leaves the starting-state. Any unexpected error here will result in panic.

--- a/src/osal/os/linux_arm/ConditionVariable.cpp
+++ b/src/osal/os/linux_arm/ConditionVariable.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011 Daniel Jerolm
+    Copyright (C) 2011, 2025 Daniel Jerolm
 */
 
 #ifdef OS_LINUX_ARM
@@ -166,13 +166,19 @@ void ConditionVariable::Wait(Mutex & mutex)
  *   Do not assume, that the condition is always true on wake up!\n
  *   Always double check the condition (before calling @ref Wait() and after @ref Wait() returns).\n
  *   Always wait for a condition variable in a tight loop.
+ * - Beware of corner cases: The condition might have come true even though a timeout is reported.
  *
  * ~~~{.cpp}
+ * using gpcc::time::TimePoint;
+ * using gpcc::time::TimeSpan;
+ * using gpcc::time::GetPrecision_ns;
+ *
  * gpcc::osal::MutexLocker locker(myMutex);
  *
  * // calculate timeout (here: 1 second from now)
- * gpcc::time::TimePoint tp = gpcc::time::TimePoint::FromSystemClock(ConditionVariable::clockID);
- * tp += gpcc::time::TimeSpan::sec(1);
+ * TimePoint const tp = TimePoint::FromSystemClock(ConditionVariable::clockID);
+ *                    + TimeSpan::sec(1);
+ *                    + TimeSpan::ns(GetPrecision_ns(ConditionVariable::clockID));
  *
  * bool timeout = false;
  * while ((condition == false) && (timeout == false))
@@ -207,11 +213,12 @@ void ConditionVariable::Wait(Mutex & mutex)
  *
  * \param absoluteTimeout
  * Absolute point in time when the timeout for waiting for the condition being signalled or broadcasted expires.\n
- * This method will return if the specified absolute point in time passes (= the system time equals or exceeds
+ * This method will return if the specified absolute point in time passes by (= the system time equals or exceeds
  * `absoluteTimeout`) regardless whether the condition has been signaled or not. This method will also return
- * immediately, if the specified point in time has already been passed when the call to this method is made.\n
+ * immediately, if the specified point in time has already passed by when the call to this method is made.\n
  * The mutex will be locked again when the method returns due to a timeout condition.\n
- * The time must be specified using the clock @ref ConditionVariable::clockID.
+ * The time must be specified using the clock @ref ConditionVariable::clockID. \n
+ * If a minimum timespan until timeout shall be guaranteed, then the clock's precision should be added to the timespan.
  *
  * \retval true
  *   Woke up due to timeout.

--- a/src/osal/os/linux_arm/ConditionVariable.cpp
+++ b/src/osal/os/linux_arm/ConditionVariable.cpp
@@ -171,14 +171,11 @@ void ConditionVariable::Wait(Mutex & mutex)
  * ~~~{.cpp}
  * using gpcc::time::TimePoint;
  * using gpcc::time::TimeSpan;
- * using gpcc::time::GetPrecision_ns;
  *
  * gpcc::osal::MutexLocker locker(myMutex);
  *
  * // calculate timeout (here: 1 second from now)
- * TimePoint const tp = TimePoint::FromSystemClock(ConditionVariable::clockID);
- *                    + TimeSpan::sec(1);
- *                    + TimeSpan::ns(GetPrecision_ns(ConditionVariable::clockID));
+ * TimePoint const tp = TimePoint::FromSystemClock(ConditionVariable::clockID) + TimeSpan::sec(1);
  *
  * bool timeout = false;
  * while ((condition == false) && (timeout == false))
@@ -219,6 +216,7 @@ void ConditionVariable::Wait(Mutex & mutex)
  * The mutex will be locked again when the method returns due to a timeout condition.\n
  * The time must be specified using the clock @ref ConditionVariable::clockID. \n
  * If a minimum timespan until timeout shall be guaranteed, then the clock's precision should be added to the timespan.
+ * It can be queried via @ref gpcc::time::GetPrecision_ns().
  *
  * \retval true
  *   Woke up due to timeout.

--- a/src/osal/os/linux_arm_tfc/ConditionVariable.cpp
+++ b/src/osal/os/linux_arm_tfc/ConditionVariable.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011 Daniel Jerolm
+    Copyright (C) 2011, 2025 Daniel Jerolm
 */
 
 #ifdef OS_LINUX_ARM_TFC
@@ -150,13 +150,19 @@ void ConditionVariable::Wait(Mutex & mutex)
  *   Do not assume, that the condition is always true on wake up!\n
  *   Always double check the condition (before calling @ref Wait() and after @ref Wait() returns).\n
  *   Always wait for a condition variable in a tight loop.
+ * - Beware of corner cases: The condition might have come true even though a timeout is reported.
  *
  * ~~~{.cpp}
+ * using gpcc::time::TimePoint;
+ * using gpcc::time::TimeSpan;
+ * using gpcc::time::GetPrecision_ns;
+ *
  * gpcc::osal::MutexLocker locker(myMutex);
  *
  * // calculate timeout (here: 1 second from now)
- * gpcc::time::TimePoint tp = gpcc::time::TimePoint::FromSystemClock(ConditionVariable::clockID);
- * tp += gpcc::time::TimeSpan::sec(1);
+ * TimePoint const tp = TimePoint::FromSystemClock(ConditionVariable::clockID);
+ *                    + TimeSpan::sec(1);
+ *                    + TimeSpan::ns(GetPrecision_ns(ConditionVariable::clockID));
  *
  * bool timeout = false;
  * while ((condition == false) && (timeout == false))
@@ -191,11 +197,12 @@ void ConditionVariable::Wait(Mutex & mutex)
  *
  * \param absoluteTimeout
  * Absolute point in time when the timeout for waiting for the condition being signalled or broadcasted expires.\n
- * This method will return if the specified absolute point in time passes (= the system time equals or exceeds
+ * This method will return if the specified absolute point in time passes by (= the system time equals or exceeds
  * `absoluteTimeout`) regardless whether the condition has been signaled or not. This method will also return
- * immediately, if the specified point in time has already been passed when the call to this method is made.\n
+ * immediately, if the specified point in time has already passed by when the call to this method is made.\n
  * The mutex will be locked again when the method returns due to a timeout condition.\n
- * The time must be specified using the clock @ref ConditionVariable::clockID.
+ * The time must be specified using the clock @ref ConditionVariable::clockID. \n
+ * If a minimum timespan until timeout shall be guaranteed, then the clock's precision should be added to the timespan.
  *
  * \retval true
  *   Woke up due to timeout.

--- a/src/osal/os/linux_arm_tfc/ConditionVariable.cpp
+++ b/src/osal/os/linux_arm_tfc/ConditionVariable.cpp
@@ -155,14 +155,11 @@ void ConditionVariable::Wait(Mutex & mutex)
  * ~~~{.cpp}
  * using gpcc::time::TimePoint;
  * using gpcc::time::TimeSpan;
- * using gpcc::time::GetPrecision_ns;
  *
  * gpcc::osal::MutexLocker locker(myMutex);
  *
  * // calculate timeout (here: 1 second from now)
- * TimePoint const tp = TimePoint::FromSystemClock(ConditionVariable::clockID);
- *                    + TimeSpan::sec(1);
- *                    + TimeSpan::ns(GetPrecision_ns(ConditionVariable::clockID));
+ * TimePoint const tp = TimePoint::FromSystemClock(ConditionVariable::clockID) + TimeSpan::sec(1);
  *
  * bool timeout = false;
  * while ((condition == false) && (timeout == false))
@@ -203,6 +200,7 @@ void ConditionVariable::Wait(Mutex & mutex)
  * The mutex will be locked again when the method returns due to a timeout condition.\n
  * The time must be specified using the clock @ref ConditionVariable::clockID. \n
  * If a minimum timespan until timeout shall be guaranteed, then the clock's precision should be added to the timespan.
+ * It can be queried via @ref gpcc::time::GetPrecision_ns().
  *
  * \retval true
  *   Woke up due to timeout.

--- a/src/osal/os/linux_x64/ConditionVariable.cpp
+++ b/src/osal/os/linux_x64/ConditionVariable.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011 Daniel Jerolm
+    Copyright (C) 2011, 2025 Daniel Jerolm
 */
 
 #ifdef OS_LINUX_X64
@@ -166,13 +166,19 @@ void ConditionVariable::Wait(Mutex & mutex)
  *   Do not assume, that the condition is always true on wake up!\n
  *   Always double check the condition (before calling @ref Wait() and after @ref Wait() returns).\n
  *   Always wait for a condition variable in a tight loop.
+ * - Beware of corner cases: The condition might have come true even though a timeout is reported.
  *
  * ~~~{.cpp}
+ * using gpcc::time::TimePoint;
+ * using gpcc::time::TimeSpan;
+ * using gpcc::time::GetPrecision_ns;
+ *
  * gpcc::osal::MutexLocker locker(myMutex);
  *
  * // calculate timeout (here: 1 second from now)
- * gpcc::time::TimePoint tp = gpcc::time::TimePoint::FromSystemClock(ConditionVariable::clockID);
- * tp += gpcc::time::TimeSpan::sec(1);
+ * TimePoint const tp = TimePoint::FromSystemClock(ConditionVariable::clockID);
+ *                    + TimeSpan::sec(1);
+ *                    + TimeSpan::ns(GetPrecision_ns(ConditionVariable::clockID));
  *
  * bool timeout = false;
  * while ((condition == false) && (timeout == false))
@@ -207,11 +213,12 @@ void ConditionVariable::Wait(Mutex & mutex)
  *
  * \param absoluteTimeout
  * Absolute point in time when the timeout for waiting for the condition being signalled or broadcasted expires.\n
- * This method will return if the specified absolute point in time passes (= the system time equals or exceeds
+ * This method will return if the specified absolute point in time passes by (= the system time equals or exceeds
  * `absoluteTimeout`) regardless whether the condition has been signaled or not. This method will also return
- * immediately, if the specified point in time has already been passed when the call to this method is made.\n
+ * immediately, if the specified point in time has already passed by when the call to this method is made.\n
  * The mutex will be locked again when the method returns due to a timeout condition.\n
- * The time must be specified using the clock @ref ConditionVariable::clockID.
+ * The time must be specified using the clock @ref ConditionVariable::clockID. \n
+ * If a minimum timespan until timeout shall be guaranteed, then the clock's precision should be added to the timespan.
  *
  * \retval true
  *   Woke up due to timeout.

--- a/src/osal/os/linux_x64/ConditionVariable.cpp
+++ b/src/osal/os/linux_x64/ConditionVariable.cpp
@@ -171,14 +171,11 @@ void ConditionVariable::Wait(Mutex & mutex)
  * ~~~{.cpp}
  * using gpcc::time::TimePoint;
  * using gpcc::time::TimeSpan;
- * using gpcc::time::GetPrecision_ns;
  *
  * gpcc::osal::MutexLocker locker(myMutex);
  *
  * // calculate timeout (here: 1 second from now)
- * TimePoint const tp = TimePoint::FromSystemClock(ConditionVariable::clockID);
- *                    + TimeSpan::sec(1);
- *                    + TimeSpan::ns(GetPrecision_ns(ConditionVariable::clockID));
+ * TimePoint const tp = TimePoint::FromSystemClock(ConditionVariable::clockID) + TimeSpan::sec(1);
  *
  * bool timeout = false;
  * while ((condition == false) && (timeout == false))
@@ -219,6 +216,7 @@ void ConditionVariable::Wait(Mutex & mutex)
  * The mutex will be locked again when the method returns due to a timeout condition.\n
  * The time must be specified using the clock @ref ConditionVariable::clockID. \n
  * If a minimum timespan until timeout shall be guaranteed, then the clock's precision should be added to the timespan.
+ * It can be queried via @ref gpcc::time::GetPrecision_ns().
  *
  * \retval true
  *   Woke up due to timeout.

--- a/src/osal/os/linux_x64_tfc/ConditionVariable.cpp
+++ b/src/osal/os/linux_x64_tfc/ConditionVariable.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011 Daniel Jerolm
+    Copyright (C) 2011, 2025 Daniel Jerolm
 */
 
 #ifdef OS_LINUX_X64_TFC
@@ -150,13 +150,19 @@ void ConditionVariable::Wait(Mutex & mutex)
  *   Do not assume, that the condition is always true on wake up!\n
  *   Always double check the condition (before calling @ref Wait() and after @ref Wait() returns).\n
  *   Always wait for a condition variable in a tight loop.
+ * - Beware of corner cases: The condition might have come true even though a timeout is reported.
  *
  * ~~~{.cpp}
+ * using gpcc::time::TimePoint;
+ * using gpcc::time::TimeSpan;
+ * using gpcc::time::GetPrecision_ns;
+ *
  * gpcc::osal::MutexLocker locker(myMutex);
  *
  * // calculate timeout (here: 1 second from now)
- * gpcc::time::TimePoint tp = gpcc::time::TimePoint::FromSystemClock(ConditionVariable::clockID);
- * tp += gpcc::time::TimeSpan::sec(1);
+ * TimePoint const tp = TimePoint::FromSystemClock(ConditionVariable::clockID);
+ *                    + TimeSpan::sec(1);
+ *                    + TimeSpan::ns(GetPrecision_ns(ConditionVariable::clockID));
  *
  * bool timeout = false;
  * while ((condition == false) && (timeout == false))
@@ -191,11 +197,12 @@ void ConditionVariable::Wait(Mutex & mutex)
  *
  * \param absoluteTimeout
  * Absolute point in time when the timeout for waiting for the condition being signalled or broadcasted expires.\n
- * This method will return if the specified absolute point in time passes (= the system time equals or exceeds
+ * This method will return if the specified absolute point in time passes by (= the system time equals or exceeds
  * `absoluteTimeout`) regardless whether the condition has been signaled or not. This method will also return
- * immediately, if the specified point in time has already been passed when the call to this method is made.\n
+ * immediately, if the specified point in time has already passed by when the call to this method is made.\n
  * The mutex will be locked again when the method returns due to a timeout condition.\n
- * The time must be specified using the clock @ref ConditionVariable::clockID.
+ * The time must be specified using the clock @ref ConditionVariable::clockID. \n
+ * If a minimum timespan until timeout shall be guaranteed, then the clock's precision should be added to the timespan.
  *
  * \retval true
  *   Woke up due to timeout.

--- a/src/osal/os/linux_x64_tfc/ConditionVariable.cpp
+++ b/src/osal/os/linux_x64_tfc/ConditionVariable.cpp
@@ -155,14 +155,11 @@ void ConditionVariable::Wait(Mutex & mutex)
  * ~~~{.cpp}
  * using gpcc::time::TimePoint;
  * using gpcc::time::TimeSpan;
- * using gpcc::time::GetPrecision_ns;
  *
  * gpcc::osal::MutexLocker locker(myMutex);
  *
  * // calculate timeout (here: 1 second from now)
- * TimePoint const tp = TimePoint::FromSystemClock(ConditionVariable::clockID);
- *                    + TimeSpan::sec(1);
- *                    + TimeSpan::ns(GetPrecision_ns(ConditionVariable::clockID));
+ * TimePoint const tp = TimePoint::FromSystemClock(ConditionVariable::clockID) + TimeSpan::sec(1);
  *
  * bool timeout = false;
  * while ((condition == false) && (timeout == false))
@@ -203,6 +200,7 @@ void ConditionVariable::Wait(Mutex & mutex)
  * The mutex will be locked again when the method returns due to a timeout condition.\n
  * The time must be specified using the clock @ref ConditionVariable::clockID. \n
  * If a minimum timespan until timeout shall be guaranteed, then the clock's precision should be added to the timespan.
+ * It can be queried via @ref gpcc::time::GetPrecision_ns().
  *
  * \retval true
  *   Woke up due to timeout.

--- a/src/time/os/linux_arm/clock.cpp
+++ b/src/time/os/linux_arm/clock.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011 Daniel Jerolm
+    Copyright (C) 2011, 2025 Daniel Jerolm
 */
 
 #ifdef OS_LINUX_ARM
@@ -13,21 +13,75 @@
 #include <gpcc/time/clock.hpp>
 #include <gpcc/osal/Panic.hpp>
 
-namespace gpcc {
-namespace time {
+namespace {
 
-static clockid_t ToClockID(Clocks const clock) noexcept
+clockid_t ToPosixClockID(gpcc::time::Clocks const clock) noexcept
 {
   switch (clock)
   {
-    case Clocks::realtimeCoarse:   return CLOCK_REALTIME_COARSE;
-    case Clocks::realtimePrecise:  return CLOCK_REALTIME;
-    case Clocks::monotonicCoarse:  return CLOCK_MONOTONIC_COARSE;
-    case Clocks::monotonicPrecise: return CLOCK_MONOTONIC;
+    case gpcc::time::Clocks::realtimeCoarse:   return CLOCK_REALTIME_COARSE;
+    case gpcc::time::Clocks::realtimePrecise:  return CLOCK_REALTIME;
+    case gpcc::time::Clocks::monotonicCoarse:  return CLOCK_MONOTONIC_COARSE;
+    case gpcc::time::Clocks::monotonicPrecise: return CLOCK_MONOTONIC;
   }
 
   PANIC();
 }
+
+class ClockResolutionCache final
+{
+  public:
+    uint32_t const resolution_clock_realtimeCoarse_ns;
+    uint32_t const resolution_clock_realtimePrecise_ns;
+    uint32_t const resolution_clock_monotonicCoarse_ns;
+    uint32_t const resolution_clock_monotonicPrecise_ns;
+
+    ClockResolutionCache(void) noexcept;
+
+    uint32_t Get_ns(gpcc::time::Clocks const clock) const noexcept;
+
+  private:
+    static uint32_t Query(gpcc::time::Clocks const clock) noexcept;
+};
+
+ClockResolutionCache::ClockResolutionCache(void) noexcept
+: resolution_clock_realtimeCoarse_ns(Query(gpcc::time::Clocks::realtimeCoarse))
+, resolution_clock_realtimePrecise_ns(Query(gpcc::time::Clocks::realtimePrecise))
+, resolution_clock_monotonicCoarse_ns(Query(gpcc::time::Clocks::monotonicCoarse))
+, resolution_clock_monotonicPrecise_ns(Query(gpcc::time::Clocks::monotonicPrecise))
+{
+}
+
+uint32_t ClockResolutionCache::Query(gpcc::time::Clocks const clock) noexcept
+{
+  struct ::timespec ts;
+  int const ret = clock_getres(ToPosixClockID(clock), &ts);
+  if (ret != 0)
+    PANIC();
+
+  if ((ts.tv_sec != 0) || (ts.tv_nsec <= 0) || (ts.tv_nsec >= 1000000000L))
+    PANIC();
+
+  return static_cast<uint32_t>(ts.tv_nsec);
+}
+
+uint32_t ClockResolutionCache::Get_ns(gpcc::time::Clocks const clock) const noexcept
+{
+  switch (clock)
+  {
+    case gpcc::time::Clocks::realtimeCoarse:   return resolution_clock_realtimeCoarse_ns;
+    case gpcc::time::Clocks::realtimePrecise:  return resolution_clock_realtimePrecise_ns;
+    case gpcc::time::Clocks::monotonicCoarse:  return resolution_clock_monotonicCoarse_ns;
+    case gpcc::time::Clocks::monotonicPrecise: return resolution_clock_monotonicPrecise_ns;
+  }
+
+  PANIC();
+}
+
+} // namespace internal
+
+namespace gpcc {
+namespace time {
 
 /**
  * \ingroup GPCC_TIME
@@ -54,16 +108,8 @@ static clockid_t ToClockID(Clocks const clock) noexcept
  */
 uint32_t GetPrecision_ns(Clocks const clock) noexcept
 {
-  struct ::timespec ts;
-
-  int const ret = clock_getres(ToClockID(clock), &ts);
-  if (ret != 0)
-    PANIC();
-
-  if ((ts.tv_sec != 0) || (ts.tv_nsec <= 0) || (ts.tv_nsec >= 1000000000L))
-    PANIC();
-
-  return static_cast<uint32_t>(ts.tv_nsec);
+  static ClockResolutionCache cache;
+  return cache.Get_ns(clock);
 }
 
 /**
@@ -93,7 +139,7 @@ uint32_t GetPrecision_ns(Clocks const clock) noexcept
  */
 void GetTime(Clocks const clock, struct ::timespec& ts) noexcept
 {
-  int const ret = clock_gettime(ToClockID(clock), &ts);
+  int const ret = clock_gettime(ToPosixClockID(clock), &ts);
   if (ret != 0)
     PANIC();
 }

--- a/src/time/os/linux_x64/clock.cpp
+++ b/src/time/os/linux_x64/clock.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011 Daniel Jerolm
+    Copyright (C) 2011, 2025 Daniel Jerolm
 */
 
 #ifdef OS_LINUX_X64
@@ -13,21 +13,75 @@
 #include <gpcc/time/clock.hpp>
 #include <gpcc/osal/Panic.hpp>
 
-namespace gpcc {
-namespace time {
+namespace {
 
-static clockid_t ToClockID(Clocks const clock) noexcept
+clockid_t ToPosixClockID(gpcc::time::Clocks const clock) noexcept
 {
   switch (clock)
   {
-    case Clocks::realtimeCoarse:   return CLOCK_REALTIME_COARSE;
-    case Clocks::realtimePrecise:  return CLOCK_REALTIME;
-    case Clocks::monotonicCoarse:  return CLOCK_MONOTONIC_COARSE;
-    case Clocks::monotonicPrecise: return CLOCK_MONOTONIC;
+    case gpcc::time::Clocks::realtimeCoarse:   return CLOCK_REALTIME_COARSE;
+    case gpcc::time::Clocks::realtimePrecise:  return CLOCK_REALTIME;
+    case gpcc::time::Clocks::monotonicCoarse:  return CLOCK_MONOTONIC_COARSE;
+    case gpcc::time::Clocks::monotonicPrecise: return CLOCK_MONOTONIC;
   }
 
   PANIC();
 }
+
+class ClockResolutionCache final
+{
+  public:
+    uint32_t const resolution_clock_realtimeCoarse_ns;
+    uint32_t const resolution_clock_realtimePrecise_ns;
+    uint32_t const resolution_clock_monotonicCoarse_ns;
+    uint32_t const resolution_clock_monotonicPrecise_ns;
+
+    ClockResolutionCache(void) noexcept;
+
+    uint32_t Get_ns(gpcc::time::Clocks const clock) const noexcept;
+
+  private:
+    static uint32_t Query(gpcc::time::Clocks const clock) noexcept;
+};
+
+ClockResolutionCache::ClockResolutionCache(void) noexcept
+: resolution_clock_realtimeCoarse_ns(Query(gpcc::time::Clocks::realtimeCoarse))
+, resolution_clock_realtimePrecise_ns(Query(gpcc::time::Clocks::realtimePrecise))
+, resolution_clock_monotonicCoarse_ns(Query(gpcc::time::Clocks::monotonicCoarse))
+, resolution_clock_monotonicPrecise_ns(Query(gpcc::time::Clocks::monotonicPrecise))
+{
+}
+
+uint32_t ClockResolutionCache::Query(gpcc::time::Clocks const clock) noexcept
+{
+  struct ::timespec ts;
+  int const ret = clock_getres(ToPosixClockID(clock), &ts);
+  if (ret != 0)
+    PANIC();
+
+  if ((ts.tv_sec != 0) || (ts.tv_nsec <= 0) || (ts.tv_nsec >= 1000000000L))
+    PANIC();
+
+  return static_cast<uint32_t>(ts.tv_nsec);
+}
+
+uint32_t ClockResolutionCache::Get_ns(gpcc::time::Clocks const clock) const noexcept
+{
+  switch (clock)
+  {
+    case gpcc::time::Clocks::realtimeCoarse:   return resolution_clock_realtimeCoarse_ns;
+    case gpcc::time::Clocks::realtimePrecise:  return resolution_clock_realtimePrecise_ns;
+    case gpcc::time::Clocks::monotonicCoarse:  return resolution_clock_monotonicCoarse_ns;
+    case gpcc::time::Clocks::monotonicPrecise: return resolution_clock_monotonicPrecise_ns;
+  }
+
+  PANIC();
+}
+
+} // namespace internal
+
+namespace gpcc {
+namespace time {
 
 /**
  * \ingroup GPCC_TIME
@@ -54,16 +108,8 @@ static clockid_t ToClockID(Clocks const clock) noexcept
  */
 uint32_t GetPrecision_ns(Clocks const clock) noexcept
 {
-  struct ::timespec ts;
-
-  int const ret = clock_getres(ToClockID(clock), &ts);
-  if (ret != 0)
-    PANIC();
-
-  if ((ts.tv_sec != 0) || (ts.tv_nsec <= 0) || (ts.tv_nsec >= 1000000000L))
-    PANIC();
-
-  return static_cast<uint32_t>(ts.tv_nsec);
+  static ClockResolutionCache cache;
+  return cache.Get_ns(clock);
 }
 
 /**
@@ -93,7 +139,7 @@ uint32_t GetPrecision_ns(Clocks const clock) noexcept
  */
 void GetTime(Clocks const clock, struct ::timespec& ts) noexcept
 {
-  int const ret = clock_gettime(ToClockID(clock), &ts);
+  int const ret = clock_gettime(ToPosixClockID(clock), &ts);
   if (ret != 0)
     PANIC();
 }


### PR DESCRIPTION
Current situation:
For some platforms `ConditionVariable::TimeLimitedWait()` adds the precision of the clock to the timeout value, which is given as absolute point in time. The intention is to guarantee a minimum timespan until timeout.

Problem:
- There are some use cases where users do not want to wait for a minimum timespan but for an absolute point in time. If `ConditionVariable::TimeLimitedWait()` adds some time to compensate for clock uncertainty, then the absolute point in time gets a skew.
- Not all OSAL variants behave the same. The variants for Linux currently do not add any compensation value.
- POSIX thread's condition variable does not consider any compensation. Its up to the user.

Enhancement by this pull-request:
- Users shall consider the clock's granularity when calculating the absolute point in time for the timeout. `ConditionVariable::TimeLimitedWait()` shall not apply any compensation across all platforms. All variants of `ConditionVariable::TimeLimitedWait()` will therefore behave the same as the Linux variant already does.