### PR TITLE
refactor: Revise compiler warning settings

### DIFF
--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -6,6 +6,9 @@
 #
 # Copyright (C) 2022, 2024, 2025 Daniel Jerolm
 
+include(cmake/compiler_warning_options.cmake)
+
+
 function(GuessUserSettings)
   # This function guesses GPCC_Compiler and GPCC_OS
 
@@ -270,12 +273,7 @@ function(SetCompilerAndLanguageOptions target)
     target_compile_options(${target} PUBLIC "$<$<COMPILE_LANGUAGE:CXX>:-fexceptions>")
     target_compile_options(${target} PUBLIC "$<$<COMPILE_LANGUAGE:CXX>:-frtti>")
 
-    target_compile_options(${target} PRIVATE "$<$<COMPILE_LANGUAGE:C>:-Wall>")
-    target_compile_options(${target} PRIVATE "$<$<COMPILE_LANGUAGE:C>:-Wextra>")
-    target_compile_options(${target} PRIVATE "$<$<COMPILE_LANGUAGE:C>:-Wstrict-prototypes>")
-
-    target_compile_options(${target} PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:-Wall>")
-    target_compile_options(${target} PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:-Wextra>")
+    target_compile_options(${target} PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:${GPCC_CXX_WARN_OPTIONS}>")
 
     if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 8.0)
       # reduce length of filenames in debug messages contained in the libs

--- a/cmake/compiler_warning_options.cmake
+++ b/cmake/compiler_warning_options.cmake
@@ -1,0 +1,30 @@
+# General Purpose Class Collection (GPCC)
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+# If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# Copyright (C) 2025 Daniel Jerolm
+
+# ------------------------------------------------------------------------
+# Warning levels and settings applied to GPCC productive and unittest code
+# ------------------------------------------------------------------------
+list(APPEND GPCC_CXX_WARN_OPTIONS "-Wall"
+                                  "-Wextra")
+
+# Currently not applied, but planned:
+# -Wformat=2
+# -Wundef
+# -Wshadow
+#    Produces approx. 26 warnings, but appliance makes sense
+#
+# -Wdouble-promotion
+#    Produces a few warnings. Appliance makes sense.
+#    snprintf can be fixed via (std::is_same<T, float>::value == false)
+#
+# -Wpedantic
+#   4 findings, easy to fix. Complains about using '#warning'
+
+# Not applied by intention:
+# -Wconversion
+#    Produces ~376 findings. All reviewed findings are intentional. Appliance is not planned.

--- a/cmake/compiler_warning_options.cmake
+++ b/cmake/compiler_warning_options.cmake
@@ -11,10 +11,10 @@
 # ------------------------------------------------------------------------
 list(APPEND GPCC_CXX_WARN_OPTIONS "-Wall"
                                   "-Wextra"
-                                  "-Wdouble-promotion")
+                                  "-Wdouble-promotion"
+                                  "-Wformat=2")
 
 # Currently not applied, but planned:
-# -Wformat=2
 # -Wundef
 # -Wshadow
 #    Produces approx. 26 warnings, but appliance makes sense

--- a/cmake/compiler_warning_options.cmake
+++ b/cmake/compiler_warning_options.cmake
@@ -11,6 +11,7 @@
 # ------------------------------------------------------------------------
 list(APPEND GPCC_CXX_WARN_OPTIONS "-Wall"
                                   "-Wextra"
+                                  "-Wpedantic"
                                   "-Wdouble-promotion"
                                   "-Wformat=2"
                                   "-Wundef")
@@ -18,10 +19,10 @@ list(APPEND GPCC_CXX_WARN_OPTIONS "-Wall"
 # Currently not applied, but planned:
 # -Wshadow
 #    Produces approx. 26 warnings, but appliance makes sense
-#
-# -Wpedantic
-#   4 findings, easy to fix. Complains about using '#warning'
 
 # Not applied by intention:
 # -Wconversion
 #    Produces ~376 findings. All reviewed findings are intentional. Appliance is not planned.
+
+# Warnings in output that shall be ignored:
+# "#warning before C++23 is a GCC extension" due to -Wpedantic

--- a/cmake/compiler_warning_options.cmake
+++ b/cmake/compiler_warning_options.cmake
@@ -10,17 +10,14 @@
 # Warning levels and settings applied to GPCC productive and unittest code
 # ------------------------------------------------------------------------
 list(APPEND GPCC_CXX_WARN_OPTIONS "-Wall"
-                                  "-Wextra")
+                                  "-Wextra"
+                                  "-Wdouble-promotion")
 
 # Currently not applied, but planned:
 # -Wformat=2
 # -Wundef
 # -Wshadow
 #    Produces approx. 26 warnings, but appliance makes sense
-#
-# -Wdouble-promotion
-#    Produces a few warnings. Appliance makes sense.
-#    snprintf can be fixed via (std::is_same<T, float>::value == false)
 #
 # -Wpedantic
 #   4 findings, easy to fix. Complains about using '#warning'

--- a/cmake/compiler_warning_options.cmake
+++ b/cmake/compiler_warning_options.cmake
@@ -6,23 +6,26 @@
 #
 # Copyright (C) 2025 Daniel Jerolm
 
-# ------------------------------------------------------------------------
+# ========================================================================
 # Warning levels and settings applied to GPCC productive and unittest code
-# ------------------------------------------------------------------------
+# ========================================================================
 list(APPEND GPCC_CXX_WARN_OPTIONS "-Wall"
                                   "-Wextra"
                                   "-Wpedantic"
+                                  "-Wshadow"
                                   "-Wdouble-promotion"
                                   "-Wformat=2"
                                   "-Wundef")
 
 # Currently not applied, but planned:
-# -Wshadow
-#    Produces approx. 26 warnings, but appliance makes sense
+# -----------------------------------
+# -
 
 # Not applied by intention:
+# -------------------------
 # -Wconversion
-#    Produces ~376 findings. All reviewed findings are intentional. Appliance is not planned.
+#    Produces approx. 376 findings. All reviewed findings are intentional. Appliance is not planned.
 
 # Warnings in output that shall be ignored:
+# -----------------------------------------
 # "#warning before C++23 is a GCC extension" due to -Wpedantic

--- a/cmake/compiler_warning_options.cmake
+++ b/cmake/compiler_warning_options.cmake
@@ -12,10 +12,10 @@
 list(APPEND GPCC_CXX_WARN_OPTIONS "-Wall"
                                   "-Wextra"
                                   "-Wdouble-promotion"
-                                  "-Wformat=2")
+                                  "-Wformat=2"
+                                  "-Wundef")
 
 # Currently not applied, but planned:
-# -Wundef
 # -Wshadow
 #    Produces approx. 26 warnings, but appliance makes sense
 #

--- a/history.txt
+++ b/history.txt
@@ -202,6 +202,13 @@ Next to do:
 
 History:
 ===============================================================================
+2025-03-28
+- Revised compiler configuration regarding warnings.
+  - Release unittest build with 0 errors, 0 warnings.
+  - Debug unittest only with anticipated warnings.
+  - Unittest execution (incl. memcheck) with 0 errors.
+  - Doxygen all OK with known warnings only.
+
 2025-03-14
 - Add capability to build linux native library and linux unittests "standalone"
 

--- a/include/gpcc/cood/ObjectARRAY.hpp
+++ b/include/gpcc/cood/ObjectARRAY.hpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2018 Daniel Jerolm
+    Copyright (C) 2018, 2025 Daniel Jerolm
 */
 
 #ifndef OBJECTARRAY_HPP_201810092146
@@ -116,16 +116,16 @@ class ObjectARRAY : public Object
 {
   public:
     ObjectARRAY(void) = delete;
-    ObjectARRAY(std::string            const & _name,
-                attr_t                 const   _attributesSI0,
-                uint8_t                const   _SI0,
-                uint8_t                const   _min_SI0,
-                uint8_t                const   _max_SI0,
-                DataType               const   _type,
-                attr_t                 const   _attributes,
-                void*                  const   _pData,
-                gpcc::osal::Mutex *    const   _pMutex,
-                IObjectNotifiable *    const   _pNotifiable);
+    ObjectARRAY(std::string            const & name,
+                attr_t                 const   attributesSI0,
+                uint8_t                const   SI0,
+                uint8_t                const   min_SI0,
+                uint8_t                const   max_SI0,
+                DataType               const   type,
+                attr_t                 const   attributes,
+                void*                  const   pData,
+                gpcc::osal::Mutex *    const   pMutex,
+                IObjectNotifiable *    const   pNotifiable);
     ObjectARRAY(ObjectARRAY const &) = delete;
     ObjectARRAY(ObjectARRAY &&) = delete;
     virtual ~ObjectARRAY(void) = default;
@@ -173,44 +173,44 @@ class ObjectARRAY : public Object
 
   private:
     /// Name of the object.
-    std::string const name;
+    std::string const name_;
 
 
     /// Attributes of subindex 0.
-    attr_t const attributesSI0;
+    attr_t const attributesSI0_;
 
     /// Value of subindex 0.
-    /** @ref pMutex is required.\n
+    /** @ref pMutex_ is required.\n
         This value indicates the number of subindices excl. SI0.\n
         This value indicates the number of array elements. */
-    uint8_t SI0;
+    uint8_t SI0_;
 
-    /// Minimum value for @ref SI0.
-    uint8_t const min_SI0;
+    /// Minimum value for @ref SI0_.
+    uint8_t const min_SI0_;
 
-    /// Maximum value for @ref SI0.
-    uint8_t const max_SI0;
+    /// Maximum value for @ref SI0_.
+    uint8_t const max_SI0_;
 
 
     /// Data type of the array elements.
-    DataType const type;
+    DataType const type_;
 
     /// Attributes of the subindices representing array elements.
-    attr_t const attributes;
+    attr_t const attributes_;
 
     /// Pointer to the memory location containing the data represented by the ARRAY object.
-    /** @ref pMutex is required.\n
+    /** @ref pMutex_ is required.\n
         The memory is provided and owned by the owner of the ARRAY object. */
-    void* pData;
+    void* pData_;
 
     /// Pointer to the mutex protecting access to the data represented by the object.
-    /** This is `nullptr` if no mutex is required to access SI0 and to the data referenced by @ref pData. */
-    gpcc::osal::Mutex* const pMutex;
+    /** This is `nullptr` if no mutex is required to access SI0 and to the data referenced by @ref pData_. */
+    gpcc::osal::Mutex* const pMutex_;
 
 
     /// Notifiable interface used to inform the owner of the object about read/write accesses.
     /** This may be `nullptr`. */
-    IObjectNotifiable * const pNotifiable;
+    IObjectNotifiable * const pNotifiable_;
 
 
     uint8_t ReadBitsFromMem(uint8_t const subIdx) const;

--- a/include/gpcc/cood/ObjectARRAY_wicb.hpp
+++ b/include/gpcc/cood/ObjectARRAY_wicb.hpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2021 Daniel Jerolm
+    Copyright (C) 2021, 2025 Daniel Jerolm
 */
 
 #ifndef OBJECT_ARRAY_WICB_HPP_202103132155
@@ -34,18 +34,18 @@ class ObjectARRAY_wicb : private IObjectNotifiable, public ObjectARRAY
 {
   public:
     ObjectARRAY_wicb(void) = delete;
-    ObjectARRAY_wicb(std::string            const & _name,
-                     attr_t                 const   _attributesSI0,
-                     uint8_t                const   _SI0,
-                     uint8_t                const   _min_SI0,
-                     uint8_t                const   _max_SI0,
-                     DataType               const   _type,
-                     attr_t                 const   _attributes,
-                     void*                  const   _pData,
-                     gpcc::osal::Mutex *    const   _pMutex,
-                     tOnBeforeReadCallback  const & _onBeforeReadCallback,
-                     tOnBeforeWriteCallback const & _onBeforeWriteCallback,
-                     tOnAfterWriteCallback  const & _onAfterWriteCallback);
+    ObjectARRAY_wicb(std::string            const & name,
+                     attr_t                 const   attributesSI0,
+                     uint8_t                const   SI0,
+                     uint8_t                const   min_SI0,
+                     uint8_t                const   max_SI0,
+                     DataType               const   type,
+                     attr_t                 const   attributes,
+                     void*                  const   pData,
+                     gpcc::osal::Mutex *    const   pMutex,
+                     tOnBeforeReadCallback  const & onBeforeReadCallback,
+                     tOnBeforeWriteCallback const & onBeforeWriteCallback,
+                     tOnAfterWriteCallback  const & onAfterWriteCallback);
     ObjectARRAY_wicb(ObjectARRAY_wicb const &) = delete;
     ObjectARRAY_wicb(ObjectARRAY_wicb &&) = delete;
 
@@ -56,13 +56,13 @@ class ObjectARRAY_wicb : private IObjectNotifiable, public ObjectARRAY
 
   private:
     /// Functor to the before-read-callback.
-    tOnBeforeReadCallback const onBeforeReadCallback;
+    tOnBeforeReadCallback const onBeforeReadCallback_;
 
     /// Functor to the before-write-callback.
-    tOnBeforeWriteCallback const onBeforeWriteCallback;
+    tOnBeforeWriteCallback const onBeforeWriteCallback_;
 
     /// Functor to the after-write-callback.
-    tOnAfterWriteCallback const onAfterWriteCallback;
+    tOnAfterWriteCallback const onAfterWriteCallback_;
 
 
     // <-- IObjectNotifiable

--- a/include/gpcc/cood/ObjectVAR.hpp
+++ b/include/gpcc/cood/ObjectVAR.hpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2018 Daniel Jerolm
+    Copyright (C) 2018, 2025 Daniel Jerolm
 */
 
 #ifndef OBJECTVAR_HPP_201809291301
@@ -73,13 +73,13 @@ class ObjectVAR : public Object
 {
   public:
     ObjectVAR(void) = delete;
-    ObjectVAR(std::string            const & _name,
-              DataType               const   _type,
-              uint16_t               const   _nElements,
-              attr_t                 const   _attributes,
-              void*                  const   _pData,
-              gpcc::osal::Mutex *    const   _pMutex,
-              IObjectNotifiable *    const   _pNotifiable);
+    ObjectVAR(std::string            const & name,
+              DataType               const   type,
+              uint16_t               const   nElements,
+              attr_t                 const   attributes,
+              void*                  const   pData,
+              gpcc::osal::Mutex *    const   pMutex,
+              IObjectNotifiable *    const   pNotifiable);
     ObjectVAR(ObjectVAR const &) = delete;
     ObjectVAR(ObjectVAR &&) = delete;
     virtual ~ObjectVAR(void) = default;
@@ -127,31 +127,31 @@ class ObjectVAR : public Object
 
   private:
     /// Name of the object.
-    std::string const name;
+    std::string const name_;
 
     /// Data type of the data represented by the object.
-    DataType const type;
+    DataType const type_;
 
-    /// Number of elements of @ref type the data represented by the object is comprised of.
+    /// Number of elements of @ref type_ the data represented by the object is comprised of.
     /** For most data types this is one.\n
         For types @ref DataType::visible_string, @ref DataType::octet_string, and @ref DataType::unicode_string
         this may be any number equal to or larger than one. */
-    uint16_t const nElements;
+    uint16_t const nElements_;
 
     /// Attributes of the object.
-    attr_t const attributes;
+    attr_t const attributes_;
 
     /// Pointer to the data represented by the object.
-    /** @ref pMutex is required. */
-    void* pData;
+    /** @ref pMutex_ is required. */
+    void* pData_;
 
     /// Pointer to the mutex protecting access to the data represented by the object.
-    /** `nullptr` if no mutex is required to access the data referenced by @ref pData. */
-    gpcc::osal::Mutex* const pMutex;
+    /** `nullptr` if no mutex is required to access the data referenced by @ref pData_. */
+    gpcc::osal::Mutex* const pMutex_;
 
     /// Notifiable interface used to inform the owner of the object about read/write accesses.
     /** This may be `nullptr`. */
-    IObjectNotifiable * const pNotifiable;
+    IObjectNotifiable * const pNotifiable_;
 };
 
 } // namespace cood

--- a/include/gpcc/cood/ObjectVAR_wicb.hpp
+++ b/include/gpcc/cood/ObjectVAR_wicb.hpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2021 Daniel Jerolm
+    Copyright (C) 2021, 2025 Daniel Jerolm
 */
 
 #ifndef OBJECT_VAR_WICB_HPP_202103121720
@@ -34,15 +34,15 @@ class ObjectVAR_wicb : private IObjectNotifiable, public ObjectVAR
 {
   public:
     ObjectVAR_wicb(void) = delete;
-    ObjectVAR_wicb(std::string            const & _name,
-                   DataType               const   _type,
-                   uint16_t               const   _nElements,
-                   attr_t                 const   _attributes,
-                   void*                  const   _pData,
-                   gpcc::osal::Mutex *    const   _pMutex,
-                   tOnBeforeReadCallback  const & _onBeforeReadCallback,
-                   tOnBeforeWriteCallback const & _onBeforeWriteCallback,
-                   tOnAfterWriteCallback  const & _onAfterWriteCallback);
+    ObjectVAR_wicb(std::string            const & name,
+                   DataType               const   type,
+                   uint16_t               const   nElements,
+                   attr_t                 const   attributes,
+                   void*                  const   pData,
+                   gpcc::osal::Mutex *    const   pMutex,
+                   tOnBeforeReadCallback  const & onBeforeReadCallback,
+                   tOnBeforeWriteCallback const & onBeforeWriteCallback,
+                   tOnAfterWriteCallback  const & onAfterWriteCallback);
     ObjectVAR_wicb(ObjectVAR_wicb const &) = delete;
     ObjectVAR_wicb(ObjectVAR_wicb &&) = delete;
 
@@ -53,13 +53,13 @@ class ObjectVAR_wicb : private IObjectNotifiable, public ObjectVAR
 
   private:
     /// Functor to the before-read-callback.
-    tOnBeforeReadCallback const onBeforeReadCallback;
+    tOnBeforeReadCallback const onBeforeReadCallback_;
 
     /// Functor to the before-write-callback.
-    tOnBeforeWriteCallback const onBeforeWriteCallback;
+    tOnBeforeWriteCallback const onBeforeWriteCallback_;
 
     /// Functor to the after-write-callback.
-    tOnAfterWriteCallback const onAfterWriteCallback;
+    tOnAfterWriteCallback const onAfterWriteCallback_;
 
 
     // <-- IObjectNotifiable

--- a/include/gpcc/cood/cli/CLIAdapterBase.hpp
+++ b/include/gpcc/cood/cli/CLIAdapterBase.hpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2019 Daniel Jerolm
+    Copyright (C) 2019, 2025 Daniel Jerolm
 */
 
 #ifndef CLIADAPTERBASE_HPP_201905062115
@@ -90,10 +90,10 @@ class CLIAdapterBase
     CLIAdapterBase& operator=(CLIAdapterBase &&) = delete;
 
   protected:
-    CLIAdapterBase(IObjectAccess & _od,
-                   gpcc::cli::CLI & _cli,
-                   std::string const & _cmdName,
-                   uint8_t const _attributeStringMaxLength);
+    CLIAdapterBase(IObjectAccess & od,
+                   gpcc::cli::CLI & cli,
+                   std::string const & cmdName,
+                   uint8_t const attributeStringMaxLength);
 
     void RegisterCLICommand(void);
     void UnregisterCLICommand(void) noexcept;
@@ -105,16 +105,16 @@ class CLIAdapterBase
 
   private:
     /// Interface used to access the object dictionary.
-    IObjectAccess & od;
+    IObjectAccess & od_;
 
     /// CLI component where the CLI command is registered.
-    gpcc::cli::CLI & cli;
+    gpcc::cli::CLI & cli_;
 
     /// Name of the published CLI command.
-    std::string const cmdName;
+    std::string const cmdName_;
 
     /// Maximum length of any string that could be returned by @ref AttributesToStringHook().
-    uint8_t const attributeStringMaxLength;
+    uint8_t const attributeStringMaxLength_;
 
 
     void CLI_CommandHandler(std::string const & restOfLine, gpcc::cli::CLI & cli);

--- a/include/gpcc/cood/remote_access/infrastructure/Multiplexer.hpp
+++ b/include/gpcc/cood/remote_access/infrastructure/Multiplexer.hpp
@@ -135,7 +135,7 @@ class Multiplexer final : private IRemoteObjectDictionaryAccessNotifiable
 
   public:
     /// Maximum number of exposed ports.
-    static size_t constexpr maxNbOfPorts_ = 256U;
+    static size_t constexpr maxNbOfPorts = 256U;
 
 
     Multiplexer(void);

--- a/include/gpcc/cood/remote_access/infrastructure/Multiplexer.hpp
+++ b/include/gpcc/cood/remote_access/infrastructure/Multiplexer.hpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2021 Daniel Jerolm
+    Copyright (C) 2021, 2025 Daniel Jerolm
 */
 
 #ifndef MULTIPLEXER_HPP_202106212050
@@ -84,35 +84,36 @@ class IRemoteObjectDictionaryAccess;
  * For each RODA/RODAN interface pair provided by the multiplexer, class @ref Multiplexer comprises one instance of
  * class @ref MultiplexerPort. Each @ref MultiplexerPort instance manages one provided pair of RODA/RODAN interfaces.
  *
- * Class @ref Multiplexer has a `state` which tracks both if the multiplexer is connected to a RODA interface and
+ * Class @ref Multiplexer has a `state_` which tracks both if the multiplexer is connected to a RODA interface and
  * the state of that interface ('ready' and 'not ready').
  *
- * Each @ref MultiplexerPort instance has a `state` which tracks if a client is connected to the provided RODA/RODAN
+ * Each @ref MultiplexerPort instance has a `state_` which tracks if a client is connected to the provided RODA/RODAN
  * interface pair and the state of the provided RODA interface.
  *
  * __Mutexes__\n
  * Class @ref Multiplexer comprises three mutexes which are shared among class @ref Multiplexer and the
  * @ref MultiplexerPort instances.
  *
- * Most attributes of class @ref Multiplexer and class @ref MultiplexerPort require both the `muxMutex` and the
- * `portMutex` for write access, while one of the two mutexes is sufficient for read access.
+ * Most attributes of class @ref Multiplexer and class @ref MultiplexerPort require both the `muxMutex_` and the
+ * `portMutex_` for write access, while one of the two mutexes is sufficient for read access.
  *
  * During calls to the RODAN interface provided by class @ref Multiplexer (bottom right of multiplexer shown in figure
- * above) `muxMutex` will always be locked. If class @ref Multiplexer needs to fiddle in the guts of a
- * @ref MultiplexerPort instance, then it may additionally lock `portMutex`. Most calls to the multiplexer's RODAN
+ * above) `muxMutex_` will always be locked. If class @ref Multiplexer needs to fiddle in the guts of a
+ * @ref MultiplexerPort instance, then it may additionally lock `portMutex_`. Most calls to the multiplexer's RODAN
  * interface will be forwarded to the RODAN interface required by a @ref MultiplexerPort. During calls to a client, the
- * `muxMutex` is always locked.
+ * `muxMutex_` is always locked.
  *
  * During calls of a client to the Register() and Unregister() methods of the RODA interface provided by a
- * @ref MultiplexerPort (top left of multiplexer shown in figure above), both `muxMutex` and `portMutex` will be locked.
- * This allows the @ref MultiplexerPort to change its state and maybe send a [PingRequest](@ref gpcc::cood::PingRequest)
- * via the RODA interface required by the multiplexer (top right in figure above).
+ * @ref MultiplexerPort (top left of multiplexer shown in figure above), both `muxMutex_` and `portMutex_` will be
+ * locked. This allows the @ref MultiplexerPort to change its state and maybe send a
+ * [PingRequest](@ref gpcc::cood::PingRequest) via the RODA interface required by the multiplexer (top right in figure
+ * above).
  *
  * During calls of a client to the Send() and RequestExecutionContext() methods of the RODA interface provided by a
- * @ref MultiplexerPort (top left in figure above) only `portMutex` will be locked. This allows the @ref MultiplexerPort
- * to read all its guts plus the guts of the @ref Multiplexer and to delegate the calls to the RODA interface required
- * by the @ref Multiplexer (top right in fiugre above). At the same time, calls made in the context of the RODAN
- * interface (bottom left) to the RODA interface (top left) are dead-lock free.
+ * @ref MultiplexerPort (top left in figure above) only `portMutex_` will be locked. This allows the
+ * @ref MultiplexerPort to read all its guts plus the guts of the @ref Multiplexer and to delegate the calls to the RODA
+ * interface required by the @ref Multiplexer (top right in figure above). At the same time, calls made in the context
+ * of the RODAN interface (bottom left) to the RODA interface (top left) are dead-lock free.
  *
  * __Session ID__\n
  * Each @ref MultiplexerPort uses a session ID to distinguish "old" responses in case a client is unregistered and
@@ -134,7 +135,7 @@ class Multiplexer final : private IRemoteObjectDictionaryAccessNotifiable
 
   public:
     /// Maximum number of exposed ports.
-    static size_t constexpr maxNbOfPorts = 256U;
+    static size_t constexpr maxNbOfPorts_ = 256U;
 
 
     Multiplexer(void);
@@ -163,51 +164,51 @@ class Multiplexer final : private IRemoteObjectDictionaryAccessNotifiable
 
 
     /// Owner ID used to tag requests and to check responses.
-    uint32_t ownerID;
+    uint32_t ownerID_;
 
     /// Mutex used to protect @ref Connect() and @ref Disconnect() against each other.
-    /** Locking order: @ref connectMutex -> @ref muxMutex -> @ref portMutex */
-    gpcc::osal::Mutex connectMutex;
+    /** Locking order: @ref connectMutex_ -> @ref muxMutex_ -> @ref portMutex_ */
+    gpcc::osal::Mutex connectMutex_;
 
     /// Mutex used to make the multiplexer and its ports thread-safe. This is intended to be locked by the multiplexer.
-    /** Locking order: @ref connectMutex -> @ref muxMutex -> @ref portMutex */
-    gpcc::osal::Mutex muxMutex;
+    /** Locking order: @ref connectMutex_ -> @ref muxMutex_ -> @ref portMutex_ */
+    gpcc::osal::Mutex muxMutex_;
 
     /// Mutex used to make the multiplexer and its ports thread-safe. This is intended to be locked by ports.
-    /** Locking order: @ref connectMutex -> @ref muxMutex -> @ref portMutex */
-    gpcc::osal::Mutex portMutex;
+    /** Locking order: @ref connectMutex_ -> @ref muxMutex_ -> @ref portMutex_ */
+    gpcc::osal::Mutex portMutex_;
 
 
     /// Current state of the multiplexer.
-    /** RD: @ref muxMutex OR @ref portMutex is required.\n
-        WR: @ref muxMutex AND @ref portMutex are both required. */
-    States state;
+    /** RD: @ref muxMutex_ OR @ref portMutex_ is required.\n
+        WR: @ref muxMutex_ AND @ref portMutex_ are both required. */
+    States state_;
 
     /// [RODA](@ref IRemoteObjectDictionaryAccess) interface the multiplexer is connected to. nullptr = none.
-    /** RD: @ref muxMutex OR @ref portMutex is required.\n
-        WR: @ref muxMutex AND @ref portMutex are both required. */
-    IRemoteObjectDictionaryAccess* pRODA;
+    /** RD: @ref muxMutex_ OR @ref portMutex_ is required.\n
+        WR: @ref muxMutex_ AND @ref portMutex_ are both required. */
+    IRemoteObjectDictionaryAccess* pRODA_;
 
     /// Maximum request size a client connected to a port of the multiplexer is allowed to transmit.
-    /** RD: @ref muxMutex OR @ref portMutex is required.\n
-        WR: @ref muxMutex AND @ref portMutex are both required.\n
-        This is only valid if @ref state is @ref States::ready. \n
+    /** RD: @ref muxMutex_ OR @ref portMutex_ is required.\n
+        WR: @ref muxMutex_ AND @ref portMutex_ are both required.\n
+        This is only valid if @ref state_ is @ref States::ready. \n
         This is set by @ref OnReady(). The size for a @ref ReturnStackItem is already subtracted.\n
         This may be zero in case of request size starvation. */
-    size_t maxRequestSize;
+    size_t maxRequestSize_;
 
     /// Maximum response size a client connected to a port of the @ref Multiplexer can receive.
-    /** RD: @ref muxMutex OR @ref portMutex is required.\n
-        WR: @ref muxMutex AND @ref portMutex are both required.\n
-        This is only valid if @ref state is @ref States::ready. \n
+    /** RD: @ref muxMutex_ OR @ref portMutex_ is required.\n
+        WR: @ref muxMutex_ AND @ref portMutex_ are both required.\n
+        This is only valid if @ref state_ is @ref States::ready. \n
         This is set by @ref OnReady(). The size for a @ref ReturnStackItem is already subtracted.\n
         This may be zero in case of response size starvation. */
-    size_t maxResponseSize;
+    size_t maxResponseSize_;
 
     /// Multiplexer's ports.
-    /** RD: @ref muxMutex OR @ref portMutex is required.\n
-        WR: @ref muxMutex AND @ref portMutex are both required. */
-    std::vector<std::shared_ptr<MultiplexerPort>> ports;
+    /** RD: @ref muxMutex_ OR @ref portMutex_ is required.\n
+        WR: @ref muxMutex_ AND @ref portMutex_ are both required. */
+    std::vector<std::shared_ptr<MultiplexerPort>> ports_;
 
 
     // <-- IRemoteObjectDictionaryAccessNotifiable

--- a/include/gpcc/cood/remote_access/infrastructure/MultiplexerPort.hpp
+++ b/include/gpcc/cood/remote_access/infrastructure/MultiplexerPort.hpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2021 Daniel Jerolm
+    Copyright (C) 2021, 2025 Daniel Jerolm
 */
 
 #ifndef MULTIPLEXERPORT_HPP_202106212102
@@ -36,7 +36,7 @@ class MultiplexerPort final : public IRemoteObjectDictionaryAccess
 
   public:
     MultiplexerPort(void) = delete;
-    MultiplexerPort(Multiplexer & _owner, uint8_t const _index) noexcept;
+    MultiplexerPort(Multiplexer & owner, uint8_t const index) noexcept;
     MultiplexerPort(MultiplexerPort const &) = delete;
     MultiplexerPort(MultiplexerPort &&) = delete;
     ~MultiplexerPort(void) override;
@@ -57,42 +57,42 @@ class MultiplexerPort final : public IRemoteObjectDictionaryAccess
 
 
     /// @ref Multiplexer instance this @ref MultiplexerPort belongs to.
-    Multiplexer & owner;
+    Multiplexer & owner_;
 
-    /// Index of this port in `owner.ports`.
-    uint8_t const index;
+    /// Index of this port in `owner_.ports`.
+    uint8_t const index_;
 
 
     /// State of this port instance.
-    /** RD: `owner.portMutex` OR `owner.muxMutex` is required.\n
-        WR: `owner.portMutex` AND `owner.muxMutex` are both required. */
-    States state;
+    /** RD: `owner_.portMutex` OR `owner_.muxMutex` is required.\n
+        WR: `owner_.portMutex` AND `owner_.muxMutex` are both required. */
+    States state_;
 
     /// [RODAN](@ref IRemoteObjectDictionaryAccessNotifiable) interface registered at this port. nullptr = none.
-    /** RD: `owner.portMutex` OR `owner.muxMutex` is required.\n
-        WR: `owner.portMutex` AND `owner.muxMutex` are both required. */
-    IRemoteObjectDictionaryAccessNotifiable* pRODAN;
+    /** RD: `owner_.portMutex` OR `owner_.muxMutex` is required.\n
+        WR: `owner_.portMutex` AND `owner_.muxMutex` are both required. */
+    IRemoteObjectDictionaryAccessNotifiable* pRODAN_;
 
 
     /// Current Session ID.
-    /** RD: `owner.portMutex` OR `owner.muxMutex` is required.\n
-        WR: `owner.portMutex` AND `owner.muxMutex` are both required. */
-    uint8_t sessionID;
+    /** RD: `owner_.portMutex` OR `owner_.muxMutex` is required.\n
+        WR: `owner_.portMutex` AND `owner_.muxMutex` are both required. */
+    uint8_t sessionID_;
 
     /// Oldest used session ID for which messages might be existing somewhere.
-    /** RD: `owner.portMutex` OR `owner.muxMutex` is required.\n
-        WR: `owner.portMutex` AND `owner.muxMutex` are both required.\n
-        If @ref sessionID shall be incremented, then the new value of @ref sessionID must not equal this. */
-    uint8_t oldestUsedSessionID;
+    /** RD: `owner_.portMutex` OR `owner_.muxMutex` is required.\n
+        WR: `owner_.portMutex` AND `owner_.muxMutex` are both required.\n
+        If @ref sessionID_ shall be incremented, then the new value of @ref sessionID_ must not equal this. */
+    uint8_t oldestUsedSessionID_;
 
-    /// Indicates if a message has been forwarded using @ref sessionID.
-    /** `owner.portMutex` is required. */
-    bool sessionIDUsed;
+    /// Indicates if a message has been forwarded using @ref sessionID_.
+    /** `owner_.portMutex` is required. */
+    bool sessionIDUsed_;
 
 
     /// Flag indicating if the registered client has requested a call to his `LoanExecutionContext()` method.
-    /** `owner.portMutex` is required. */
-    bool execContextRequested;
+    /** `owner_.portMutex` is required. */
+    bool execContextRequested_;
 
 
     // <-- IRemoteObjectDictionaryAccess

--- a/include/gpcc/cood/remote_access/infrastructure/RODACLIClientBase.hpp
+++ b/include/gpcc/cood/remote_access/infrastructure/RODACLIClientBase.hpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2021 Daniel Jerolm
+    Copyright (C) 2021, 2025 Daniel Jerolm
 */
 
 #ifndef RODACLICLIENTBASE_HPP_202105221835
@@ -80,10 +80,10 @@ class RODACLIClientBase : private IRemoteObjectDictionaryAccessNotifiable
 
   protected:
     /// CLI where the CLI command is registered.
-    gpcc::cli::CLI & cli;
+    gpcc::cli::CLI & cli_;
 
 
-    RODACLIClientBase(gpcc::cli::CLI & _cli, uint8_t const _attributeStringMaxLength);
+    RODACLIClientBase(gpcc::cli::CLI & cli, uint8_t const attributeStringMaxLength);
     virtual ~RODACLIClientBase(void);
 
 
@@ -112,65 +112,65 @@ class RODACLIClientBase : private IRemoteObjectDictionaryAccessNotifiable
     };
 
     /// Timeout while waiting for reception of a response in ms.
-    static uint16_t constexpr rxTimeout_ms = 1000U;
+    static uint16_t constexpr rxTimeout_ms_ = 1000U;
 
 
     /// Maximum length of any string that could be returned by @ref AttributesToStringHook().
-    uint8_t const attributeStringMaxLength;
+    uint8_t const attributeStringMaxLength_;
 
     /// Owner ID used to tag requests and to check responses.
-    uint32_t ownerID;
+    uint32_t ownerID_;
 
     /// Mutex used to make @ref Connect() and @ref Disconnect() thread safe.
-    /** Locking order: @ref connectMutex -> @ref internalMutex */
-    gpcc::osal::Mutex connectMutex;
+    /** Locking order: @ref connectMutex_ -> @ref internalMutex_ */
+    gpcc::osal::Mutex connectMutex_;
 
     /// Mutex used to make this class thread-safe.
-    /** Locking order: @ref connectMutex -> @ref internalMutex */
-    gpcc::osal::Mutex internalMutex;
+    /** Locking order: @ref connectMutex_ -> @ref internalMutex_ */
+    gpcc::osal::Mutex internalMutex_;
 
 
     /// Current state of the client.
-    /** @ref internalMutex is required. */
-    States state;
+    /** @ref internalMutex_ is required. */
+    States state_;
 
     /// Pointer to the RODA interface the client is connected to. nullptr = none.
-    /** RD: @ref connectMutex OR @ref internalMutex is required.\n
-        WR: @ref connectMutex AND @ref internalMutex are both required. */
-    IRemoteObjectDictionaryAccess* pRODA;
+    /** RD: @ref connectMutex_ OR @ref internalMutex_ is required.\n
+        WR: @ref connectMutex_ AND @ref internalMutex_ are both required. */
+    IRemoteObjectDictionaryAccess* pRODA_;
 
     /// Maximum request size the client is allowed to transmit.
-    /** @ref internalMutex is required.\n
-        This is only valid if @ref state is @ref States::ready. \n
+    /** @ref internalMutex_ is required.\n
+        This is only valid if @ref state_ is @ref States::ready. \n
         This is set by @ref OnReady(). The size for a @ref ReturnStackItem is already subtracted. */
-    size_t maxRequestSize;
+    size_t maxRequestSize_;
 
     /// Maximum response size the client can receive.
-    /** @ref internalMutex is required.\n
-        This is only valid if @ref state is @ref States::ready. \n
+    /** @ref internalMutex_ is required.\n
+        This is only valid if @ref state_ is @ref States::ready. \n
         This is set by @ref OnReady(). The size for a @ref ReturnStackItem is already subtracted. */
-    size_t maxResponseSize;
+    size_t maxResponseSize_;
 
     /// Session counter.
-    /** @ref internalMutex is required. */
-    uint32_t sessionCnt;
+    /** @ref internalMutex_ is required. */
+    uint32_t sessionCnt_;
 
     /// Response received via the RODAN interface. nullptr = none available.
-    /** @ref internalMutex is required. */
-    std::unique_ptr<ResponseBase> spReceivedResponse;
+    /** @ref internalMutex_ is required. */
+    std::unique_ptr<ResponseBase> spReceivedResponse_;
 
     /// Flag indicating that a new response has been received via the RODAN interface before the previous response in
-    /// @ref spReceivedResponse has been consumed.
-    /** @ref internalMutex is required. */
-    bool receiveOverflow;
+    /// @ref spReceivedResponse_ has been consumed.
+    /** @ref internalMutex_ is required. */
+    bool receiveOverflow_;
 
-    /// Condition variable indicating that @ref spReceivedResponse has been filled with a received response.
-    /** This shall be used in conjunction with @ref internalMutex. */
-    gpcc::osal::ConditionVariable respReceivedConVar;
+    /// Condition variable indicating that @ref spReceivedResponse_ has been filled with a received response.
+    /** This shall be used in conjunction with @ref internalMutex_. */
+    gpcc::osal::ConditionVariable respReceivedConVar_;
 
-    /// Condition variable indicating that @ref state has changed.
-    /** This shall be used in conjunction with @ref internalMutex. */
-    gpcc::osal::ConditionVariable stateChangeConVar;
+    /// Condition variable indicating that @ref state_ has changed.
+    /** This shall be used in conjunction with @ref internalMutex_. */
+    gpcc::osal::ConditionVariable stateChangeConVar_;
 
 
     static uint_fast8_t DigitsInSubindex(uint8_t const si) noexcept;

--- a/include/gpcc/cood/remote_access/requests_and_responses/ObjectEnumRequest.hpp
+++ b/include/gpcc/cood/remote_access/requests_and_responses/ObjectEnumRequest.hpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2021 Daniel Jerolm
+    Copyright (C) 2021, 2025 Daniel Jerolm
 */
 
 #ifndef OBJECTENUMREQUEST_HPP_202103022210
@@ -65,10 +65,10 @@ class ObjectEnumRequest final : public RequestBase
 {
   public:
     ObjectEnumRequest(void) = delete;
-    ObjectEnumRequest(uint16_t                   const _startIndex,
-                      uint16_t                   const _lastIndex,
-                      gpcc::cood::Object::attr_t const _attrFilter,
-                      size_t                     const _maxResponseSize);
+    ObjectEnumRequest(uint16_t                   const startIndex,
+                      uint16_t                   const lastIndex,
+                      gpcc::cood::Object::attr_t const attrFilter,
+                      size_t                     const maxResponseSize);
 
     ObjectEnumRequest(gpcc::stream::IStreamReader & sr, uint8_t const versionOnHand, ObjectEnumRequestPassKey);
 
@@ -93,20 +93,20 @@ class ObjectEnumRequest final : public RequestBase
 
   private:
     /// Binary size of a serialized @ref ObjectEnumRequest object (excl. base class @ref RequestBase).
-    static size_t const objectEnumRequestBinarySize = 6U;
+    static size_t const objectEnumRequestBinarySize_ = 6U;
 
 
     /// Index where enumeration shall start.
     /** Objects located at indices less than this will not be enumerated. */
-    uint16_t const startIndex;
+    uint16_t const startIndex_;
 
     /// Index where enumeration shall stop.
     /** Objects located at indices larger than this will not be enumerated. */
-    uint16_t const lastIndex;
+    uint16_t const lastIndex_;
 
     /// Attribute-filter for enumeration.
     /** Only objects with at least one matching attribute bit will be enumerated. */
-    gpcc::cood::Object::attr_t attrFilter;
+    gpcc::cood::Object::attr_t attrFilter_;
 };
 
 /**
@@ -131,7 +131,7 @@ class ObjectEnumRequest final : public RequestBase
  */
 inline uint16_t ObjectEnumRequest::GetStartIndex(void) const noexcept
 {
-  return startIndex;
+  return startIndex_;
 }
 
 /**
@@ -156,7 +156,7 @@ inline uint16_t ObjectEnumRequest::GetStartIndex(void) const noexcept
  */
 inline uint16_t ObjectEnumRequest::GetLastIndex(void) const noexcept
 {
-  return lastIndex;
+  return lastIndex_;
 }
 
 /**
@@ -181,7 +181,7 @@ inline uint16_t ObjectEnumRequest::GetLastIndex(void) const noexcept
  */
 inline gpcc::cood::Object::attr_t ObjectEnumRequest::GetAttributeFilter(void) const noexcept
 {
-  return attrFilter;
+  return attrFilter_;
 }
 
 } // namespace cood

--- a/include/gpcc/cood/remote_access/requests_and_responses/ObjectEnumResponse.hpp
+++ b/include/gpcc/cood/remote_access/requests_and_responses/ObjectEnumResponse.hpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2021 Daniel Jerolm
+    Copyright (C) 2021, 2025 Daniel Jerolm
 */
 
 #ifndef OBJECTENUMRESPONSE_HPP_202103042132
@@ -91,7 +91,7 @@ class ObjectEnumResponse final : public ResponseBase
   public:
     ObjectEnumResponse(void) = delete;
 
-    explicit ObjectEnumResponse(SDOAbortCode const _result);
+    explicit ObjectEnumResponse(SDOAbortCode const result);
 
     ObjectEnumResponse(gpcc::stream::IStreamReader & sr, uint8_t const versionOnHand, ObjectEnumResponsePassKey);
 
@@ -113,8 +113,8 @@ class ObjectEnumResponse final : public ResponseBase
     // --> ResponseBase
 
     // for server
-    void SetError(SDOAbortCode const _result);
-    void SetData(std::vector<uint16_t> && _indices, bool const _complete);
+    void SetError(SDOAbortCode const result);
+    void SetData(std::vector<uint16_t> && indices, bool const complete);
 
     // for originator of enum request
     SDOAbortCode GetResult(void) const noexcept;
@@ -125,22 +125,22 @@ class ObjectEnumResponse final : public ResponseBase
   private:
     /// Binary size of a serialized @ref ObjectEnumResponse object with @ref SDOAbortCode::OK (excl. base class
     /// @ref ResponseBase and without any data).
-    static size_t const objectEnumResponseBinarySize = 7U;
+    static size_t const objectEnumResponseBinarySize_ = 7U;
 
     /// Maximum number of indices that can be encapsulated in this response object.
-    static size_t const maxNbOfIndices = 65536UL;
+    static size_t const maxNbOfIndices_ = 65536UL;
 
 
     /// Result of the enum operation.
-    SDOAbortCode result;
+    SDOAbortCode result_;
 
     /// Flag indicating if enumeration is complete.
-    /** This is only valid, if @ref result is @ref SDOAbortCode::OK */
-    bool complete;
+    /** This is only valid, if @ref result_ is @ref SDOAbortCode::OK */
+    bool complete_;
 
     /// Indices of enumerated objects.
-    /** This is only valid, if @ref result is @ref SDOAbortCode::OK */
-    std::vector<uint16_t> indices;
+    /** This is only valid, if @ref result_ is @ref SDOAbortCode::OK */
+    std::vector<uint16_t> indices_;
 };
 
 } // namespace cood

--- a/include/gpcc/cood/remote_access/requests_and_responses/ObjectInfoRequest.hpp
+++ b/include/gpcc/cood/remote_access/requests_and_responses/ObjectInfoRequest.hpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2021 Daniel Jerolm
+    Copyright (C) 2021, 2025 Daniel Jerolm
 */
 
 #ifndef OBJECTINFOREQUEST_HPP_202102131446
@@ -70,12 +70,12 @@ class ObjectInfoRequest final : public RequestBase
 {
   public:
     ObjectInfoRequest(void) = delete;
-    ObjectInfoRequest(uint16_t const _index,
-                      uint8_t  const _firstSubIndex,
-                      uint8_t  const _lastSubIndex,
-                      bool     const _inclusiveNames,
-                      bool     const _inclusiveAppSpecificMetaData,
-                      size_t   const _maxResponseSize);
+    ObjectInfoRequest(uint16_t const index,
+                      uint8_t  const firstSubIndex,
+                      uint8_t  const lastSubIndex,
+                      bool     const inclusiveNames,
+                      bool     const inclusiveAppSpecificMetaData,
+                      size_t   const maxResponseSize);
 
     ObjectInfoRequest(gpcc::stream::IStreamReader & sr, uint8_t const versionOnHand, ObjectInfoRequestPassKey);
 
@@ -102,23 +102,23 @@ class ObjectInfoRequest final : public RequestBase
 
   private:
     /// Binary size of a serialized @ref ObjectInfoRequest object (excl. base class @ref RequestBase).
-    static size_t const objectInfoRequestBinarySize = 5U;
+    static size_t const objectInfoRequestBinarySize_ = 5U;
 
 
     /// Index of the object whose meta data shall be queried.
-    uint16_t const index;
+    uint16_t const index_;
 
     /// First subindex whose meta data shall be queried.
-    uint8_t const firstSubIndex;
+    uint8_t const firstSubIndex_;
 
     /// Last subindex whose meta data shall be queried.
-    uint8_t const lastSubIndex;
+    uint8_t const lastSubIndex_;
 
     /// Flag indicating if object's and subindices' names shall be included in the response.
-    bool const inclusiveNames;
+    bool const inclusiveNames_;
 
     /// Flag indicating if application specific meta data of the subindices shall be included in the response.
-    bool const inclusiveAppSpecificMetaData;
+    bool const inclusiveAppSpecificMetaData_;
 };
 
 /**
@@ -142,7 +142,7 @@ class ObjectInfoRequest final : public RequestBase
  */
 inline uint16_t ObjectInfoRequest::GetIndex(void) const noexcept
 {
-  return index;
+  return index_;
 }
 
 /**
@@ -166,7 +166,7 @@ inline uint16_t ObjectInfoRequest::GetIndex(void) const noexcept
  */
 inline uint8_t ObjectInfoRequest::GetFirstSubIndex(void) const noexcept
 {
-  return firstSubIndex;
+  return firstSubIndex_;
 }
 
 /**
@@ -190,7 +190,7 @@ inline uint8_t ObjectInfoRequest::GetFirstSubIndex(void) const noexcept
  */
 inline uint8_t ObjectInfoRequest::GetLastSubIndex(void) const noexcept
 {
-  return lastSubIndex;
+  return lastSubIndex_;
 }
 
 /**
@@ -214,7 +214,7 @@ inline uint8_t ObjectInfoRequest::GetLastSubIndex(void) const noexcept
  */
 inline bool ObjectInfoRequest::IsInclusiveNames(void) const noexcept
 {
-  return inclusiveNames;
+  return inclusiveNames_;
 }
 
 /**
@@ -238,7 +238,7 @@ inline bool ObjectInfoRequest::IsInclusiveNames(void) const noexcept
  */
 inline bool ObjectInfoRequest::IsInclusiveAppSpecificMetaData(void) const noexcept
 {
-  return inclusiveAppSpecificMetaData;
+  return inclusiveAppSpecificMetaData_;
 }
 
 } // namespace cood

--- a/include/gpcc/cood/remote_access/requests_and_responses/ObjectInfoResponse.hpp
+++ b/include/gpcc/cood/remote_access/requests_and_responses/ObjectInfoResponse.hpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2021 Daniel Jerolm
+    Copyright (C) 2021, 2025 Daniel Jerolm
 */
 
 #ifndef OBJECTINFORESPONSE_HPP_202102132033
@@ -97,7 +97,7 @@ class ObjectInfoResponse final : public ResponseBase
                                 uint8_t lastSubindex,
                                 bool const _inclusiveNames,
                                 bool const _inclusiveAppSpecificMetaData,
-                                size_t const maxResponseSize,
+                                size_t const _maxResponseSize,
                                 size_t const returnStackSize);
 
     ObjectInfoResponse(gpcc::stream::IStreamReader & sr, uint8_t const versionOnHand, ObjectInfoResponsePassKey);
@@ -217,7 +217,7 @@ class ObjectInfoResponse final : public ResponseBase
 
 
     void ValidateObjNotEmpty(void) const;
-    size_t CalcRemainingPayload(size_t const maxResponseSize, size_t const returnStackSize) const;
+    size_t CalcRemainingPayload(size_t const _maxResponseSize, size_t const returnStackSize) const;
     uint8_t MapSubindexToSubIndexDescr(uint8_t const subindex) const;
 };
 

--- a/include/gpcc/cood/remote_access/requests_and_responses/ObjectInfoResponse.hpp
+++ b/include/gpcc/cood/remote_access/requests_and_responses/ObjectInfoResponse.hpp
@@ -91,13 +91,13 @@ class ObjectInfoResponse final : public ResponseBase
   public:
     ObjectInfoResponse(void) = delete;
 
-    explicit ObjectInfoResponse(SDOAbortCode const _result);
+    explicit ObjectInfoResponse(SDOAbortCode const result);
     explicit ObjectInfoResponse(Object const & obj,
-                                uint8_t const _firstSubindex,
+                                uint8_t const firstSubindex,
                                 uint8_t lastSubindex,
-                                bool const _inclusiveNames,
-                                bool const _inclusiveAppSpecificMetaData,
-                                size_t const _maxResponseSize,
+                                bool const inclusiveNames,
+                                bool const inclusiveAppSpecificMetaData,
+                                size_t const maximumResponseSize,
                                 size_t const returnStackSize);
 
     ObjectInfoResponse(gpcc::stream::IStreamReader & sr, uint8_t const versionOnHand, ObjectInfoResponsePassKey);
@@ -174,50 +174,50 @@ class ObjectInfoResponse final : public ResponseBase
 
 
     /// Result of the query operation.
-    SDOAbortCode result;
+    SDOAbortCode result_;
 
     /// Indicates if object's and subindices' names are included in queried meta data or not.
-    /** This is only valid, if @ref result is @ref SDOAbortCode::OK. */
-    bool inclusiveNames;
+    /** This is only valid, if @ref result_ is @ref SDOAbortCode::OK. */
+    bool inclusiveNames_;
 
     /// Indicates if application specific meta data of the subindices shall be included in queried meta data or not.
-    /** This is only valid, if @ref result is @ref SDOAbortCode::OK. */
-    bool inclusiveAppSpecificMetaData;
+    /** This is only valid, if @ref result_ is @ref SDOAbortCode::OK. */
+    bool inclusiveAppSpecificMetaData_;
 
 
     /// Object code of the object.
-    /** This is only valid, if @ref result is @ref SDOAbortCode::OK. */
-    Object::ObjectCode objectCode;
+    /** This is only valid, if @ref result_ is @ref SDOAbortCode::OK. */
+    Object::ObjectCode objectCode_;
 
     /// Data type of the object.
-    /** This is only valid, if @ref result is @ref SDOAbortCode::OK. */
-    DataType objType;
+    /** This is only valid, if @ref result_ is @ref SDOAbortCode::OK. */
+    DataType objType_;
 
     /// Name of the object.
-    /** This is only valid, if @ref result is @ref SDOAbortCode::OK and @ref inclusiveNames is true. */
-    std::string objName;
+    /** This is only valid, if @ref result_ is @ref SDOAbortCode::OK and @ref inclusiveNames_ is true. */
+    std::string objName_;
 
     /// Maximum number of subindices (incl. SI 0).
-    /** This is only valid, if @ref result is @ref SDOAbortCode::OK. */
-    uint16_t maxNbOfSubindices;
+    /** This is only valid, if @ref result_ is @ref SDOAbortCode::OK. */
+    uint16_t maxNbOfSubindices_;
 
-    /// Number of the first subindex described in @ref subindexDescr.
-    /** This is only valid, if @ref result is @ref SDOAbortCode::OK. \n
-        If @ref inclusiveAppSpecificMetaData is false, then this is 0 or 1 for an ARRAY object. */
-    uint8_t firstSubindex;
+    /// Number of the first subindex described in @ref subindexDescr_.
+    /** This is only valid, if @ref result_ is @ref SDOAbortCode::OK. \n
+        If @ref inclusiveAppSpecificMetaData_ is false, then this is 0 or 1 for an ARRAY object. */
+    uint8_t firstSubindex_;
 
     /// Subindex descriptions.
-    /** This is only valid, if @ref result is @ref SDOAbortCode::OK. \n
+    /** This is only valid, if @ref result_ is @ref SDOAbortCode::OK. \n
         For a VARIABLE object, this contains exactly one item.\n
-        For an ARRAY object, this contains 1..2 items, if @ref inclusiveAppSpecificMetaData is false.\n
-        For an ARRAy object, this contains 1..256 items, if @ref inclusiveAppSpecificMetaData is true.\n
+        For an ARRAY object, this contains 1..2 items, if @ref inclusiveAppSpecificMetaData_ is false.\n
+        For an ARRAy object, this contains 1..256 items, if @ref inclusiveAppSpecificMetaData_ is true.\n
         For a RECORD object, this contains 1..256 items.\n
         If the @ref ObjectInfoResponse was the source of a move-operation, then this is empty. */
-    std::vector<SubindexDescr> subindexDescr;
+    std::vector<SubindexDescr> subindexDescr_;
 
 
     void ValidateObjNotEmpty(void) const;
-    size_t CalcRemainingPayload(size_t const _maxResponseSize, size_t const returnStackSize) const;
+    size_t CalcRemainingPayload(size_t const maximumResponseSize, size_t const returnStackSize) const;
     uint8_t MapSubindexToSubIndexDescr(uint8_t const subindex) const;
 };
 

--- a/include/gpcc/cood/remote_access/requests_and_responses/PingRequest.hpp
+++ b/include/gpcc/cood/remote_access/requests_and_responses/PingRequest.hpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2021 Daniel Jerolm
+    Copyright (C) 2021, 2025 Daniel Jerolm
 */
 
 #ifndef PINGREQUEST_HPP_202108051135
@@ -48,7 +48,7 @@ class PingRequest final : public RequestBase
   public:
     PingRequest(void) = delete;
 
-    PingRequest(size_t const _maxResponseSize);
+    PingRequest(size_t const maxResponseSize);
 
     PingRequest(gpcc::stream::IStreamReader & sr, uint8_t const versionOnHand, PingRequestPassKey);
 

--- a/include/gpcc/cood/remote_access/requests_and_responses/ReadRequest.hpp
+++ b/include/gpcc/cood/remote_access/requests_and_responses/ReadRequest.hpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2021 Daniel Jerolm
+    Copyright (C) 2021, 2025 Daniel Jerolm
 */
 
 #ifndef READREQUEST_HPP_202010091707
@@ -58,11 +58,11 @@ class ReadRequest final : public RequestBase
 
     ReadRequest(void) = delete;
 
-    ReadRequest(AccessType     const _accessType,
-                uint16_t       const _index,
-                uint8_t        const _subindex,
-                Object::attr_t const _permissions,
-                size_t         const _maxResponseSize);
+    ReadRequest(AccessType     const accessType,
+                uint16_t       const index,
+                uint8_t        const subindex,
+                Object::attr_t const permissions,
+                size_t         const maxResponseSize);
 
     ReadRequest(gpcc::stream::IStreamReader & sr, uint8_t const versionOnHand, ReadRequestPassKey);
 
@@ -90,20 +90,20 @@ class ReadRequest final : public RequestBase
 
   private:
     /// Binary size of a serialized @ref ReadRequest object (excl. base class @ref RequestBase).
-    static size_t const readRequestBinarySize = 6U;
+    static size_t const readRequestBinarySize_ = 6U;
 
     /// Access type.
-    AccessType const accessType;
+    AccessType const accessType_;
 
     /// Index of the object that shall be read.
-    uint16_t const index;
+    uint16_t const index_;
 
     /// Subindex that shall be read.
-    uint8_t const subindex;
+    uint8_t const subindex_;
 
     /// Permissions provided by the originator of the read request.
     /** This is any combination of attr_ACCESS_X values from class @ref Object. */
-    Object::attr_t const permissions;
+    Object::attr_t const permissions_;
 
 
     static AccessType U8_to_AccessType(uint8_t const u8);
@@ -130,7 +130,7 @@ class ReadRequest final : public RequestBase
  */
 inline ReadRequest::AccessType ReadRequest::GetAccessType(void) const noexcept
 {
-  return accessType;
+  return accessType_;
 }
 
 /**
@@ -154,7 +154,7 @@ inline ReadRequest::AccessType ReadRequest::GetAccessType(void) const noexcept
  */
 inline uint16_t ReadRequest::GetIndex(void) const noexcept
 {
-  return index;
+  return index_;
 }
 
 /**
@@ -178,7 +178,7 @@ inline uint16_t ReadRequest::GetIndex(void) const noexcept
  */
 inline uint8_t ReadRequest::GetSubIndex(void) const noexcept
 {
-  return subindex;
+  return subindex_;
 }
 
 /**
@@ -202,7 +202,7 @@ inline uint8_t ReadRequest::GetSubIndex(void) const noexcept
  */
 inline Object::attr_t ReadRequest::GetPermissions(void) const noexcept
 {
-  return permissions;
+  return permissions_;
 }
 
 } // namespace cood

--- a/include/gpcc/cood/remote_access/requests_and_responses/ReadRequestResponse.hpp
+++ b/include/gpcc/cood/remote_access/requests_and_responses/ReadRequestResponse.hpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2021 Daniel Jerolm
+    Copyright (C) 2021, 2025 Daniel Jerolm
 */
 
 #ifndef READREQUESTRESPONSE_HPP_202010101331
@@ -64,7 +64,7 @@ class ReadRequestResponse final : public ResponseBase
   public:
     ReadRequestResponse(void) = delete;
 
-    explicit ReadRequestResponse(SDOAbortCode const _result);
+    explicit ReadRequestResponse(SDOAbortCode const result);
 
     ReadRequestResponse(gpcc::stream::IStreamReader & sr, uint8_t const versionOnHand, ReadRequestResponsePassKey);
 
@@ -86,8 +86,8 @@ class ReadRequestResponse final : public ResponseBase
     // --> ResponseBase
 
     // for server
-    void SetError(SDOAbortCode const _result);
-    void SetData(std::vector<uint8_t> && _data, size_t const _sizeInBit);
+    void SetError(SDOAbortCode const result);
+    void SetData(std::vector<uint8_t> && data, size_t const sizeInBit);
 
     // for originator of read request
     SDOAbortCode GetResult(void) const noexcept;
@@ -95,21 +95,21 @@ class ReadRequestResponse final : public ResponseBase
     std::vector<uint8_t> const & GetData(void) const;
 
   private:
-    /// Binary size of a serialized @ref ReadRequestResponse object with __positive__ @ref result
+    /// Binary size of a serialized @ref ReadRequestResponse object with __positive__ @ref result_
     /// (excl. base class @ref ResponseBase and any data).
-    static size_t const readRequestResponseBinarySize = 7U;
+    static size_t const readRequestResponseBinarySize_ = 7U;
 
 
     /// Result of the read request.
-    SDOAbortCode result;
+    SDOAbortCode result_;
 
     /// Data that has been read.
-    /** This is only valid, if @ref result is @ref SDOAbortCode::OK. */
-    std::vector<uint8_t> data;
+    /** This is only valid, if @ref result_ is @ref SDOAbortCode::OK. */
+    std::vector<uint8_t> data_;
 
-    /// Size of @ref data in bit.
-    /** This is only valid, if @ref result is @ref SDOAbortCode::OK. */
-    size_t sizeInBit;
+    /// Size of @ref data_ in bit.
+    /** This is only valid, if @ref result_ is @ref SDOAbortCode::OK. */
+    size_t sizeInBit_;
 };
 
 } // namespace cood

--- a/include/gpcc/cood/remote_access/requests_and_responses/RequestBase.hpp
+++ b/include/gpcc/cood/remote_access/requests_and_responses/RequestBase.hpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2021 Daniel Jerolm
+    Copyright (C) 2021, 2025 Daniel Jerolm
 */
 
 #ifndef REQUESTBASE_HPP_202006251835
@@ -120,18 +120,18 @@ class RequestBase
     /// Latest version of binary data supported by this class and its sub-classes.
     /** @ref ToBinary() will generate a binary with this version.\n
         @ref FromBinary() will accept this version and potential older versions, too. */
-    static uint8_t const version = 1U;
+    static uint8_t const version_ = 1U;
 
     /// Binary size (in byte) of a serialized @ref RequestBase object (excl. `returnStack` and derived class(es)).
-    static size_t const baseBinarySize = 7U;
+    static size_t const baseBinarySize_ = 7U;
 
 
     /// Type of request. Indicates the type of sub-class.
-    RequestTypes const type;
+    RequestTypes const type_;
 
 
-    RequestBase(RequestTypes const _type, size_t const _maxResponseSize);
-    RequestBase(RequestTypes const _type, gpcc::stream::IStreamReader & sr, uint8_t const versionOnHand);
+    RequestBase(RequestTypes const type, size_t const maxResponseSize);
+    RequestBase(RequestTypes const type, gpcc::stream::IStreamReader & sr, uint8_t const versionOnHand);
 
     RequestBase(RequestBase const & other);
     RequestBase(RequestBase && other) noexcept;
@@ -150,10 +150,10 @@ class RequestBase
     /// connected in between.
     /** The value refers to a serialized response object and includes any @ref ReturnStackItem objects contained in
         the response object. */
-    size_t maxResponseSize;
+    size_t maxResponseSize_;
 
     /// Stack of information required to route the response back to the originator of the request.
-    std::vector<ReturnStackItem> returnStack;
+    std::vector<ReturnStackItem> returnStack_;
 
 
     static RequestTypes ToRequestType(uint8_t const value);
@@ -180,7 +180,7 @@ class RequestBase
  */
 inline RequestBase::RequestTypes RequestBase::GetType(void) const noexcept
 {
-  return type;
+  return type_;
 }
 
 /**
@@ -205,7 +205,7 @@ inline RequestBase::RequestTypes RequestBase::GetType(void) const noexcept
  */
 inline size_t RequestBase::GetMaxResponseSize(void) const
 {
-  return maxResponseSize;
+  return maxResponseSize_;
 }
 
 /**

--- a/include/gpcc/cood/remote_access/requests_and_responses/ResponseBase.hpp
+++ b/include/gpcc/cood/remote_access/requests_and_responses/ResponseBase.hpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2021 Daniel Jerolm
+    Copyright (C) 2021, 2025 Daniel Jerolm
 */
 
 #ifndef RESPONSEBASE_HPP_202006282132
@@ -115,18 +115,18 @@ class ResponseBase
     /// Latest version of binary data supported by this class and its sub-classes.
     /** @ref ToBinary() will generate a binary with this version.\n
         @ref FromBinary() will accept this version and potential older versions, too. */
-    static uint8_t const version = 1U;
+    static uint8_t const version_ = 1U;
 
-    /// Binary size of a serialized @ref ResponseBase object (excl. `returnStack` and derived class(es)).
-    static size_t const baseBinarySize = 3U;
+    /// Binary size of a serialized @ref ResponseBase object (excl. `returnStack_` and derived class(es)).
+    static size_t const baseBinarySize_ = 3U;
 
 
     /// Type of response. Indicates the type of sub-class.
-    ResponseTypes const type;
+    ResponseTypes const type_;
 
 
-    explicit ResponseBase(ResponseTypes const _type);
-    ResponseBase(ResponseTypes const _type, gpcc::stream::IStreamReader & sr, uint8_t const versionOnHand);
+    explicit ResponseBase(ResponseTypes const type);
+    ResponseBase(ResponseTypes const type, gpcc::stream::IStreamReader & sr, uint8_t const versionOnHand);
 
     ResponseBase(ResponseBase const & other);
     ResponseBase(ResponseBase && other) noexcept;
@@ -142,7 +142,7 @@ class ResponseBase
     ResponseBase* pNextInIntrusiveDList;
 
     /// Stack of information required to route the response back to the originator of the request.
-    std::vector<ReturnStackItem> returnStack;
+    std::vector<ReturnStackItem> returnStack_;
 
 
     static ResponseTypes ToResponseType(uint8_t const value);

--- a/include/gpcc/cood/remote_access/requests_and_responses/WriteRequest.hpp
+++ b/include/gpcc/cood/remote_access/requests_and_responses/WriteRequest.hpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2021 Daniel Jerolm
+    Copyright (C) 2021, 2025 Daniel Jerolm
 */
 
 #ifndef WRITEREQUEST_HPP_202006251837
@@ -58,12 +58,12 @@ class WriteRequest final : public RequestBase
 
     WriteRequest(void) = delete;
 
-    WriteRequest(AccessType           const _accessType,
-                 uint16_t             const _index,
-                 uint8_t              const _subindex,
-                 Object::attr_t       const _permissions,
-                 std::vector<uint8_t> &&    _data,
-                 size_t               const _maxResponseSize);
+    WriteRequest(AccessType           const accessType,
+                 uint16_t             const index,
+                 uint8_t              const subindex,
+                 Object::attr_t       const permissions,
+                 std::vector<uint8_t> &&    data,
+                 size_t               const maxResponseSize);
 
     WriteRequest(gpcc::stream::IStreamReader & sr, uint8_t const versionOnHand, WriteRequestPassKey);
 
@@ -92,24 +92,24 @@ class WriteRequest final : public RequestBase
 
   private:
     /// Binary size of a serialized @ref WriteRequest object (excl. base class @ref RequestBase).
-    static size_t const writeRequestBinarySize = 8U;
+    static size_t const writeRequestBinarySize_ = 8U;
 
 
     /// Access type.
-    AccessType const accessType;
+    AccessType const accessType_;
 
     /// Index of the object that shall be written.
-    uint16_t const index;
+    uint16_t const index_;
 
     /// Subindex that shall be written.
-    uint8_t const subindex;
+    uint8_t const subindex_;
 
     /// Permissions provided by the originator of the write request.
     /** This is any combination of attr_ACCESS_X values from class @ref Object. */
-    Object::attr_t const permissions;
+    Object::attr_t const permissions_;
 
     /// Data that shall be written.
-    std::vector<uint8_t> data;
+    std::vector<uint8_t> data_;
 
 
     static AccessType U8_to_AccessType(uint8_t const u8);
@@ -136,7 +136,7 @@ class WriteRequest final : public RequestBase
  */
 inline WriteRequest::AccessType WriteRequest::GetAccessType(void) const noexcept
 {
-  return accessType;
+  return accessType_;
 }
 
 /**
@@ -160,7 +160,7 @@ inline WriteRequest::AccessType WriteRequest::GetAccessType(void) const noexcept
  */
 inline uint16_t WriteRequest::GetIndex(void) const noexcept
 {
-  return index;
+  return index_;
 }
 
 /**
@@ -184,7 +184,7 @@ inline uint16_t WriteRequest::GetIndex(void) const noexcept
  */
 inline uint8_t WriteRequest::GetSubIndex(void) const noexcept
 {
-  return subindex;
+  return subindex_;
 }
 
 /**
@@ -208,7 +208,7 @@ inline uint8_t WriteRequest::GetSubIndex(void) const noexcept
  */
 inline Object::attr_t WriteRequest::GetPermissions(void) const noexcept
 {
-  return permissions;
+  return permissions_;
 }
 
 } // namespace cood

--- a/include/gpcc/cood/remote_access/requests_and_responses/WriteRequestResponse.hpp
+++ b/include/gpcc/cood/remote_access/requests_and_responses/WriteRequestResponse.hpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2021 Daniel Jerolm
+    Copyright (C) 2021, 2025 Daniel Jerolm
 */
 
 #ifndef WRITEREQUESTRESPONSE_HPP_202006292122
@@ -49,7 +49,7 @@ class WriteRequestResponse final : public ResponseBase
   public:
     WriteRequestResponse(void) = delete;
 
-    explicit WriteRequestResponse(SDOAbortCode const _result);
+    explicit WriteRequestResponse(SDOAbortCode const result);
 
     WriteRequestResponse(gpcc::stream::IStreamReader & sr, uint8_t const versionOnHand, WriteRequestResponsePassKey);
 
@@ -69,17 +69,17 @@ class WriteRequestResponse final : public ResponseBase
     // --> ResponseBase
 
     // for server
-    void SetResult(SDOAbortCode const _result) noexcept;
+    void SetResult(SDOAbortCode const result) noexcept;
 
     // for originator of request
     SDOAbortCode GetResult(void) const noexcept;
 
   private:
     /// Binary size of a serialized @ref WriteRequestResponse object (excl. base class @ref ResponseBase).
-    static size_t const writeRequestResponseBinarySize = 4U;
+    static size_t const writeRequestResponseBinarySize_ = 4U;
 
     /// Result of the write request.
-    SDOAbortCode result;
+    SDOAbortCode result_;
 };
 
 /**
@@ -98,12 +98,12 @@ class WriteRequestResponse final : public ResponseBase
  *
  * - - -
  *
- * \param _result
+ * \param result
  * Desired value for the encapsulated result value.
  */
-inline void WriteRequestResponse::SetResult(SDOAbortCode const _result) noexcept
+inline void WriteRequestResponse::SetResult(SDOAbortCode const result) noexcept
 {
-  result = _result;
+  result_ = result;
 }
 
 /**
@@ -127,7 +127,7 @@ inline void WriteRequestResponse::SetResult(SDOAbortCode const _result) noexcept
  */
 inline SDOAbortCode WriteRequestResponse::GetResult(void) const noexcept
 {
-  return result;
+  return result_;
 }
 
 } // namespace cood

--- a/include/gpcc/execution/cyclic/TriggeredThreadedCyclicExec.hpp
+++ b/include/gpcc/execution/cyclic/TriggeredThreadedCyclicExec.hpp
@@ -26,17 +26,18 @@ namespace stdif
 }
 
 namespace execution {
-namespace cyclic {
+namespace cyclic    {
 
 /**
  * \ingroup GPCC_EXECUTION_CYCLIC
- * \brief Abstract base class for cyclic (triggered) execution of subclass' code in an own thread.
+ * \brief Abstract base class for cyclic triggered execution of subclass' code in an own thread.
  *
- * The executed subclass' code usually implements some kind of controller or control loop that must be
- * cyclically executed (or "sampled" to say it in the language of control technology). Cyclic execution
- * is triggered by an [IIRQ2ThreadWakeup](@ref gpcc::stdif::IIRQ2ThreadWakeup) which is used to deliver
- * an (cyclic) trigger to class @ref TriggeredThreadedCyclicExec. Execution of the subclass' code can be
- * enabled and disabled.
+ * The subclass' code usually implements some kind of controller or control loop that must be cyclically executed
+ * (or "sampled" to say it in the language of control technology). Cyclic execution is triggered by an
+ * [IIRQ2ThreadWakeup](@ref gpcc::stdif::IIRQ2ThreadWakeup) which is used to deliver a cyclic trigger to class
+ * @ref TriggeredThreadedCyclicExec.
+ *
+ * Cylic execution of the subclass' code can be gracefully enabled and disabled.
  *
  * # Subclassing
  * The derived sub-class must implement the following virtual methods:
@@ -46,51 +47,48 @@ namespace cyclic {
  * - @ref Sample()
  * - @ref OnStateChange()
  *
- * Method @ref OnStart() is invoked upon reception of the trigger exactly one cycle before method
- * @ref Sample() is called for the first time. It can be used by the subclass to initialize or prepare stuff
- * that is used within @ref Sample(). @ref OnStart() must finish before the next trigger is received, or
- * an overrun condition will be detected.
+ * Method @ref OnStart() is invoked upon reception of the trigger exactly one cycle before method @ref Sample() is
+ * called for the first time. It can be used by the subclass to initialize or prepare stuff that is used within
+ * @ref Sample(). @ref OnStart() must finish before the next trigger is received, or an overrun condition will be
+ * detected.
  *
- * Method @ref OnStop() is invoked after cyclic execution of @ref Sample() has stopped. It is either
- * executed upon reception of the next trigger after the last call to @ref Sample() or it is executed
- * directly after @ref Sample() has returned. @ref OnStop() is intended to inform the subclass that cyclic
- * execution of @ref Sample() has been stopped. The subclass may use @ref OnStop() to perform clean-up
- * operations or shut things properly down. In contrast to @ref OnStart(), @ref OnStop() does not necessarily
- * need to finish before reception of the next trigger.\n
+ * Method @ref OnStop() is invoked after cyclic execution of @ref Sample() has stopped. It is either executed upon
+ * reception of the next trigger after the last call to @ref Sample() or it is executed directly after @ref Sample() has
+ * returned. @ref OnStop() is intended to inform the subclass that cyclic execution of @ref Sample() has been stopped.
+ * The subclass may use @ref OnStop() to perform clean-up operations or shut things properly down. In contrast to
+ * @ref OnStart(), @ref OnStop() does not necessarily need to finish before reception of the next trigger.\n
  * _Note:_\n
- * _OnStop() is not called or the call is not completed if StopThread() is invoked!_\n
+ * _OnStop() is not called or the call is not completed if @ref StopThread() is invoked!_\n
  * See section "Starting and Stopping the internal thread" below.
  *
- * Method @ref Sample() is invoked upon reception of the (cyclic) trigger. The subclass is intended to run the
- * code that shall be cyclically executed from within this method. @ref Sample() must finish before the next
- * trigger is received, or an overrun condition will be detected. Any overrun condition is reported to
- * @ref Sample() via parameter `overrun`.
+ * Method @ref Sample() is invoked upon reception of the cyclic trigger. The subclass is intended to run the code that
+ * shall be cyclically executed from within this method. @ref Sample() must finish before the next trigger is received,
+ * or an overrun condition will be detected. Any overrun condition is reported to @ref Sample() via parameter `overrun`.
  *
- * Method @ref Cyclic() is always cyclically invoked, regardless of if the cyclic trigger (e.g. from a PLL)
- * is present or not, or if the PLL (if any) is locked or not, or if cyclic execution of @ref Sample()
- * is currently enabled or not.\n
+ * Method @ref Cyclic() is always cyclically invoked, regardless of if the cyclic trigger is present or not, or if the
+ * PLL (if any) is locked or not, or if cyclic execution of @ref Sample() is currently enabled or not.\n
  * If cyclic execution of @ref Sample() is enabled, then @ref Cyclic() is executed after @ref Sample() has
  * returned. @ref Cyclic() must finish before the next trigger is received, or an overrun condition will be
  * detected. However, @ref Cyclic() should also finish before reception of the next trigger if cyclic execution
  * of @ref Sample() is disabled.\n
- * Subclasses may use @ref Cyclic() to run code cyclically even if cyclic execution of @ref Sample() is
- * disabled or if the cyclic trigger is missing. In the latter case, @ref Cyclic() is executed each time
- * the timeout used to monitor the cyclic trigger expires. Subclasses shall therefore not rely on deterministic
- * behavior regarding calls to @ref Cyclic(). An typical example for usage of @ref Cyclic() includes control of status
- * indicator LEDs or sampling pushbuttons.
+ * Subclasses may use @ref Cyclic() to run code cyclically even if cyclic execution of @ref Sample() is disabled or if
+ * the cyclic trigger is missing. In the latter case, @ref Cyclic() is executed each time the timeout used to monitor
+ * presence of the cyclic trigger expires. Subclasses shall therefore not rely on deterministic behavior regarding calls
+ * to @ref Cyclic(). An typical example for usage of @ref Cyclic() includes control of status indicator LEDs or
+ * sampling pushbuttons.
  *
  * All virtual methods mentioned in this section are executed in the context of the thread provided by this class.
  * No internal mutex of the @ref TriggeredThreadedCyclicExec is locked upon invocation of any of the virtual methods.
  * Thus it is safe to invoke any of the public methods @ref RequestStartSampling(), @ref RequestStopSampling() and
  * @ref GetCurrentState() from the virtual methods.
  *
- * For further details on the virtual methods please refer to the documentation of these methods.
+ * For further details about the virtual methods please refer to their documentation.
  *
  * # Trigger
  * On instantiation, a reference to an [IIRQ2ThreadWakeup](@ref gpcc::stdif::IIRQ2ThreadWakeup) interface is passed
  * to the constructor of class @ref TriggeredThreadedCyclicExec. The interface is used to receive the cyclic trigger.\n
- * The trigger is typically generated by a hardware timer or a PLL implemented using a hardware timer, but it
- * could also be pure software generated.
+ * The trigger is typically generated by a hardware timer or a PLL implemented using a hardware timer, but it could also
+ * be pure software generated.
  *
  * # PLL Lock State Monitoring
  * If a PLL is generating the cyclic trigger via the [IIRQ2ThreadWakeup](@ref gpcc::stdif::IIRQ2ThreadWakeup) interface,
@@ -98,35 +96,38 @@ namespace cyclic {
  * cyclic execution of the @ref Sample() method is stopped.\n
  * Monitoring is accomplished using a callback passed to the constructor of class @ref TriggeredThreadedCyclicExec.
  * The callback is invoked after reception of each trigger to check the lock state.\n
- * If no PLL is used to generate the trigger, or if lock-state monitoring is not required, then the callback
- * can be omitted during instantiation of class @ref TriggeredThreadedCyclicExec.
+ * If no PLL is used to generate the trigger, or if lock-state monitoring is not required, then the callback can be
+ * omitted during instantiation of class @ref TriggeredThreadedCyclicExec.
  *
  * # Monitoring of cyclic trigger
- * While this class is waiting for the PLL to lock or while the PLL is locked and @ref Sample() is cyclically
- * executed during normal operation, the presence of the cyclic trigger is monitored using a timeout. If the cyclic
- * trigger does not occur within the timeout, then cyclic execution of method @ref Sample() is stopped.\n
+ * While this class is waiting for the PLL to lock or while the PLL is locked and @ref Sample() is cyclically executed
+ * during normal operation, the presence of the cyclic trigger is monitored using a timeout. If the cyclic trigger does
+ * not occur within the timeout, then cyclic execution of method @ref Sample() is stopped.\n
  * Note that method @ref Cyclic() will still be cyclically executed each time the timeout expires.
  *
- * # Starting and Stopping sampling
+ * # Starting and stopping sampling
  * Execution of method @ref Sample() can be enabled and disabled using the methods @ref RequestStartSampling()
  * and @ref RequestStopSampling(). \n
- * Sampling is gracefully started and stopped with invocations of @ref OnStart(), @ref OnStop(), and
+ * Sampling is gracefully started and stopped comprising invocation of @ref OnStart(), @ref OnStop(), and
  * @ref OnStateChange() (see state chart below).
- * Usually class @ref TTCEStartStopCtrl is used in conjunction with this class to conveniently enable and disable
- * cyclic execution of the @ref Sample() method.
+ *
+ * Usually class @ref TTCEStartStopCtrl is used in conjunction with this class to conveniently enable and disable cyclic
+ * execution of the @ref Sample() method.
  *
  * \htmlonly <style>div.image img[src="execution/cyclic/TTCE_StateMachine.png"]{width:75%;}</style> \endhtmlonly
  * \image html "execution/cyclic/TTCE_StateMachine.png" "Internal States of class TriggeredThreadedCyclicExec"
  *
  * ## Startup sequence
- * After invocation of @ref RequestStartSampling(), the @ref TriggeredThreadedCyclicExec switches to state
- * @ref States::starting upon reception of the next trigger.\n
+ * After invocation of @ref RequestStartSampling(), class @ref TriggeredThreadedCyclicExec switches to state
+ * @ref States::starting upon reception of the next trigger.
+ *
  * @ref TriggeredThreadedCyclicExec remains in @ref States::starting for the number of trigger events passed to
  * @ref RequestStartSampling() via parameter `startDelay` plus one. If `startDelay` is zero, then the
  * @ref TriggeredThreadedCyclicExec switches to @ref States::waitLock upon reception of the next trigger.
- * Otherwise it remains in @ref States::starting for the number of extra triggers setup via `startDelay`.\n
- * @ref TriggeredThreadedCyclicExec remains in @ref States::waitLock, until the PLL driving the trigger
- * has locked. Once the PLL has locked, or if no callback for lock-check has been specified during instantiation,
+ * Otherwise it remains in @ref States::starting for the number of extra triggers setup via `startDelay`.
+ *
+ * @ref TriggeredThreadedCyclicExec remains in @ref States::waitLock, until the PLL driving the trigger has locked. Once
+ * the PLL has locked, or if no callback for querying the lock-status has been specified during instantiation,
  * @ref TriggeredThreadedCyclicExec switches to @ref States::running upon reception of the next trigger.
  *
  * ## Stop sequence
@@ -134,33 +135,33 @@ namespace cyclic {
  * @ref States::stopped upon the next trigger event.
  *
  * ## Stop due to errors
- * In addition to stops due to calls to @ref RequestStopSampling(), @ref TriggeredThreadedCyclicExec also
- * switches to state @ref States::stopped in case of the following error conditions:
+ * In addition to stops due to calls to @ref RequestStopSampling(), @ref TriggeredThreadedCyclicExec also switches to
+ * state @ref States::stopped in case of the following error conditions:
  * - the trigger timeout expires
- * - the PLL driving the trigger leaves the lock-state (optional,  see "PLL Lock state monitoring" above)
+ * - the PLL driving the trigger leaves the lock-state (optional, see "PLL Lock state monitoring" above)
  * - @ref Sample() returned false
  *
  * # Starting and Stopping the internal thread
- * @ref TriggeredThreadedCyclicExec uses an own thread to execute the subclass' code. After instantiation,
- * the thread must be started using @ref StartThread() to allow @ref TriggeredThreadedCyclicExec to become
- * functional.
+ * @ref TriggeredThreadedCyclicExec uses an own thread to execute the subclass' code. After instantiation, the thread
+ * must be started using @ref StartThread() to allow @ref TriggeredThreadedCyclicExec to become functional.
  *
  * Before destruction, the thread must be stopped again using @ref StopThread().
  *
- * _Note: The thread is stopped using deferred cancellation._
- * _If the operating system does not support deferred cancellation, then the thread will be stopped_
- * _upon reception of the next trigger or upon trigger timeout._
+ * __Note:__\n
+ * The thread is stopped using deferred cancellation.\n
+ * If the operating system does not support deferred cancellation, then the thread will be stopped upon reception of the
+ * next trigger or upon trigger timeout.
  *
  * It is recommended to stop the thread while the @ref TriggeredThreadedCyclicExec instance is in state
- * @ref States::stopped. This prevents any issues with deferred cancellation occurring e.g. during execution
- * of @ref Sample(). \n
+ * @ref States::stopped. This prevents any issues with deferred cancellation occurring e.g. during execution of
+ * @ref Sample(). \n
  * However, @ref Cyclic() should still be aware of deferred cancellation, because it is also executed in state
  * @ref States::stopped.
  *
  * After terminating the object's thread, it can be restarted by calling @ref StartThread(). The
  * @ref TriggeredThreadedCyclicExec then continues in state @ref States::stopped.
  *
- * ---
+ * - - -
  *
  * __Thread safety:__\n
  * Thread-safe.
@@ -188,26 +189,28 @@ class TriggeredThreadedCyclicExec
     };
 
     /**
-     * \brief Type definition of a functor to a method for retrieving the lock-state of the PLL.
+     * \brief Type definition of a functor to a function for querying the lock status of the PLL.
      *
      * Note:
      * - Using a PLL to drive the trigger is optional.
      * - Using the PLL lock monitoring feature is optional (see constructor).
      *
-     * Return value:\n
-     * The return value shall indicate if the PLL is in the lock state or not:\n
-     * true  = PLL is locked\n
-     * false = PLL is not locked.
+     * - - -
      *
-     * __Thread-safety requirements/hints:__\n
-     * The referenced method will be cyclically executed in the context of class
-     * @ref TriggeredThreadedCyclicExec's thread with internal mutexes being locked.
-     * The referenced method is not allowed to call any method of class @ref TriggeredThreadedCyclicExec.
+     * \retval true   PLL is locked.
+     * \retval false  PLL is not locked.
      *
-     * __Exception-safety requirements/hints:__\n
+     * - - -
+     *
+     * __Thread safety requirements/hints:__\n
+     * The referenced function/method will be cyclically executed in the context of class
+     * @ref TriggeredThreadedCyclicExec's thread with internal mutexes being locked.\n
+     * The referenced function/method is not allowed to call any method of class @ref TriggeredThreadedCyclicExec.
+     *
+     * __Exception safety requirements/hints:__\n
      * The referenced function/method shall provide the no-throw guarantee.
      *
-     * __Thread-cancellation-safety requirements/hints:__\n
+     * __Thread cancellation safety requirements/hints:__\n
      * The referenced function/method will be invoked with deferred cancellation enabled.
      */
     typedef std::function<bool(void)> tIsPllLocked;
@@ -221,12 +224,13 @@ class TriggeredThreadedCyclicExec
     TriggeredThreadedCyclicExec(TriggeredThreadedCyclicExec &&) = delete;
     virtual ~TriggeredThreadedCyclicExec(void);
 
-    static char const * State2String(States const state);
-    static char const * StopReasons2String(StopReasons const code);
-    static char const * StopReasons2Description(StopReasons const code);
-
     TriggeredThreadedCyclicExec& operator=(TriggeredThreadedCyclicExec const &) = delete;
     TriggeredThreadedCyclicExec& operator=(TriggeredThreadedCyclicExec &&) = delete;
+
+
+    static char const * State2String(States const state) noexcept;
+    static char const * StopReasons2String(StopReasons const code) noexcept;
+    static char const * StopReasons2Description(StopReasons const code) noexcept;
 
 
     void StartThread(osal::Thread::SchedPolicy const schedPolicy,
@@ -250,9 +254,9 @@ class TriggeredThreadedCyclicExec
   private:
     /// Enumeration with flags for asynchronous requests issued to the class' state machine.
     /** Note:\n
-        The enum values are stored in @ref asyncReqFlags_ (uint8_t) later. Multiple enum values may be
-        or-combined in @ref asyncReqFlags_ to allow multiple flags being set simultaneously.\n
-        _Therefore enum values must be a power of 2 (0,1,2,4,8,...)._ */
+        The enum values are stored in @ref asyncReqFlags_ (uint8_t) later. Multiple enum values may be or-combined in
+        @ref asyncReqFlags_ to allow multiple flags being set simultaneously.\n
+        Therefore enum values must be a power of 2 (0,1,2,4,8,...). */
     enum class AsyncReqFlags
     {
       none  = 0x00, ///<No request pending.
@@ -261,21 +265,20 @@ class TriggeredThreadedCyclicExec
     };
 
 
-    /// Reference to a [IIRQ2ThreadWakeup](@ref gpcc::stdif::IIRQ2ThreadWakeup) subclass instance providing the cyclic
-    /// trigger.
+    /// Reference to a [IIRQ2ThreadWakeup](@ref gpcc::stdif::IIRQ2ThreadWakeup) interface providing the cyclic trigger.
     stdif::IIRQ2ThreadWakeup & trigger_;
 
     /// Timeout for the cyclic trigger.
     time::TimeSpan const timeout_;
 
-    /// Functor to a method for retrieving the PLL lock state.
+    /// Functor to a function/method for retrieving the PLL's lock state.
     /** If no function/method is referenced, then the PLL lock state is not checked. */
     tIsPllLocked const isPllLockedFunc_;
 
     /// Thread used for cyclic execution of the subclasses' code.
     osal::Thread thread_;
 
-    /// Mutex used to make things thread-safe.
+    /// Mutex used to make this class thread-safe.
     mutable osal::Mutex mutex_;
 
     /// Flags for signaling asynchronous requests to the @ref TriggeredThreadedCyclicExec's state machine.
@@ -298,22 +301,23 @@ class TriggeredThreadedCyclicExec
  * \fn void TriggeredThreadedCyclicExec::Cyclic(void)
  * \brief This is called cyclically regardless of the @ref TriggeredThreadedCyclicExec's state.
  *
- * This is called independently of the @ref TriggeredThreadedCyclicExec's state each time when either a trigger
- * is received or a timeout occurs while waiting for the trigger.
+ * This is called independently of the @ref TriggeredThreadedCyclicExec's state each time when either the cyclic trigger
+ * is received or a timeout occurs while waiting for the cyclic trigger.
  *
  * If the @ref TriggeredThreadedCyclicExec is in state @ref States::running, then this is called after @ref Sample().
  *
- * ---
+ * - - -
  *
- * __Thread safety:__\n
- * This is executed in the context of the TriggeredThreadedCyclicExec's thread.
+ * __Thread safety requirements/hints:__\n
+ * This is executed in the context of the @ref TriggeredThreadedCyclicExec's thread.
  *
- * __Exception safety:__\n
+ * __Exception safety requirements/hints:__\n
+ * This method shall provide the no-throw guarantee.\n
  * Any thrown exception will result in program termination via @ref gpcc::osal::Panic().
  *
- * __Thread cancellation safety:__\n
- * This is invoked with deferred cancellation enabled.\n
- * The subclass must be aware of deferred cancellation if @ref StopThread() is invoked.
+ * __Thread cancellation safety requirements/hints:__\n
+ * This method shall provide at least the strong guarantee.\n
+ * The implementation must be aware of deferred cancellation if @ref StopThread() is invoked.
  */
 
 /**
@@ -325,17 +329,18 @@ class TriggeredThreadedCyclicExec
  * 2. @ref OnStateChange()
  * 3. @ref OnStart()
  *
- * ---
+ * - - -
  *
- * __Thread safety:__\n
+ * __Thread safety requirements/hints:__\n
  * This is executed in the context of the @ref TriggeredThreadedCyclicExec's thread.
  *
- * __Exception safety:__\n
+ * __Exception safety requirements/hints:__\n
+ * This method shall provide the no-throw guarantee.\n
  * Any thrown exception will result in program termination via @ref gpcc::osal::Panic().
  *
- * __Thread cancellation safety:__\n
- * This is invoked with deferred cancellation enabled.\n
- * The subclass must be aware of deferred cancellation if @ref StopThread() is invoked.
+ * __Thread cancellation safety requirements/hints:__\n
+ * This method shall provide at least the strong guarantee.\n
+ * The implementation must be aware of deferred cancellation if @ref StopThread() is invoked.
  */
 
 /**
@@ -347,49 +352,54 @@ class TriggeredThreadedCyclicExec
  * 2. @ref OnStop()
  * 3. @ref OnStateChange()
  *
- * ---
+ * - - -
  *
- * __Thread safety:__\n
+ * __Thread safety requirements/hints:__\n
  * This is executed in the context of the @ref TriggeredThreadedCyclicExec's thread.
  *
- * __Exception safety:__\n
+ * __Exception safety requirements/hints:__\n
+ * This method shall provide the no-throw guarantee.\n
  * Any thrown exception will result in program termination via @ref gpcc::osal::Panic().
  *
- * __Thread cancellation safety:__\n
- * This is invoked with deferred cancellation enabled.\n
- * The subclass must be aware of deferred cancellation if @ref StopThread() is invoked.
+ * __Thread cancellation safety requirements/hints:__\n
+ * This method shall provide at least the strong guarantee.\n
+ * The implementation must be aware of deferred cancellation if @ref StopThread() is invoked.
  */
 
 /**
  * \fn bool TriggeredThreadedCyclicExec::Sample(bool const overrun)
  * \brief In state @ref States::running, this is called cyclically each time the trigger is received.
  *
- * __Thread safety:__\n
+ * - - -
+ *
+ * __Thread safety requirements/hints:__\n
  * This is executed in the context of the @ref TriggeredThreadedCyclicExec's thread.
  *
- * __Exception safety:__\n
+ * __Exception safety requirements/hints:__\n
+ * This method shall provide the no-throw guarantee.\n
  * Any thrown exception will result in program termination via @ref gpcc::osal::Panic().
  *
- * __Thread cancellation safety:__\n
- * This is invoked with deferred cancellation enabled.\n
- * The subclass must be aware of deferred cancellation if @ref StopThread() is invoked.
+ * __Thread cancellation safety requirements/hints:__\n
+ * This method shall provide at least the strong guarantee.\n
+ * The implementation must be aware of deferred cancellation if @ref StopThread() is invoked.
  *
- * ---
+ * - - -
  *
  * \param overrun
  * true  = at least the last trigger event was missed\n
  * false = previous trigger event was normally received
- * \return
- * true  = OK\n
- * false = Cyclic execution of @ref Sample() shall be stopped.\n
- * The @ref TriggeredThreadedCyclicExec's state will be changed to @ref States::stopped. The reason for stopping
- * reported via @ref OnStateChange() will be @ref StopReasons::sampleRetFalse. @ref OnStop() will be called.
+ *
+ * \retval true   OK
+ * \retval false  Cyclic execution of @ref Sample() shall be stopped.\n
+ *                The @ref TriggeredThreadedCyclicExec's state will be switched to @ref States::stopped. The reason for
+ *                stopping reported via @ref OnStateChange() will be @ref StopReasons::sampleRetFalse. @ref OnStop()
+ *                will be called.
  */
 
 /**
  * \fn void TriggeredThreadedCyclicExec::OnStateChange(State const newState, StopReasons const stopReason)
- * \brief This is called after the state of @ref TriggeredThreadedCyclicExec has changed or after a stop request is
- * received when the state is already @ref States::stopped.
+ * \brief This is called after the state of @ref TriggeredThreadedCyclicExec has changed or after a stop request has
+ *        been received while the state was already @ref States::stopped.
  *
  * Usually a subclass implements this method to inform an [TTCEStartStopCtrl](@ref gpcc::execution::cyclic::TTCEStartStopCtrl)
  * instance via [TTCEStartStopCtrl::OnTTCEStateChange()](@ref gpcc::execution::cyclic::TTCEStartStopCtrl::OnTTCEStateChange)
@@ -409,23 +419,25 @@ class TriggeredThreadedCyclicExec
  * 1. State is set to the new state
  * 2. @ref OnStateChange()
  *
- * ---
+ * - - -
  *
- * __Thread safety:__\n
+ * __Thread safety requirements/hints:__\n
  * This is executed in the context of the @ref TriggeredThreadedCyclicExec's thread.\n
  * All public methods of the @ref TriggeredThreadedCyclicExec instance are allowed to be called from this method.
  *
- * __Exception safety:__\n
+ * __Exception safety requirements/hints:__\n
+ * This method shall provide the no-throw guarantee.\n
  * Any thrown exception will result in program termination via @ref gpcc::osal::Panic().
  *
- * __Thread cancellation safety:__\n
- * This is invoked with deferred cancellation enabled.\n
- * The subclass must be aware of deferred cancellation if @ref StopThread() is invoked.
+ * __Thread cancellation safety requirements/hints:__\n
+ * This method shall provide at least the strong guarantee.\n
+ * The implementation must be aware of deferred cancellation if @ref StopThread() is invoked.
  *
- * ---
+ * - - -
  *
  * \param newState
- * New state of the @ref TriggeredThreadedCyclicExec.
+ * New state of the @ref TriggeredThreadedCyclicExec instance.
+ *
  * \param stopReason
  * If the new state is @ref States::stopped, then this provides the reason for the transition to @ref States::stopped. \n
  * If the new state is not @ref States::stopped, then this is always @ref StopReasons::none.

--- a/include/gpcc/execution/cyclic/TriggeredThreadedCyclicExec.hpp
+++ b/include/gpcc/execution/cyclic/TriggeredThreadedCyclicExec.hpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011 Daniel Jerolm
+    Copyright (C) 2011, 2025 Daniel Jerolm
 */
 
 #ifndef TRIGGEREDTHREADEDCYCLICEXEC_HPP_201612301706
@@ -214,9 +214,9 @@ class TriggeredThreadedCyclicExec
 
 
     TriggeredThreadedCyclicExec(char const * const pThreadName,
-                                stdif::IIRQ2ThreadWakeup & _trigger,
-                                time::TimeSpan const & _timeout,
-                                tIsPllLocked const & _isPllLockedFunc);
+                                stdif::IIRQ2ThreadWakeup & trigger,
+                                time::TimeSpan const & timeout,
+                                tIsPllLocked const & isPllLockedFunc);
     TriggeredThreadedCyclicExec(TriggeredThreadedCyclicExec const &) = delete;
     TriggeredThreadedCyclicExec(TriggeredThreadedCyclicExec &&) = delete;
     virtual ~TriggeredThreadedCyclicExec(void);
@@ -250,8 +250,8 @@ class TriggeredThreadedCyclicExec
   private:
     /// Enumeration with flags for asynchronous requests issued to the class' state machine.
     /** Note:\n
-        The enum values are stored in @ref asyncReqFlags (uint8_t) later. Multiple enum values may be
-        or-combined in @ref asyncReqFlags to allow multiple flags being set simultaneously.\n
+        The enum values are stored in @ref asyncReqFlags_ (uint8_t) later. Multiple enum values may be
+        or-combined in @ref asyncReqFlags_ to allow multiple flags being set simultaneously.\n
         _Therefore enum values must be a power of 2 (0,1,2,4,8,...)._ */
     enum class AsyncReqFlags
     {
@@ -263,32 +263,32 @@ class TriggeredThreadedCyclicExec
 
     /// Reference to a [IIRQ2ThreadWakeup](@ref gpcc::stdif::IIRQ2ThreadWakeup) subclass instance providing the cyclic
     /// trigger.
-    stdif::IIRQ2ThreadWakeup & trigger;
+    stdif::IIRQ2ThreadWakeup & trigger_;
 
     /// Timeout for the cyclic trigger.
-    time::TimeSpan const timeout;
+    time::TimeSpan const timeout_;
 
     /// Functor to a method for retrieving the PLL lock state.
     /** If no function/method is referenced, then the PLL lock state is not checked. */
-    tIsPllLocked const isPllLockedFunc;
+    tIsPllLocked const isPllLockedFunc_;
 
     /// Thread used for cyclic execution of the subclasses' code.
-    osal::Thread thread;
+    osal::Thread thread_;
 
     /// Mutex used to make things thread-safe.
-    mutable osal::Mutex mutex;
+    mutable osal::Mutex mutex_;
 
     /// Flags for signaling asynchronous requests to the @ref TriggeredThreadedCyclicExec's state machine.
-    /** @ref mutex is required. */
-    uint8_t asyncReqFlags;
+    /** @ref mutex_ is required. */
+    uint8_t asyncReqFlags_;
 
     /// Current state of the @ref TriggeredThreadedCyclicExec's state machine.
-    /** @ref mutex is required. */
-    States state;
+    /** @ref mutex_ is required. */
+    States state_;
 
     /// Counter used to implement the start delay.
-    /** @ref mutex is required. */
-    uint8_t startDelayCnt;
+    /** @ref mutex_ is required. */
+    uint8_t startDelayCnt_;
 
 
     void* InternalThreadEntry(void);

--- a/src/cli/CLI.cpp
+++ b/src/cli/CLI.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011, 2024 Daniel Jerolm
+    Copyright (C) 2011, 2024, 2025 Daniel Jerolm
 */
 
 #include <gpcc/cli/CLI.hpp>
@@ -2303,9 +2303,9 @@ void CLI::PrintException(std::exception const & e, size_t const level)
   {
     std::rethrow_if_nested(e);
   }
-  catch (std::exception const & e)
+  catch (std::exception const & e_nested)
   {
-    PrintException(e, level + 1U);
+    PrintException(e_nested, level + 1U);
   }
   catch (...)
   {

--- a/src/cood/ObjectARRAY.cpp
+++ b/src/cood/ObjectARRAY.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2018 Daniel Jerolm
+    Copyright (C) 2018, 2025 Daniel Jerolm
 */
 
 #include <gpcc/cood/ObjectARRAY.hpp>
@@ -36,125 +36,125 @@ namespace cood {
  *
  * - - -
  *
- * \param _name
+ * \param name
  * Name for the object.
  *
- * \param _attributesSI0
+ * \param attributesSI0
  * Attributes for subindex 0.\n
  * There must be at least one read-permission set.
  *
- * \param _SI0
+ * \param SI0
  * Initial value for SI0.\n
  * SI0 indicates the number of subindices representing array elements and therefore the number of array elements.\n
  * The allowed range is 0-255.\n
- * This must also be within the range given by `_min_SI0` and `_max_SI0`.
+ * This must also be within the range given by `min_SI0` and `max_SI0`.
  *
- * \param _min_SI0
+ * \param min_SI0
  * Minimum value for SI0. Allowed range: 0-255.\n
- * This must be equal to or less than `_max_SI0`.
+ * This must be equal to or less than `max_SI0`.
  *
- * \param _max_SI0
+ * \param max_SI0
  * Maximum value for SI0. Allowed range: 0-255.\n
- * This must be equal to or larger than `_min_SI0`.
+ * This must be equal to or larger than `min_SI0`.
  *
- * \param _type
+ * \param type
  * CANopen data type of the array elements represented by the object. Since the constructed object is an ARRAY
  * object, the object itself will have the same data type as the data represented by it.\n
  * \n
- * The type of the native data referenced by `_pData` must match the CANopen data type. The documentation of the
+ * The type of the native data referenced by `pData` must match the CANopen data type. The documentation of the
  * @ref DataType enumeration contains a list of native types associated with each CANopen data type.\n
  * \n
- * Note that if '_type' is any of the types bit1..bit8 or boolean_native_bit1, then the native data must be an array of
+ * Note that if 'type' is any of the types bit1..bit8 or boolean_native_bit1, then the native data must be an array of
  * data type uint8_t and the bits will be stuffed together inside the native array.\n
  * Example:\n
  * An array of 18 elements of type `bit2` would be comprised of 36 bits. The native array would occupy 5 native
  * elements of type uint8_t and the upper four bits of the last element would be unused.
  *
- * \param _attributes
+ * \param attributes
  * Attributes for the subindices representing array elements.\n
  * The attributes are applied to all subindices except for SI0.\n
  * At least one read- or write-permission must be set.
  *
- * \param _pData
+ * \param pData
  * Pointer to the memory location containing the data represented by the ARRAY object.\n
  * The memory is provided and owned by the owner of the ARRAY object.\n
  * The memory location must be valid during the life-time of the ARRAY object or until a different
  * memory location is configured via @ref SetData(). \n
- * The memory must contain `_max_SI0` elements of data type `_type`.\n
- * See parameter `_type` for details.
+ * The memory must contain `max_SI0` elements of data type `type`.\n
+ * See parameter `type` for details.
  *
- * \param _pMutex
- * Pointer to a mutex protecting access to SI0 and to the native data referenced by `_pData`.\n
+ * \param pMutex
+ * Pointer to a mutex protecting access to SI0 and to the native data referenced by `pData`.\n
  * The mutex is optional. If the whole object is read-only __and__ if the application does not modify the
- * value of SI0 and if the application does not modify the data referenced by `_pData`, then a mutex is not required
+ * value of SI0 and if the application does not modify the data referenced by `pData`, then a mutex is not required
  * and this parameter may be `nullptr`.\n
  * __BUT__ if SI0 or the array data represented by the object is writeable, or if the application may modify SI0, or
- * if the application may modify the native data referenced by `_pData`, then a mutex must be specified.\n
+ * if the application may modify the native data referenced by `pData`, then a mutex must be specified.\n
  * \n
- * The application must obey the following rules when accessing the native data referenced by `_pData`:
+ * The application must obey the following rules when accessing the native data referenced by `pData`:
  * - If the array data is READ-ONLY, then the application must lock the mutex only if it wants to modify the data
- *   referenced by `_pData`. The application does not need to lock the mutex for reading the data referenced by
- *   `_pData` in this case.
+ *   referenced by `pData`. The application does not need to lock the mutex for reading the data referenced by
+ *   `pData` in this case.
  * - If the array data is READ-WRITE, then the application must lock the mutex ALWAYS when it wants to read or write
- *   the data referenced by `_pData`.
+ *   the data referenced by `pData`.
  *
- * \param _pNotifiable
+ * \param pNotifiable
  * Pointer to a @ref IObjectNotifiable interface that shall be used to deliver callbacks to the owner of the object.\n
  * nullptr is allowed.
  */
-ObjectARRAY::ObjectARRAY(std::string            const & _name,
-                         attr_t                 const   _attributesSI0,
-                         uint8_t                const   _SI0,
-                         uint8_t                const   _min_SI0,
-                         uint8_t                const   _max_SI0,
-                         DataType               const   _type,
-                         attr_t                 const   _attributes,
-                         void*                  const   _pData,
-                         gpcc::osal::Mutex *    const   _pMutex,
-                         IObjectNotifiable *    const   _pNotifiable)
+ObjectARRAY::ObjectARRAY(std::string            const & name,
+                         attr_t                 const   attributesSI0,
+                         uint8_t                const   SI0,
+                         uint8_t                const   min_SI0,
+                         uint8_t                const   max_SI0,
+                         DataType               const   type,
+                         attr_t                 const   attributes,
+                         void*                  const   pData,
+                         gpcc::osal::Mutex *    const   pMutex,
+                         IObjectNotifiable *    const   pNotifiable)
 : Object()
-, name(_name)
-, attributesSI0(_attributesSI0)
-, SI0(_SI0)
-, min_SI0(_min_SI0)
-, max_SI0(_max_SI0)
-, type(_type)
-, attributes(_attributes)
-, pData(_pData)
-, pMutex(_pMutex)
-, pNotifiable(_pNotifiable)
+, name_(name)
+, attributesSI0_(attributesSI0)
+, SI0_(SI0)
+, min_SI0_(min_SI0)
+, max_SI0_(max_SI0)
+, type_(type)
+, attributes_(attributes)
+, pData_(pData)
+, pMutex_(pMutex)
+, pNotifiable_(pNotifiable)
 {
   // SI0 must have at least read permission set
-  if ((attributesSI0 & attr_ACCESS_RD) == 0U)
-    throw std::invalid_argument("ObjectARRAY::ObjectARRAY: '_attributesSI0' must have at least one read-permission set");
+  if ((attributesSI0_ & attr_ACCESS_RD) == 0U)
+    throw std::invalid_argument("ObjectARRAY::ObjectARRAY: 'attributesSI0' must have at least one read-permission set");
 
   // check number of SIs
-  if (   (min_SI0 > max_SI0)
-      || (SI0 < min_SI0)
-      || (SI0 > max_SI0))
+  if (   (min_SI0_ > max_SI0_)
+      || (SI0_ < min_SI0_)
+      || (SI0_ > max_SI0_))
   {
-    throw std::invalid_argument("ObjectARRAY::ObjectARRAY: \"_SI0 <= _min_SI0 <= _max_SI0\" violated");
+    throw std::invalid_argument("ObjectARRAY::ObjectARRAY: \"SI0 <= min_SI0 <= max_SI0\" violated");
   }
 
   // data type supported?
-  if (   (type == DataType::visible_string)
-      || (type == DataType::octet_string)
-      || (type == DataType::unicode_string)
-      || (DataTypeBitLengthTable[static_cast<int>(type)] == 0U)
-      || (NativeDataTypeBitLengthTable[static_cast<int>(type)] == 0U))
+  if (   (type_ == DataType::visible_string)
+      || (type_ == DataType::octet_string)
+      || (type_ == DataType::unicode_string)
+      || (DataTypeBitLengthTable[static_cast<int>(type_)] == 0U)
+      || (NativeDataTypeBitLengthTable[static_cast<int>(type_)] == 0U))
   {
-    throw DataTypeNotSupportedError(type);
+    throw DataTypeNotSupportedError(type_);
   }
 
   // at least one read or write permission specified for array's data?
-  if ((attributes & attr_ACCESS_RW) == 0U)
-    throw std::invalid_argument("ObjectARRAY::ObjectARRAY: No read- or write-permissions set in '_attributes'");
+  if ((attributes_ & attr_ACCESS_RW) == 0U)
+    throw std::invalid_argument("ObjectARRAY::ObjectARRAY: No read- or write-permissions set in 'attributes'");
 
-  if (pData == nullptr)
-    throw std::invalid_argument("ObjectARRAY::ObjectARRAY: '_pData' is nullptr");
+  if (pData_ == nullptr)
+    throw std::invalid_argument("ObjectARRAY::ObjectARRAY: 'pData' is nullptr");
 
   // check: a mutex must be specified if write access is possible
-  if ((((attributesSI0 & attr_ACCESS_WR) != 0U) || ((attributes & attr_ACCESS_WR) != 0U)) && (pMutex == nullptr))
+  if ((((attributesSI0_ & attr_ACCESS_WR) != 0U) || ((attributes_ & attr_ACCESS_WR) != 0U)) && (pMutex_ == nullptr))
     throw std::logic_error("ObjectARRAY::ObjectARRAY: Object with write-permission requires a mutex");
 }
 
@@ -179,7 +179,7 @@ ObjectARRAY::ObjectARRAY(std::string            const & _name,
  *
  * \param newSI0
  * New value for subindex 0.\n
- * This must match the bounds for SI0 that have been passed to the constructor (`_min_SI0` and `_max_SI0`).
+ * This must match the bounds for SI0 that have been passed to the constructor (`min_SI0` and `max_SI0`).
  *
  * \param pNewData
  * Pointer to the (new) memory location containing the data that shall be represented by the ARRAY object.\n
@@ -190,22 +190,22 @@ ObjectARRAY::ObjectARRAY(std::string            const & _name,
  * The memory location must be valid during the life-time of the ARRAY object or until a different
  * memory location is configured via @ref SetData(). \n
  * The number of data elements in the referenced memory and their type must meet the parameters
- * `_max_SI0` and `_type` that have been passed to the constructor.
+ * `max_SI0` and `type` that have been passed to the constructor.
  */
 void ObjectARRAY::SetData(uint8_t const newSI0, void* const pNewData)
 {
-  if (pMutex == nullptr)
+  if (pMutex_ == nullptr)
     throw std::logic_error("ObjectARRAY::SetData: Operation requires that a mutex has been passed to the constructor");
 
-  if ((newSI0 < min_SI0) || (newSI0 > max_SI0))
+  if ((newSI0 < min_SI0_) || (newSI0 > max_SI0_))
     throw std::invalid_argument("ObjectARRAY::SetData: 'newSI0' is out of min/max for SI0");
 
   if (pNewData == nullptr)
     throw std::invalid_argument("ObjectARRAY::SetData: 'pNewData' is nullptr");
 
-  gpcc::osal::MutexLocker mutexLocker(*pMutex);
-  SI0   = newSI0;
-  pData = pNewData;
+  gpcc::osal::MutexLocker mutexLocker(*pMutex_);
+  SI0_   = newSI0;
+  pData_ = pNewData;
 }
 
 // <-- base class Object
@@ -219,25 +219,25 @@ Object::ObjectCode ObjectARRAY::GetObjectCode(void) const noexcept
 /// \copydoc Object::GetObjectDataType
 DataType ObjectARRAY::GetObjectDataType(void) const noexcept
 {
-  return MapAlternativeDataTypesToOriginalTypes(type);
+  return MapAlternativeDataTypesToOriginalTypes(type_);
 }
 
 /// \copydoc Object::GetObjectName
 std::string ObjectARRAY::GetObjectName(void) const
 {
-  return name;
+  return name_;
 }
 
 /// \copydoc Object::GetMaxNbOfSubindices
 uint16_t ObjectARRAY::GetMaxNbOfSubindices(void) const noexcept
 {
-  return static_cast<uint_fast16_t>(max_SI0) + 1U; // +1 for SI0
+  return static_cast<uint_fast16_t>(max_SI0_) + 1U; // +1 for SI0
 }
 
 /// \copydoc Object::IsSubIndexEmpty
 bool ObjectARRAY::IsSubIndexEmpty(uint8_t const subIdx) const
 {
-  if (subIdx > max_SI0)
+  if (subIdx > max_SI0_)
     throw SubindexNotExistingError();
 
   return false;
@@ -246,25 +246,25 @@ bool ObjectARRAY::IsSubIndexEmpty(uint8_t const subIdx) const
 /// \copydoc Object::GetSubIdxDataType
 DataType ObjectARRAY::GetSubIdxDataType(uint8_t const subIdx) const
 {
-  if (subIdx > max_SI0)
+  if (subIdx > max_SI0_)
     throw SubindexNotExistingError();
 
   if (subIdx == 0U)
     return DataType::unsigned8;
   else
-    return MapAlternativeDataTypesToOriginalTypes(type);
+    return MapAlternativeDataTypesToOriginalTypes(type_);
 }
 
 /// \copydoc Object::GetSubIdxAttributes
 Object::attr_t ObjectARRAY::GetSubIdxAttributes(uint8_t const subIdx) const
 {
-  if (subIdx > max_SI0)
+  if (subIdx > max_SI0_)
     throw SubindexNotExistingError();
 
   if (subIdx == 0U)
-    return attributesSI0;
+    return attributesSI0_;
   else
-    return attributes;
+    return attributes_;
 }
 
 /// \copydoc Object::GetSubIdxMaxSize
@@ -276,17 +276,17 @@ size_t ObjectARRAY::GetSubIdxMaxSize(uint8_t const subIdx) const
   }
   else
   {
-    if (subIdx > max_SI0)
+    if (subIdx > max_SI0_)
       throw SubindexNotExistingError();
 
-    return DataTypeBitLengthTable[static_cast<int>(type)];
+    return DataTypeBitLengthTable[static_cast<int>(type_)];
   }
 }
 
 /// \copydoc Object::GetSubIdxName
 std::string ObjectARRAY::GetSubIdxName(uint8_t const subIdx) const
 {
-  if (subIdx > max_SI0)
+  if (subIdx > max_SI0_)
     throw SubindexNotExistingError();
 
   if (subIdx == 0U)
@@ -304,13 +304,13 @@ std::string ObjectARRAY::GetSubIdxName(uint8_t const subIdx) const
 /// \copydoc Object::LockData
 gpcc::osal::MutexLocker ObjectARRAY::LockData(void) const
 {
-  return gpcc::osal::MutexLocker(pMutex);
+  return gpcc::osal::MutexLocker(pMutex_);
 }
 
 /// \copydoc Object::GetObjectStreamSize
 size_t ObjectARRAY::GetObjectStreamSize(bool const SI016Bits) const noexcept
 {
-  uint_fast16_t sizeInBit = static_cast<uint_fast16_t>(DataTypeBitLengthTable[static_cast<int>(type)]) * SI0;
+  uint_fast16_t sizeInBit = static_cast<uint_fast16_t>(DataTypeBitLengthTable[static_cast<int>(type_)]) * SI0_;
   if (SI016Bits)
     sizeInBit += 16U;
   else
@@ -321,7 +321,7 @@ size_t ObjectARRAY::GetObjectStreamSize(bool const SI016Bits) const noexcept
 /// \copydoc Object::GetNbOfSubIndices
 uint16_t ObjectARRAY::GetNbOfSubIndices(void) const noexcept
 {
-  return static_cast<uint_fast16_t>(SI0) + 1U; // +1 for SI0
+  return static_cast<uint_fast16_t>(SI0_) + 1U; // +1 for SI0
 }
 
 /// \copydoc Object::GetSubIdxActualSize
@@ -333,10 +333,10 @@ size_t ObjectARRAY::GetSubIdxActualSize(uint8_t const subIdx) const
   }
   else
   {
-    if (subIdx > SI0)
+    if (subIdx > SI0_)
       throw SubindexNotExistingError();
 
-    return DataTypeBitLengthTable[static_cast<int>(type)];
+    return DataTypeBitLengthTable[static_cast<int>(type_)];
   }
 }
 
@@ -345,7 +345,7 @@ SDOAbortCode ObjectARRAY::Read(uint8_t const subIdx,
                                attr_t const permissions,
                                gpcc::stream::IStreamWriter & isw) const
 {
-  if (subIdx > SI0)
+  if (subIdx > SI0_)
     return SDOAbortCode::SubindexDoesNotExist;
 
   if (subIdx == 0U)
@@ -353,50 +353,50 @@ SDOAbortCode ObjectARRAY::Read(uint8_t const subIdx,
     // (subindex 0 shall be read)
 
     // check permissions
-    if ((permissions & attr_ACCESS_RD & attributesSI0) == 0U)
+    if ((permissions & attr_ACCESS_RD & attributesSI0_) == 0U)
       return SDOAbortCode::AttemptToReadWrOnlyObject;
 
     // invoke before-read-callback
-    if (pNotifiable != nullptr)
+    if (pNotifiable_ != nullptr)
     {
-      auto const result = pNotifiable->OnBeforeRead(this, 0, false, false);
+      auto const result = pNotifiable_->OnBeforeRead(this, 0, false, false);
       if (result != SDOAbortCode::OK)
         return result;
     }
 
     // read SI0
-    isw.Write_uint8(SI0);
+    isw.Write_uint8(SI0_);
   }
   else
   {
     // (subindex 0 shall not be read)
 
     // check permissions
-    if ((permissions & attr_ACCESS_RD & attributes) == 0U)
+    if ((permissions & attr_ACCESS_RD & attributes_) == 0U)
       return SDOAbortCode::AttemptToReadWrOnlyObject;
 
     // invoke before-read-callback
-    if (pNotifiable != nullptr)
+    if (pNotifiable_ != nullptr)
     {
-      auto const result = pNotifiable->OnBeforeRead(this, subIdx, false, false);
+      auto const result = pNotifiable_->OnBeforeRead(this, subIdx, false, false);
       if (result != SDOAbortCode::OK)
         return result;
     }
 
-    if (IsNativeDataStuffed(type))
+    if (IsNativeDataStuffed(type_))
     {
       // (data type is bit-based and native data is stuffed)
 
       uint8_t const bits = ReadBitsFromMem(subIdx);
-      NativeDataToCANopenEncodedData(&bits, type, 1U, false, isw);
+      NativeDataToCANopenEncodedData(&bits, type_, 1U, false, isw);
     }
     else
     {
       // (data type may be bit-based, but native data is NOT stuffed)
 
-      uint_fast16_t const nativeSizeInByte = NativeDataTypeBitLengthTable[static_cast<int>(type)] / 8U;
-      uint8_t const * const ptr = static_cast<uint8_t const *>(pData) + ((subIdx - 1U) * nativeSizeInByte);
-      NativeDataToCANopenEncodedData(ptr, type, 1U, false, isw);
+      uint_fast16_t const nativeSizeInByte = NativeDataTypeBitLengthTable[static_cast<int>(type_)] / 8U;
+      uint8_t const * const ptr = static_cast<uint8_t const *>(pData_) + ((subIdx - 1U) * nativeSizeInByte);
+      NativeDataToCANopenEncodedData(ptr, type_, 1U, false, isw);
     }
   }
 
@@ -408,7 +408,7 @@ SDOAbortCode ObjectARRAY::Write(uint8_t const subIdx,
                                 attr_t const permissions,
                                 gpcc::stream::IStreamReader & isr)
 {
-  if (subIdx > SI0)
+  if (subIdx > SI0_)
     return SDOAbortCode::SubindexDoesNotExist;
 
   if (subIdx == 0)
@@ -416,7 +416,7 @@ SDOAbortCode ObjectARRAY::Write(uint8_t const subIdx,
     // (subindex 0 shall be written)
 
     // check permissions
-    if ((permissions & attr_ACCESS_WR & attributesSI0) == 0U)
+    if ((permissions & attr_ACCESS_WR & attributesSI0_) == 0U)
       return SDOAbortCode::AttemptToWriteRdOnlyObject;
 
     // read the data that shall be written to SI0 into a temporary variable
@@ -436,33 +436,33 @@ SDOAbortCode ObjectARRAY::Write(uint8_t const subIdx,
     }
 
     // check range
-    if (data < min_SI0)
+    if (data < min_SI0_)
       return SDOAbortCode::ValueTooLow;
-    if (data > max_SI0)
+    if (data > max_SI0_)
       return SDOAbortCode::ValueTooHigh;
 
     // invoke before-write-callback
-    if (pNotifiable != nullptr)
+    if (pNotifiable_ != nullptr)
     {
-      auto const result = pNotifiable->OnBeforeWrite(this, 0, false, 0, &data);
+      auto const result = pNotifiable_->OnBeforeWrite(this, 0, false, 0, &data);
       if (result != SDOAbortCode::OK)
         return result;
     }
 
     // finally write to SI0
-    SI0 = data;
+    SI0_ = data;
   }
   else
   {
     // (subindex 0 shall not be written)
 
     // check permissions
-    if ((permissions & attr_ACCESS_WR & attributes) == 0U)
+    if ((permissions & attr_ACCESS_WR & attributes_) == 0U)
       return SDOAbortCode::AttemptToWriteRdOnlyObject;
 
     // determine number of bytes required to store the data that shall be written in native format
     // (cannot be zero, ensured by constructor)
-    uint_fast16_t const nativeSizeInByte = NativeDataTypeBitLengthTable[static_cast<int>(type)] / 8U;
+    uint_fast16_t const nativeSizeInByte = NativeDataTypeBitLengthTable[static_cast<int>(type_)] / 8U;
 
     // allocate some temporary storage (pTempMem) either on the stack or on the heap
     uint64_t localMem;
@@ -481,7 +481,7 @@ SDOAbortCode ObjectARRAY::Write(uint8_t const subIdx,
     // read the data that shall be written to the subindex into pTempMem
     try
     {
-      CANopenEncodedDataToNativeData(isr, type, 1U, false, pTempMem);
+      CANopenEncodedDataToNativeData(isr, type_, 1U, false, pTempMem);
       isr.EnsureAllDataConsumed(gpcc::stream::IStreamReader::RemainingNbOfBits::sevenOrLess);
     }
     catch (gpcc::stream::EmptyError const &)
@@ -494,15 +494,15 @@ SDOAbortCode ObjectARRAY::Write(uint8_t const subIdx,
     }
 
     // invoke before-write-callback
-    if (pNotifiable != nullptr)
+    if (pNotifiable_ != nullptr)
     {
-      auto const result = pNotifiable->OnBeforeWrite(this, subIdx, false, 0, pTempMem);
+      auto const result = pNotifiable_->OnBeforeWrite(this, subIdx, false, 0, pTempMem);
       if (result != SDOAbortCode::OK)
         return result;
     }
 
     // finally write the data to the subindex
-    if (IsNativeDataStuffed(type))
+    if (IsNativeDataStuffed(type_))
     {
       // (data type is bit-based and native data is stuffed)
 
@@ -512,7 +512,7 @@ SDOAbortCode ObjectARRAY::Write(uint8_t const subIdx,
     {
       // (data type may be bit-based, but native data is NOT stuffed)
 
-      uint8_t* const ptr = static_cast<uint8_t*>(pData) + ((subIdx - 1U) * nativeSizeInByte);
+      uint8_t* const ptr = static_cast<uint8_t*>(pData_) + ((subIdx - 1U) * nativeSizeInByte);
       memcpy(ptr, pTempMem, nativeSizeInByte);
     }
   }
@@ -520,8 +520,8 @@ SDOAbortCode ObjectARRAY::Write(uint8_t const subIdx,
   // invoke after-write-callback
   try
   {
-    if (pNotifiable != nullptr)
-      pNotifiable->OnAfterWrite(this, subIdx, false);
+    if (pNotifiable_ != nullptr)
+      pNotifiable_->OnAfterWrite(this, subIdx, false);
   }
   catch (std::exception const & e)
   {
@@ -543,26 +543,26 @@ SDOAbortCode ObjectARRAY::CompleteRead(bool const inclSI0,
 {
   // If subindex 0 is included, then check the access permission for subindex 0.
   // Note: Subindex 0 is never pure write-only (ensured by constructor).
-  if ((inclSI0) && ((attributesSI0 & attr_ACCESS_RD & permissions) == 0U))
+  if ((inclSI0) && ((attributesSI0_ & attr_ACCESS_RD & permissions) == 0U))
     return SDOAbortCode::AttemptToReadWrOnlyObject;
 
   // special case: SI0 is not included and SI0 is zero
-  if ((!inclSI0) && (SI0 == 0U))
+  if ((!inclSI0) && (SI0_ == 0U))
     return SDOAbortCode::OK;
 
   // determine if the other subindices are pure write-only
-  bool const dataPureWriteOnly = ((attributes & attr_ACCESS_RD) == 0U);
+  bool const dataPureWriteOnly = ((attributes_ & attr_ACCESS_RD) == 0U);
 
   // If there are other subindices, then check the access permissions for the other subindices.
-  if ((SI0 != 0U) &&
+  if ((SI0_ != 0U) &&
       (!dataPureWriteOnly) &&
-      ((attributes & attr_ACCESS_RD & permissions) == 0U))
+      ((attributes_ & attr_ACCESS_RD & permissions) == 0U))
     return SDOAbortCode::AttemptToReadWrOnlyObject;
 
   // call the before-read-callback
-  if (pNotifiable != nullptr)
+  if (pNotifiable_ != nullptr)
   {
-    auto const result = pNotifiable->OnBeforeRead(this, inclSI0 ? 0U : 1U, true, false);
+    auto const result = pNotifiable_->OnBeforeRead(this, inclSI0 ? 0U : 1U, true, false);
     if (result != SDOAbortCode::OK)
       return result;
   }
@@ -571,13 +571,13 @@ SDOAbortCode ObjectARRAY::CompleteRead(bool const inclSI0,
   if (inclSI0)
   {
     if (SI016Bits)
-      isw.Write_uint16(SI0);
+      isw.Write_uint16(SI0_);
     else
-      isw.Write_uint8(SI0);
+      isw.Write_uint8(SI0_);
   }
 
   // special case: no data that could be read
-  if (SI0 == 0U)
+  if (SI0_ == 0U)
     return SDOAbortCode::OK;
 
   // is the data pure write-only?
@@ -586,9 +586,9 @@ SDOAbortCode ObjectARRAY::CompleteRead(bool const inclSI0,
     // (data is pure write-only; pure write-only subindices read as zero)
 
     // calculate number of bits
-    uint_fast16_t const nBits = static_cast<uint_fast16_t>(DataTypeBitLengthTable[static_cast<int>(type)]) * SI0;
+    uint_fast16_t const nBits = static_cast<uint_fast16_t>(DataTypeBitLengthTable[static_cast<int>(type_)]) * SI0_;
 
-    if (IsDataTypeBitBased(type))
+    if (IsDataTypeBitBased(type_))
     {
       isw.FillBits(nBits, false);
     }
@@ -602,7 +602,7 @@ SDOAbortCode ObjectARRAY::CompleteRead(bool const inclSI0,
   {
     // (data is not pure write-only)
 
-    NativeDataToCANopenEncodedData(pData, type, SI0, true, isw);
+    NativeDataToCANopenEncodedData(pData_, type_, SI0_, true, isw);
   }
 
   return SDOAbortCode::OK;
@@ -616,22 +616,22 @@ SDOAbortCode ObjectARRAY::CompleteWrite(bool const inclSI0,
                                         gpcc::stream::IStreamReader::RemainingNbOfBits const ernob)
 {
   // determine if SI0 is pure read-only
-  bool const SI0pureReadOnly = ((attributesSI0 & attr_ACCESS_WR) == 0U);
+  bool const SI0pureReadOnly = ((attributesSI0_ & attr_ACCESS_WR) == 0U);
 
   // If subindex 0 is included, then check the access permission for subindex 0.
   if ((inclSI0) &&
       (!SI0pureReadOnly) &&
-      ((attributesSI0 & attr_ACCESS_WR & permissions) == 0U))
+      ((attributesSI0_ & attr_ACCESS_WR & permissions) == 0U))
     return SDOAbortCode::AttemptToWriteRdOnlyObject;
 
   // determine if data is pure read-only
-  bool const dataPureReadOnly = ((attributes & attr_ACCESS_WR) == 0U);
+  bool const dataPureReadOnly = ((attributes_ & attr_ACCESS_WR) == 0U);
 
   // Prepare a pointer to temporary storage for preview data. The storage will be allocated later.
   uint8_t* pTempMem = nullptr;
   ON_SCOPE_EXIT(releaseTempMem) { delete [] pTempMem; };
 
-  uint16_t newSI0 = SI0;
+  uint16_t newSI0 = SI0_;
 
   try
   {
@@ -650,15 +650,15 @@ SDOAbortCode ObjectARRAY::CompleteWrite(bool const inclSI0,
       {
         // the new value for SI0 MUST MATCH the current value of SI0.
 
-        if (newSI0 != SI0)
+        if (newSI0 != SI0_)
           return SDOAbortCode::UnsupportedAccessToObject;
       }
       else
       {
         // the new value for SI0 must match bounds for SI0
-        if (newSI0 < min_SI0)
+        if (newSI0 < min_SI0_)
           return SDOAbortCode::ValueTooLow;
-        else if (newSI0 > max_SI0)
+        else if (newSI0 > max_SI0_)
           return SDOAbortCode::ValueTooHigh;
       }
     }
@@ -666,15 +666,15 @@ SDOAbortCode ObjectARRAY::CompleteWrite(bool const inclSI0,
     // if any subindex will be written, then check the permissions for accessing the subindices
     if ((newSI0 != 0U) &&
         (!dataPureReadOnly) &&
-        ((attributes & attr_ACCESS_WR & permissions) == 0U))
+        ((attributes_ & attr_ACCESS_WR & permissions) == 0U))
       return SDOAbortCode::AttemptToWriteRdOnlyObject;
 
     // determine number of bytes required to store the data that shall be written in native format (excl. SI0)
     uint_fast16_t nBytesNative;
-    if (IsNativeDataStuffed(type))
-      nBytesNative = ((static_cast<uint_fast16_t>(DataTypeBitLengthTable[static_cast<int>(type)]) * newSI0) + 7U) / 8U;
+    if (IsNativeDataStuffed(type_))
+      nBytesNative = ((static_cast<uint_fast16_t>(DataTypeBitLengthTable[static_cast<int>(type_)]) * newSI0) + 7U) / 8U;
     else
-      nBytesNative = static_cast<uint_fast16_t>(NativeDataTypeBitLengthTable[static_cast<int>(type)] / 8U) * newSI0;
+      nBytesNative = static_cast<uint_fast16_t>(NativeDataTypeBitLengthTable[static_cast<int>(type_)] / 8U) * newSI0;
 
     // allocate temporary storage used to preview the data that shall be written
     if (nBytesNative != 0U)
@@ -682,7 +682,7 @@ SDOAbortCode ObjectARRAY::CompleteWrite(bool const inclSI0,
 
     // read the data from 'isr'
     if (newSI0 != 0U)
-      CANopenEncodedDataToNativeData(isr, type, newSI0, true, pTempMem);
+      CANopenEncodedDataToNativeData(isr, type_, newSI0, true, pTempMem);
 
     isr.EnsureAllDataConsumed(ernob);
   }
@@ -696,25 +696,25 @@ SDOAbortCode ObjectARRAY::CompleteWrite(bool const inclSI0,
   }
 
   // invoke before-write-callback
-  if (pNotifiable != nullptr)
+  if (pNotifiable_ != nullptr)
   {
-    auto const result = pNotifiable->OnBeforeWrite(this, inclSI0 ? 0U : 1U, true, inclSI0 ? newSI0 : 0U, pTempMem);
+    auto const result = pNotifiable_->OnBeforeWrite(this, inclSI0 ? 0U : 1U, true, inclSI0 ? newSI0 : 0U, pTempMem);
     if (result != SDOAbortCode::OK)
       return result;
   }
 
   // write to SI0
-  SI0 = newSI0;
+  SI0_ = newSI0;
 
   // write the other subindices
-  if ((SI0 != 0U) && (!dataPureReadOnly))
+  if ((SI0_ != 0U) && (!dataPureReadOnly))
   {
     // calculate the number of bits to be copied
     uint_fast16_t nBitsToBeCopied;
-    if (IsNativeDataStuffed(type))
-      nBitsToBeCopied = static_cast<uint_fast16_t>(DataTypeBitLengthTable[static_cast<int>(type)]) * SI0;
+    if (IsNativeDataStuffed(type_))
+      nBitsToBeCopied = static_cast<uint_fast16_t>(DataTypeBitLengthTable[static_cast<int>(type_)]) * SI0_;
     else
-      nBitsToBeCopied = static_cast<uint_fast16_t>(NativeDataTypeBitLengthTable[static_cast<int>(type)]) * SI0;
+      nBitsToBeCopied = static_cast<uint_fast16_t>(NativeDataTypeBitLengthTable[static_cast<int>(type_)]) * SI0_;
 
     // calculate the number of whole bytes and remaining bits to be copied
     uint_fast16_t nBytesToBeCopied = nBitsToBeCopied / 8U;
@@ -722,13 +722,13 @@ SDOAbortCode ObjectARRAY::CompleteWrite(bool const inclSI0,
 
     // copy whole bytes
     if (nBytesToBeCopied != 0U)
-      memcpy(pData, pTempMem, nBytesToBeCopied);
+      memcpy(pData_, pTempMem, nBytesToBeCopied);
 
     // any bits left to be copied?
     if (nBitsToBeCopied != 0U)
     {
       // copy the remaining bits
-      uint8_t* const pLastByte = static_cast<uint8_t*>(pData) + nBytesToBeCopied;
+      uint8_t* const pLastByte = static_cast<uint8_t*>(pData_) + nBytesToBeCopied;
       uint8_t const mask = (1U << nBitsToBeCopied) - 1U;
       *pLastByte = (*pLastByte & (~mask)) | (pTempMem[nBytesToBeCopied] & mask);
     }
@@ -737,8 +737,8 @@ SDOAbortCode ObjectARRAY::CompleteWrite(bool const inclSI0,
   // invoke after-write-callback
   try
   {
-    if (pNotifiable != nullptr)
-      pNotifiable->OnAfterWrite(this, inclSI0 ? 0U : 1U, true);
+    if (pNotifiable_ != nullptr)
+      pNotifiable_->OnAfterWrite(this, inclSI0 ? 0U : 1U, true);
   }
   catch (std::exception const & e)
   {
@@ -754,7 +754,7 @@ SDOAbortCode ObjectARRAY::CompleteWrite(bool const inclSI0,
 // --> base class Object
 
 /**
- * \brief Reads the bits represented by a subindex from @ref pData (native format).
+ * \brief Reads the bits represented by a subindex from @ref pData_ (native format).
  *
  * \pre   The size of the array elements must be 1..8 bits, and the native data must be stuffed
  *        (= Data types bit1..bit8 and boolean_native_bit1).
@@ -762,7 +762,7 @@ SDOAbortCode ObjectARRAY::CompleteWrite(bool const inclSI0,
  * - - -
  *
  * __Thread safety:__\n
- * @ref pMutex must be locked.
+ * @ref pMutex_ must be locked.
  *
  * __Exception safety:__\n
  * Strong guarantee.
@@ -776,12 +776,12 @@ SDOAbortCode ObjectARRAY::CompleteWrite(bool const inclSI0,
  * Subindex whose data shall be read. Allowed range: 1..SI0. There is no bounds check.
  *
  * \return
- * Bits represented by subindex 'subIdx', read from the memory referenced by @ref pData. \n
+ * Bits represented by subindex 'subIdx', read from the memory referenced by @ref pData_. \n
  * The read bits are aligned to the LSB. Upper unused bits will be zero.
  */
 uint8_t ObjectARRAY::ReadBitsFromMem(uint8_t const subIdx) const
 {
-  uint8_t const arrayElementSizeInBit = DataTypeBitLengthTable[static_cast<int>(type)];
+  uint8_t const arrayElementSizeInBit = DataTypeBitLengthTable[static_cast<int>(type_)];
 
   // check precondition
   if ((arrayElementSizeInBit < 1U) || (arrayElementSizeInBit > 8U))
@@ -791,7 +791,7 @@ uint8_t ObjectARRAY::ReadBitsFromMem(uint8_t const subIdx) const
   uint_fast16_t bitOffset = static_cast<uint_fast16_t>(subIdx - 1U) * arrayElementSizeInBit;
 
   // get a pointer to the byte containing the first bit to be read
-  uint8_t const * const ptr = static_cast<uint8_t const*>(pData) + (bitOffset / 8U);
+  uint8_t const * const ptr = static_cast<uint8_t const*>(pData_) + (bitOffset / 8U);
 
   // calculate the offset of the first bit to be read inside the byte referenced by ptr
   bitOffset %= 8U;
@@ -814,7 +814,7 @@ uint8_t ObjectARRAY::ReadBitsFromMem(uint8_t const subIdx) const
 }
 
 /**
- * \brief Writes the bits represented by a subindex into @ref pData (native format).
+ * \brief Writes the bits represented by a subindex into @ref pData_ (native format).
  *
  * \pre   The size of the array elements must be 1..8 bits, and the native data must be stuffed
  *        (= Data types bit1..bit8 and boolean_native_bit1).
@@ -822,7 +822,7 @@ uint8_t ObjectARRAY::ReadBitsFromMem(uint8_t const subIdx) const
  * - - -
  *
  * __Thread safety:__\n
- * @ref pMutex must be locked.
+ * @ref pMutex_ must be locked.
  *
  * __Exception safety:__\n
  * Strong guarantee.
@@ -840,7 +840,7 @@ uint8_t ObjectARRAY::ReadBitsFromMem(uint8_t const subIdx) const
  */
 void ObjectARRAY::WriteBitsToMem(uint8_t const subIdx, uint8_t const data)
 {
-  uint8_t const arrayElementSizeInBit = DataTypeBitLengthTable[static_cast<int>(type)];
+  uint8_t const arrayElementSizeInBit = DataTypeBitLengthTable[static_cast<int>(type_)];
 
   // check precondition
   if ((arrayElementSizeInBit < 1U) || (arrayElementSizeInBit > 8U))
@@ -850,7 +850,7 @@ void ObjectARRAY::WriteBitsToMem(uint8_t const subIdx, uint8_t const data)
   uint_fast16_t bitOffset = static_cast<uint_fast16_t>(subIdx - 1U) * arrayElementSizeInBit;
 
   // get a pointer to the byte containing the first bit to be written
-  uint8_t * const ptr = static_cast<uint8_t*>(pData) + (bitOffset / 8U);
+  uint8_t * const ptr = static_cast<uint8_t*>(pData_) + (bitOffset / 8U);
 
   // calculate the offset of the first bit to be written inside the byte referenced by ptr
   bitOffset %= 8U;

--- a/src/cood/ObjectARRAY_wicb.cpp
+++ b/src/cood/ObjectARRAY_wicb.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2021 Daniel Jerolm
+    Copyright (C) 2021, 2025 Daniel Jerolm
 */
 
 #include <gpcc/cood/ObjectARRAY_wicb.hpp>
@@ -26,100 +26,100 @@ namespace cood {
  *
  * - - -
  *
- * \param _name
+ * \param name
  * Name for the object.
  *
- * \param _attributesSI0
+ * \param attributesSI0
  * Attributes for subindex 0.\n
  * There must be at least one read-permission set.
  *
- * \param _SI0
+ * \param SI0
  * Initial value for SI0.\n
  * SI0 indicates the number of subindices representing array elements and therefore the number of array elements.\n
  * The allowed range is 0-255.\n
- * This must also be within the range given by `_min_SI0` and `_max_SI0`.
+ * This must also be within the range given by `min_SI0` and `max_SI0`.
  *
- * \param _min_SI0
+ * \param min_SI0
  * Minimum value for SI0. Allowed range: 0-255.\n
- * This must be equal to or less than `_max_SI0`.
+ * This must be equal to or less than `max_SI0`.
  *
- * \param _max_SI0
+ * \param max_SI0
  * Maximum value for SI0. Allowed range: 0-255.\n
- * This must be equal to or larger than `_min_SI0`.
+ * This must be equal to or larger than `min_SI0`.
  *
- * \param _type
+ * \param type
  * CANopen data type of the array elements represented by the object. Since the constructed object is an ARRAY
  * object, the object itself will have the same data type as the data represented by it.\n
  * \n
- * The type of the native data referenced by `_pData` must match the CANopen data type. The documentation of the
+ * The type of the native data referenced by `pData` must match the CANopen data type. The documentation of the
  * @ref DataType enumeration contains a list of native types associated with each CANopen data type.\n
  * \n
- * Note that if '_type' is any of the types bit1..bit8 or boolean_native_bit1, then the native data must be an array of
+ * Note that if 'type' is any of the types bit1..bit8 or boolean_native_bit1, then the native data must be an array of
  * data type uint8_t and the bits will be stuffed together inside the native array.\n
  * Example:\n
  * An array of 18 elements of type `bit2` would be comprised of 36 bits. The native array would occupy 5 native
  * elements of type uint8_t and the upper four bits of the last element would be unused.
  *
- * \param _attributes
+ * \param attributes
  * Attributes for the subindices representing array elements.\n
  * The attributes are applied to all subindices except for SI0.\n
  * At least one read- or write-permission must be set.
  *
- * \param _pData
+ * \param pData
  * Pointer to the memory location containing the data represented by the ARRAY object.\n
  * The memory is provided and owned by the owner of the ARRAY object.\n
  * The memory location must be valid during the life-time of the ARRAY object or until a different
  * memory location is configured via @ref SetData(). \n
- * The memory must contain `_max_SI0` elements of data type `_type`.\n
- * See parameter `_type` for details.
+ * The memory must contain `max_SI0` elements of data type `type`.\n
+ * See parameter `type` for details.
  *
- * \param _pMutex
- * Pointer to a mutex protecting access to SI0 and to the native data referenced by `_pData`.\n
+ * \param pMutex
+ * Pointer to a mutex protecting access to SI0 and to the native data referenced by `pData`.\n
  * The mutex is optional. If the whole object is read-only __and__ if the application does not modify the
- * value of SI0 and if the application does not modify the data referenced by `_pData`, then a mutex is not required
+ * value of SI0 and if the application does not modify the data referenced by `pData`, then a mutex is not required
  * and this parameter may be `nullptr`.\n
  * __BUT__ if SI0 or the array data represented by the object is writeable, or if the application may modify SI0, or
- * if the application may modify the native data referenced by `_pData`, then a mutex must be specified.\n
+ * if the application may modify the native data referenced by `pData`, then a mutex must be specified.\n
  * \n
- * The application must obey the following rules when accessing the native data referenced by `_pData`:
+ * The application must obey the following rules when accessing the native data referenced by `pData`:
  * - If the array data is READ-ONLY, then the application must lock the mutex only if it wants to modify the data
- *   referenced by `_pData`. The application does not need to lock the mutex for reading the data referenced by
- *   `_pData` in this case.
+ *   referenced by `pData`. The application does not need to lock the mutex for reading the data referenced by
+ *   `pData` in this case.
  * - If the array data is READ-WRITE, then the application must lock the mutex ALWAYS when it wants to read or write
- *   the data referenced by `_pData`.
+ *   the data referenced by `pData`.
  *
- * \param _onBeforeReadCallback
+ * \param onBeforeReadCallback
  * Functor to a callback that will be invoked before reading from the object.\n
  * For details please refer to @ref tOnBeforeReadCallback. \n
  * This is optional. The functor may refer to nothing.
  *
- * \param _onBeforeWriteCallback
+ * \param onBeforeWriteCallback
  * Functor to a callback that will be invoked before writing to the object.\n
  * For details please refer to @ref tOnBeforeWriteCallback. \n
  * This is optional. The functor may refer to nothing.
  *
- * \param _onAfterWriteCallback
+ * \param onAfterWriteCallback
  * Functor to a callback that will be invoked after writing to the object.\n
  * For details please refer to the documentation of @ref tOnAfterWriteCallback. \n
  * This is optional. The functor may refer to nothing.
  */
-ObjectARRAY_wicb::ObjectARRAY_wicb(std::string            const & _name,
-                                   attr_t                 const   _attributesSI0,
-                                   uint8_t                const   _SI0,
-                                   uint8_t                const   _min_SI0,
-                                   uint8_t                const   _max_SI0,
-                                   DataType               const   _type,
-                                   attr_t                 const   _attributes,
-                                   void*                  const   _pData,
-                                   gpcc::osal::Mutex *    const   _pMutex,
-                                   tOnBeforeReadCallback  const & _onBeforeReadCallback,
-                                   tOnBeforeWriteCallback const & _onBeforeWriteCallback,
-                                   tOnAfterWriteCallback  const & _onAfterWriteCallback)
+ObjectARRAY_wicb::ObjectARRAY_wicb(std::string            const & name,
+                                   attr_t                 const   attributesSI0,
+                                   uint8_t                const   SI0,
+                                   uint8_t                const   min_SI0,
+                                   uint8_t                const   max_SI0,
+                                   DataType               const   type,
+                                   attr_t                 const   attributes,
+                                   void*                  const   pData,
+                                   gpcc::osal::Mutex *    const   pMutex,
+                                   tOnBeforeReadCallback  const & onBeforeReadCallback,
+                                   tOnBeforeWriteCallback const & onBeforeWriteCallback,
+                                   tOnAfterWriteCallback  const & onAfterWriteCallback)
 : IObjectNotifiable()
-, ObjectARRAY(_name, _attributesSI0, _SI0, _min_SI0, _max_SI0, _type, _attributes, _pData, _pMutex, this)
-, onBeforeReadCallback(_onBeforeReadCallback)
-, onBeforeWriteCallback(_onBeforeWriteCallback)
-, onAfterWriteCallback(_onAfterWriteCallback)
+, ObjectARRAY(name, attributesSI0, SI0, min_SI0, max_SI0, type, attributes, pData, pMutex, this)
+, onBeforeReadCallback_(onBeforeReadCallback)
+, onBeforeWriteCallback_(onBeforeWriteCallback)
+, onAfterWriteCallback_(onAfterWriteCallback)
 {
 }
 
@@ -127,36 +127,36 @@ ObjectARRAY_wicb::ObjectARRAY_wicb(std::string            const & _name,
 
 /// \copydoc gpcc::cood::IObjectNotifiable::OnBeforeRead
 SDOAbortCode ObjectARRAY_wicb::OnBeforeRead(gpcc::cood::Object const * pObj,
-                                          uint8_t const subindex,
-                                          bool const completeAccess,
-                                          bool const querySizeWillNotRead)
+                                            uint8_t const subindex,
+                                            bool const completeAccess,
+                                            bool const querySizeWillNotRead)
 {
-  if (!onBeforeReadCallback)
+  if (!onBeforeReadCallback_)
     return SDOAbortCode::OK;
 
-  return onBeforeReadCallback(pObj, subindex, completeAccess, querySizeWillNotRead);
+  return onBeforeReadCallback_(pObj, subindex, completeAccess, querySizeWillNotRead);
 }
 
 /// \copydoc gpcc::cood::IObjectNotifiable::OnBeforeWrite
 SDOAbortCode ObjectARRAY_wicb::OnBeforeWrite(gpcc::cood::Object const * pObj,
-                                           uint8_t const subindex,
-                                           bool const completeAccess,
-                                           uint8_t const valueWrittenToSI0,
-                                           void const * pData)
+                                             uint8_t const subindex,
+                                             bool const completeAccess,
+                                             uint8_t const valueWrittenToSI0,
+                                             void const * pData)
 {
-  if (!onBeforeWriteCallback)
+  if (!onBeforeWriteCallback_)
     return SDOAbortCode::OK;
 
-  return onBeforeWriteCallback(pObj, subindex, completeAccess, valueWrittenToSI0, pData);
+  return onBeforeWriteCallback_(pObj, subindex, completeAccess, valueWrittenToSI0, pData);
 }
 
 /// \copydoc gpcc::cood::IObjectNotifiable::OnAfterWrite
 void ObjectARRAY_wicb::OnAfterWrite(gpcc::cood::Object const * pObj,
-                                  uint8_t const subindex,
-                                  bool const completeAccess)
+                                    uint8_t const subindex,
+                                    bool const completeAccess)
 {
-  if (onAfterWriteCallback)
-    onAfterWriteCallback(pObj, subindex, completeAccess);
+  if (onAfterWriteCallback_)
+    onAfterWriteCallback_(pObj, subindex, completeAccess);
 }
 
 // --> IObjectNotifiable

--- a/src/cood/ObjectVAR.cpp
+++ b/src/cood/ObjectVAR.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2018 Daniel Jerolm
+    Copyright (C) 2018, 2025 Daniel Jerolm
 */
 
 #include <gpcc/cood/ObjectVAR.hpp>
@@ -35,103 +35,103 @@ namespace cood {
  *
  * - - -
  *
- * \param _name
+ * \param name
  * Name for the object.
  *
- * \param _type
+ * \param type
  * CANopen data type of the data represented by the object.\n
  * Since the constructed object is a VARIABLE object, the object will have the same type as the data
  * represented by it.\n
  * The documentation of the enumeration [DataType](@ref gpcc::cood::DataType) contains a list of native types associated
  * with each CANopen data type.
  *
- * \param _nElements
- * Number of elements of `_type` the data represented by the object is comprised of.\n
+ * \param nElements
+ * Number of elements of `type` the data represented by the object is comprised of.\n
  * For most data types this is one.\n
  * For types [DataType::visible_string](@ref gpcc::cood::DataType::visible_string),
  * [DataType::octet_string](@ref gpcc::cood::DataType::octet_string), and
  * [DataType::unicode_string](@ref gpcc::cood::DataType::unicode_string) this may be any number equal to or larger
  * than one.
  *
- * \param _attributes
+ * \param attributes
  * Attributes for the one and only subindex 0.\n
  * At least one read- or write-permission must be specified.
  *
- * \param _pData
+ * \param pData
  * Pointer to the native data represented by the object. `nullptr` is not allowed.\n
  * The type of the referenced native data must match the CANopen data type specified by parameter `type`
- * and the number of data elements must match parameter `_nElements`.\n
+ * and the number of data elements must match parameter `nElements`.\n
  * The documentation of the enumeration [DataType](@ref gpcc::cood::DataType) contains a list of native types associated
  * with each CANopen data type.\n
  * The memory location must be valid during the life-time of the VARIABLE object or until a different
  * memory location is configured via @ref SetData().
  *
- * \param _pMutex
- * Pointer to a mutex protecting access to the native data referenced by `_pData`.\n
+ * \param pMutex
+ * Pointer to a mutex protecting access to the native data referenced by `pData`.\n
  * The mutex is optional. If the object is read-only __and__ if the application does not modify the
- * data referenced by `_pData`, then a mutex is not required and this parameter may be `nullptr`.\n
- * __BUT__ if the object is writeable, or if the application may modify the data referenced by `_pData`,
+ * data referenced by `pData`, then a mutex is not required and this parameter may be `nullptr`.\n
+ * __BUT__ if the object is writeable, or if the application may modify the data referenced by `pData`,
  * then a mutex must be specified.\n
  * \n
- * The application must obey the following rules when accessing the native data referenced by `_pData`:
+ * The application must obey the following rules when accessing the native data referenced by `pData`:
  * - If the object is READ-ONLY, then the application must lock the mutex only if it wants to
- *   modify the data referenced by `_pData`. The application does not need to lock the mutex for reading
- *   the data referenced by `_pData` in this case.
+ *   modify the data referenced by `pData`. The application does not need to lock the mutex for reading
+ *   the data referenced by `pData` in this case.
  * - If the object is READ-WRITE, then the application must lock the mutex ALWAYS when it wants to
- *   read or write the data referenced by `_pData`.
+ *   read or write the data referenced by `pData`.
  *
- * \param _pNotifiable
+ * \param pNotifiable
  * Pointer to a [IObjectNotifiable](@ref gpcc::cood::IObjectNotifiable) interface that shall be used to deliver
  * callbacks to the owner of the object.\n
  * nullptr is allowed.
  */
-ObjectVAR::ObjectVAR(std::string            const & _name,
-                     DataType               const   _type,
-                     uint16_t               const   _nElements,
-                     attr_t                 const   _attributes,
-                     void*                  const   _pData,
-                     gpcc::osal::Mutex *    const   _pMutex,
-                     IObjectNotifiable *    const   _pNotifiable)
+ObjectVAR::ObjectVAR(std::string            const & name,
+                     DataType               const   type,
+                     uint16_t               const   nElements,
+                     attr_t                 const   attributes,
+                     void*                  const   pData,
+                     gpcc::osal::Mutex *    const   pMutex,
+                     IObjectNotifiable *    const   pNotifiable)
 : Object()
-, name(_name)
-, type(_type)
-, nElements(_nElements)
-, attributes(_attributes)
-, pData(_pData)
-, pMutex(_pMutex)
-, pNotifiable(_pNotifiable)
+, name_(name)
+, type_(type)
+, nElements_(nElements)
+, attributes_(attributes)
+, pData_(pData)
+, pMutex_(pMutex)
+, pNotifiable_(pNotifiable)
 {
   // data type supported?
-  if (   (DataTypeBitLengthTable[static_cast<int>(type)] == 0U)
-      || (NativeDataTypeBitLengthTable[static_cast<int>(type)] == 0U))
+  if (   (DataTypeBitLengthTable[static_cast<int>(type_)] == 0U)
+      || (NativeDataTypeBitLengthTable[static_cast<int>(type_)] == 0U))
   {
-    throw DataTypeNotSupportedError(type);
+    throw DataTypeNotSupportedError(type_);
   }
 
   // check nElements
-  if (   (type == DataType::visible_string)
-      || (type == DataType::octet_string)
-      || (type == DataType::unicode_string))
+  if (   (type_ == DataType::visible_string)
+      || (type_ == DataType::octet_string)
+      || (type_ == DataType::unicode_string))
   {
-    if (nElements == 0U)
-      throw std::invalid_argument("ObjectVAR::ObjectVAR: '_nElements' is zero");
+    if (nElements_ == 0U)
+      throw std::invalid_argument("ObjectVAR::ObjectVAR: 'nElements' is zero");
   }
   else
   {
-    if (nElements != 1U)
-      throw std::invalid_argument("ObjectVAR::ObjectVAR: '_nElements' must be one for given '_type'");
+    if (nElements_ != 1U)
+      throw std::invalid_argument("ObjectVAR::ObjectVAR: 'nElements' must be one for given 'type'");
   }
 
   // at least one read or write permission specified?
-  if ((attributes & attr_ACCESS_RW) == 0U)
-    throw std::invalid_argument("ObjectVAR::ObjectVAR: No read- or write-permissions set in '_attributes'");
+  if ((attributes_ & attr_ACCESS_RW) == 0U)
+    throw std::invalid_argument("ObjectVAR::ObjectVAR: No read- or write-permissions set in 'attributes'");
 
   // check: a mutex must be specified if write access is possible
-  if (((attributes & attr_ACCESS_WR) != 0U) && (pMutex == nullptr))
+  if (((attributes_ & attr_ACCESS_WR) != 0U) && (pMutex_ == nullptr))
     throw std::logic_error("ObjectVAR::ObjectVAR: Object with write-permission requires a mutex");
 
-  if (pData == nullptr)
-    throw std::invalid_argument("ObjectVAR::ObjectVAR: _pData is nullptr");
+  if (pData_ == nullptr)
+    throw std::invalid_argument("ObjectVAR::ObjectVAR: pData is nullptr");
 }
 
 /**
@@ -159,7 +159,7 @@ ObjectVAR::ObjectVAR(std::string            const & _name,
  * A pointer referencing to the currently configured memory is allowed if the objects's data shall not
  * be updated.\n
  * The type of the referenced native data must match the CANopen data type specified by parameter `type`
- * that has been passed to the constructor and the number of data elements must match parameter `_nElements`
+ * that has been passed to the constructor and the number of data elements must match parameter `nElements`
  * that has been passed to the constructor.\n
  * The documentation of the enumeration @ref DataType contains a list of native types associated with each
  * CANopen data type.\n
@@ -168,14 +168,14 @@ ObjectVAR::ObjectVAR(std::string            const & _name,
  */
 void ObjectVAR::SetData(void* const pNewData)
 {
-  if (pMutex == nullptr)
+  if (pMutex_ == nullptr)
     throw std::logic_error("ObjectVAR::SetData: Operation requires that a mutex has been specified during object creation");
 
   if (pNewData == nullptr)
     throw std::invalid_argument("ObjectVAR::SetData: pNewData is nullptr");
 
-  gpcc::osal::MutexLocker mutexLocker(*pMutex);
-  pData = pNewData;
+  gpcc::osal::MutexLocker mutexLocker(*pMutex_);
+  pData_ = pNewData;
 }
 
 // <-- base class Object
@@ -189,13 +189,13 @@ Object::ObjectCode ObjectVAR::GetObjectCode(void) const noexcept
 /// \copydoc Object::GetObjectDataType
 DataType ObjectVAR::GetObjectDataType(void) const noexcept
 {
-  return MapAlternativeDataTypesToOriginalTypes(type);
+  return MapAlternativeDataTypesToOriginalTypes(type_);
 }
 
 /// \copydoc Object::GetObjectName
 std::string ObjectVAR::GetObjectName(void) const
 {
-  return name;
+  return name_;
 }
 
 /// \copydoc Object::GetMaxNbOfSubindices
@@ -219,7 +219,7 @@ DataType ObjectVAR::GetSubIdxDataType(uint8_t const subIdx) const
   if (subIdx != 0U)
     throw SubindexNotExistingError();
 
-  return MapAlternativeDataTypesToOriginalTypes(type);
+  return MapAlternativeDataTypesToOriginalTypes(type_);
 }
 
 /// \copydoc Object::GetSubIdxAttributes
@@ -228,7 +228,7 @@ Object::attr_t ObjectVAR::GetSubIdxAttributes(uint8_t const subIdx) const
   if (subIdx != 0U)
     throw SubindexNotExistingError();
 
-  return attributes;
+  return attributes_;
 }
 
 /// \copydoc Object::GetSubIdxMaxSize
@@ -237,7 +237,7 @@ size_t ObjectVAR::GetSubIdxMaxSize(uint8_t const subIdx) const
   if (subIdx != 0U)
     throw SubindexNotExistingError();
 
-  return static_cast<uint_fast32_t>(DataTypeBitLengthTable[static_cast<int>(type)]) * nElements;
+  return static_cast<uint_fast32_t>(DataTypeBitLengthTable[static_cast<int>(type_)]) * nElements_;
 }
 
 /// \copydoc Object::GetSubIdxName
@@ -246,20 +246,20 @@ std::string ObjectVAR::GetSubIdxName(uint8_t const subIdx) const
   if (subIdx != 0U)
     throw SubindexNotExistingError();
 
-  return name;
+  return name_;
 }
 
 /// \copydoc Object::LockData
 gpcc::osal::MutexLocker ObjectVAR::LockData(void) const
 {
-  return gpcc::osal::MutexLocker(pMutex);
+  return gpcc::osal::MutexLocker(pMutex_);
 }
 
 /// \copydoc Object::GetObjectStreamSize
 size_t ObjectVAR::GetObjectStreamSize(bool const SI016Bits) const noexcept
 {
   (void)SI016Bits;
-  return static_cast<uint_fast32_t>(DataTypeBitLengthTable[static_cast<int>(type)]) * nElements;
+  return static_cast<uint_fast32_t>(DataTypeBitLengthTable[static_cast<int>(type_)]) * nElements_;
 }
 
 /// \copydoc Object::GetNbOfSubIndices
@@ -275,16 +275,16 @@ size_t ObjectVAR::GetSubIdxActualSize(uint8_t const subIdx) const
     throw SubindexNotExistingError();
 
   // data types with flexible-length require invocation of before-read-callback
-  if ((type == DataType::visible_string) && (pNotifiable != nullptr))
+  if ((type_ == DataType::visible_string) && (pNotifiable_ != nullptr))
   {
-    auto const result = pNotifiable->OnBeforeRead(this, 0, false, true);
+    auto const result = pNotifiable_->OnBeforeRead(this, 0, false, true);
     if (result == SDOAbortCode::OutOfMemory)
       throw std::bad_alloc();
     else if (result != SDOAbortCode::OK)
       throw std::runtime_error("ObjectVAR::GetSubIdxActualSize: Before-read-callback failed.");
   }
 
-  return DetermineSizeOfCANopenEncodedData(pData, type, nElements);
+  return DetermineSizeOfCANopenEncodedData(pData_, type_, nElements_);
 }
 
 /// \copydoc Object::Read
@@ -295,17 +295,17 @@ SDOAbortCode ObjectVAR::Read(uint8_t const subIdx,
   if (subIdx != 0U)
     return SDOAbortCode::SubindexDoesNotExist;
 
-  if ((permissions & attr_ACCESS_RD & attributes) == 0U)
+  if ((permissions & attr_ACCESS_RD & attributes_) == 0U)
     return SDOAbortCode::AttemptToReadWrOnlyObject;
 
-  if (pNotifiable != nullptr)
+  if (pNotifiable_ != nullptr)
   {
-    auto const result = pNotifiable->OnBeforeRead(this, 0, false, false);
+    auto const result = pNotifiable_->OnBeforeRead(this, 0, false, false);
     if (result != SDOAbortCode::OK)
       return result;
   }
 
-  NativeDataToCANopenEncodedData(pData, type, nElements, false, isw);
+  NativeDataToCANopenEncodedData(pData_, type_, nElements_, false, isw);
 
   return SDOAbortCode::OK;
 }
@@ -318,12 +318,12 @@ SDOAbortCode ObjectVAR::Write(uint8_t const subIdx,
   if (subIdx != 0U)
     return SDOAbortCode::SubindexDoesNotExist;
 
-  if ((permissions & attr_ACCESS_WR & attributes) == 0U)
+  if ((permissions & attr_ACCESS_WR & attributes_) == 0U)
     return SDOAbortCode::AttemptToWriteRdOnlyObject;
 
   // determine number of bytes required to store the data that shall be written in native format
   // (cannot be zero, ensured by constructor)
-  uint_fast32_t const nBytesNative = static_cast<uint_fast32_t>(NativeDataTypeBitLengthTable[static_cast<int>(type)] / 8U) * nElements;
+  uint_fast32_t const nBytesNative = static_cast<uint_fast32_t>(NativeDataTypeBitLengthTable[static_cast<int>(type_)] / 8U) * nElements_;
 
   // allocate some temporary storage (pTempMem) either on the stack or on the heap
   uint64_t localMem;
@@ -342,7 +342,7 @@ SDOAbortCode ObjectVAR::Write(uint8_t const subIdx,
   // read data into pTempMem for preview
   try
   {
-    CANopenEncodedDataToNativeData(isr, type, nElements, false, pTempMem);
+    CANopenEncodedDataToNativeData(isr, type_, nElements_, false, pTempMem);
     isr.EnsureAllDataConsumed(gpcc::stream::IStreamReader::RemainingNbOfBits::sevenOrLess);
   }
   catch (gpcc::stream::EmptyError const &)
@@ -355,9 +355,9 @@ SDOAbortCode ObjectVAR::Write(uint8_t const subIdx,
   }
 
   // invoke before-write-callback (preview)
-  if (pNotifiable != nullptr)
+  if (pNotifiable_ != nullptr)
   {
-    auto const result = pNotifiable->OnBeforeWrite(this, 0, false, 0, pTempMem);
+    auto const result = pNotifiable_->OnBeforeWrite(this, 0, false, 0, pTempMem);
     if (result != SDOAbortCode::OK)
       return result;
   }
@@ -366,29 +366,29 @@ SDOAbortCode ObjectVAR::Write(uint8_t const subIdx,
   switch (nBytesNative)
   {
     case 1U:
-      *static_cast<uint8_t*>(pData) = *pTempMem;
+      *static_cast<uint8_t*>(pData_) = *pTempMem;
       break;
 
     case 2U:
-      *static_cast<uint16_t*>(pData) = *reinterpret_cast<uint16_t*>(pTempMem);
+      *static_cast<uint16_t*>(pData_) = *reinterpret_cast<uint16_t*>(pTempMem);
       break;
 
     case 4U:
-      *static_cast<uint32_t*>(pData) = *reinterpret_cast<uint32_t*>(pTempMem);
+      *static_cast<uint32_t*>(pData_) = *reinterpret_cast<uint32_t*>(pTempMem);
       break;
 
     case 8U:
-      *static_cast<uint64_t*>(pData) = localMem;
+      *static_cast<uint64_t*>(pData_) = localMem;
       break;
 
     default:
-      memcpy(pData, pTempMem, nBytesNative);
+      memcpy(pData_, pTempMem, nBytesNative);
   }
 
   try
   {
-    if (pNotifiable != nullptr)
-      pNotifiable->OnAfterWrite(this, 0, false);
+    if (pNotifiable_ != nullptr)
+      pNotifiable_->OnAfterWrite(this, 0, false);
   }
   catch (std::exception const & e)
   {

--- a/src/cood/ObjectVAR_wicb.cpp
+++ b/src/cood/ObjectVAR_wicb.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2021 Daniel Jerolm
+    Copyright (C) 2021, 2025 Daniel Jerolm
 */
 
 #include <gpcc/cood/ObjectVAR_wicb.hpp>
@@ -26,78 +26,80 @@ namespace cood {
  *
  * - - -
  *
- * \param _name
+ * \param name
  * Name for the object.
  *
- * \param _type
+ * \param type
  * CANopen data type of the data represented by the object.\n
  * Since the constructed object is a VARIABLE object, the object will have the same type as the data
  * represented by it.\n
- * The documentation of the enumeration @ref DataType contains a list of native types associated with each
- * CANopen data type.
+ * The documentation of the enumeration [DataType](@ref gpcc::cood::DataType) contains a list of native types associated
+ * with each CANopen data type.
  *
- * \param _nElements
- * Number of elements of `_type` the data represented by the object is comprised of.\n
+ * \param nElements
+ * Number of elements of `type` the data represented by the object is comprised of.\n
  * For most data types this is one.\n
- * For types @ref DataType::visible_string, @ref DataType::octet_string, and @ref DataType::unicode_string
- * this may be any number equal to or larger than one.
+ * For types [DataType::visible_string](@ref gpcc::cood::DataType::visible_string),
+ * [DataType::octet_string](@ref gpcc::cood::DataType::octet_string), and
+ * [DataType::unicode_string](@ref gpcc::cood::DataType::unicode_string) this may be any number equal to or larger
+ * than one.
  *
- * \param _attributes
+ * \param attributes
  * Attributes for the one and only subindex 0.\n
  * At least one read- or write-permission must be specified.
  *
- * \param _pData
+ * \param pData
  * Pointer to the native data represented by the object. `nullptr` is not allowed.\n
  * The type of the referenced native data must match the CANopen data type specified by parameter `type`
- * and the number of data elements must match parameter `_nElements`.\n
- * The documentation of the enumeration @ref DataType contains a list of native types associated with each
- * CANopen data type.\n
+ * and the number of data elements must match parameter `nElements`.\n
+ * The documentation of the enumeration [DataType](@ref gpcc::cood::DataType) contains a list of native types associated
+ * with each CANopen data type.\n
  * The memory location must be valid during the life-time of the VARIABLE object or until a different
  * memory location is configured via @ref SetData().
  *
- * \param _pMutex
- * Pointer to a mutex protecting access to the native data referenced by `_pData`.\n
+ * \param pMutex
+ * Pointer to a mutex protecting access to the native data referenced by `pData`.\n
  * The mutex is optional. If the object is read-only __and__ if the application does not modify the
- * data referenced by `_pData`, then a mutex is not required and this parameter may be `nullptr`.\n
- * __BUT__ if the object is writeable, or if the application may modify the data referenced by `_pData`,
+ * data referenced by `pData`, then a mutex is not required and this parameter may be `nullptr`.\n
+ * __BUT__ if the object is writeable, or if the application may modify the data referenced by `pData`,
  * then a mutex must be specified.\n
  * \n
- * The application must obey the following rules when accessing the native data referenced by `_pData`:
+ * The application must obey the following rules when accessing the native data referenced by `pData`:
  * - If the object is READ-ONLY, then the application must lock the mutex only if it wants to
- *   modify the data referenced by `_pData`. The application does not need to lock the mutex for reading
- *   the data referenced by `_pData` in this case.
+ *   modify the data referenced by `pData`. The application does not need to lock the mutex for reading
+ *   the data referenced by `pData` in this case.
  * - If the object is READ-WRITE, then the application must lock the mutex ALWAYS when it wants to
- *   read or write the data referenced by `_pData`.
+ *   read or write the data referenced by `pData`.
  *
- * \param _onBeforeReadCallback
+ * \param onBeforeReadCallback
  * Functor to a callback that will be invoked before reading from the object.\n
  * For details please refer to @ref tOnBeforeReadCallback. \n
  * This is optional. The functor may refer to nothing.
  *
- * \param _onBeforeWriteCallback
+ * \param onBeforeWriteCallback
  * Functor to a callback that will be invoked before writing to the object.\n
  * For details please refer to @ref tOnBeforeWriteCallback. \n
  * This is optional. The functor may refer to nothing.
  *
- * \param _onAfterWriteCallback
+ * \param onAfterWriteCallback
  * Functor to a callback that will be invoked after writing to the object.\n
  * For details please refer to the documentation of @ref tOnAfterWriteCallback. \n
  * This is optional. The functor may refer to nothing.
  */
-ObjectVAR_wicb::ObjectVAR_wicb(std::string            const & _name,
-                               DataType               const   _type,
-                               uint16_t               const   _nElements,
-                               attr_t                 const   _attributes,
-                               void*                  const   _pData,
-                               gpcc::osal::Mutex *    const   _pMutex,
-                               tOnBeforeReadCallback  const & _onBeforeReadCallback,
-                               tOnBeforeWriteCallback const & _onBeforeWriteCallback,
-                               tOnAfterWriteCallback  const & _onAfterWriteCallback)
+ObjectVAR_wicb::ObjectVAR_wicb(std::string            const & name,
+                               DataType               const   type,
+                               uint16_t               const   nElements,
+                               attr_t                 const   attributes,
+                               void*                  const   pData,
+                               gpcc::osal::Mutex *    const   pMutex,
+                               tOnBeforeReadCallback  const & onBeforeReadCallback,
+                               tOnBeforeWriteCallback const & onBeforeWriteCallback,
+                               tOnAfterWriteCallback  const & onAfterWriteCallback)
 : IObjectNotifiable()
-, ObjectVAR(_name, _type, _nElements, _attributes, _pData, _pMutex, this)
-, onBeforeReadCallback(_onBeforeReadCallback)
-, onBeforeWriteCallback(_onBeforeWriteCallback)
-, onAfterWriteCallback(_onAfterWriteCallback)
+, ObjectVAR(name, type, nElements, attributes, pData, pMutex, this)
+, onBeforeReadCallback_(onBeforeReadCallback)
+, onBeforeWriteCallback_(onBeforeWriteCallback)
+, onAfterWriteCallback_(onAfterWriteCallback)
 {
 }
 
@@ -109,10 +111,10 @@ SDOAbortCode ObjectVAR_wicb::OnBeforeRead(gpcc::cood::Object const * pObj,
                                           bool const completeAccess,
                                           bool const querySizeWillNotRead)
 {
-  if (!onBeforeReadCallback)
+  if (!onBeforeReadCallback_)
     return SDOAbortCode::OK;
 
-  return onBeforeReadCallback(pObj, subindex, completeAccess, querySizeWillNotRead);
+  return onBeforeReadCallback_(pObj, subindex, completeAccess, querySizeWillNotRead);
 }
 
 /// \copydoc gpcc::cood::IObjectNotifiable::OnBeforeWrite
@@ -122,10 +124,10 @@ SDOAbortCode ObjectVAR_wicb::OnBeforeWrite(gpcc::cood::Object const * pObj,
                                            uint8_t const valueWrittenToSI0,
                                            void const * pData)
 {
-  if (!onBeforeWriteCallback)
+  if (!onBeforeWriteCallback_)
     return SDOAbortCode::OK;
 
-  return onBeforeWriteCallback(pObj, subindex, completeAccess, valueWrittenToSI0, pData);
+  return onBeforeWriteCallback_(pObj, subindex, completeAccess, valueWrittenToSI0, pData);
 }
 
 /// \copydoc gpcc::cood::IObjectNotifiable::OnAfterWrite
@@ -133,8 +135,8 @@ void ObjectVAR_wicb::OnAfterWrite(gpcc::cood::Object const * pObj,
                                   uint8_t const subindex,
                                   bool const completeAccess)
 {
-  if (onAfterWriteCallback)
-    onAfterWriteCallback(pObj, subindex, completeAccess);
+  if (onAfterWriteCallback_)
+    onAfterWriteCallback_(pObj, subindex, completeAccess);
 }
 
 // --> IObjectNotifiable

--- a/src/cood/cli/CLIAdapterBase.cpp
+++ b/src/cood/cli/CLIAdapterBase.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2019, 2024 Daniel Jerolm
+    Copyright (C) 2019, 2024, 2025 Daniel Jerolm
 */
 
 #include <gpcc/cood/cli/CLIAdapterBase.hpp>
@@ -54,31 +54,31 @@ namespace cood {
  *
  * - - -
  *
- * \param _od
+ * \param od
  * @ref IObjectAccess interface of the object dictionary that shall be accessed by the CLI command.
  *
- * \param _cli
+ * \param cli
  * Reference to the CLI instance where the CLI command shall be registered.
  *
- * \param _cmdName
+ * \param cmdName
  * Desired name for the CLI command.\n
  * Sub-commands will be realized via arguments passed to the command.\n
  * The string must meet the requirements of [cli::Command::Create()](@ref gpcc::cli::Command::Create) or
  * @ref RegisterCLICommand() will fail later.
  *
- * \param _attributeStringMaxLength
+ * \param attributeStringMaxLength
  * Maximum length of any string that could be returned by @ref AttributesToStringHook(). Zero is not allowed.
  */
-CLIAdapterBase::CLIAdapterBase(IObjectAccess & _od,
-                               gpcc::cli::CLI & _cli,
-                               std::string const & _cmdName,
-                               uint8_t const _attributeStringMaxLength)
-: od(_od)
-, cli(_cli)
-, cmdName(_cmdName)
-, attributeStringMaxLength(_attributeStringMaxLength)
+CLIAdapterBase::CLIAdapterBase(IObjectAccess & od,
+                               gpcc::cli::CLI & cli,
+                               std::string const & cmdName,
+                               uint8_t const attributeStringMaxLength)
+: od_(od)
+, cli_(cli)
+, cmdName_(cmdName)
+, attributeStringMaxLength_(attributeStringMaxLength)
 {
-  if (attributeStringMaxLength == 0U)
+  if (attributeStringMaxLength_ == 0U)
     throw std::invalid_argument("CLIAdapterBase::CLIAdapterBase: '_attributeStringMaxLength' invalid");
 }
 
@@ -108,46 +108,46 @@ void CLIAdapterBase::RegisterCLICommand(void)
 
   ON_SCOPE_EXIT(undoCMDRegistration) { UnregisterCLICommand(); };
 
-  cli.AddCommand(Command::Create(cmdName.c_str(), " subcmd [args...]\n"
-                                 "Accesses the local object dictionary. The type of access is specified by <subcmd>:\n"
-                                 "- enum [0xFROM-0xTO]\n"
-                                 "  Enumerates objects contained in the object dictionary.\n"
-                                 "  Options:\n"
-                                 "    FROM   Index where enumeration shall start. Default: 0x0000\n"
-                                 "    TO     Index where enumeration shall end. Default: 0xFFFF\n"
-                                 "    FROM <= TO must be valid.\n"
-                                 "\n"
-                                 "- info 0xINDEX [asm]\n"
-                                 "  Prints the meta data of an object and its subindices.\n"
-                                 "  Options:\n"
-                                 "    asm   Includes application-specific meta data in the output.\n"
-                                 "\n"
-                                 "- read 0xINDEX:Subindex\n"
-                                 "  Reads the data of a subindex and prints it to CLI.\n"
-                                 "  <subindex> shall be provided in decimal format.\n"
-                                 "\n"
-                                 "- write 0xINDEX:Subindex DATA\n"
-                                 "  Writes <DATA> to a subindex. <Subindex> shall be provided in decimal format.\n"
-                                 "\n"
-                                 "  The format of <DATA> must meet the data type of the subindex:\n"
-                                 "  For BOOLEAN: TRUE, FALSE, true, false\n"
-                                 "  For REAL32/64: [+|-]digits[.][digits][(e|E)[+|-]digits]\n"
-                                 "  For VISIBLE_STRING: \"Text...\"\n"
-                                 "  For OCTET_STRING: 5B A3 ... (8bit hex values, separated by spaces)\n"
-                                 "  For UNICODE_STRING: 5B33 A6CF (16bit hex values, separated by spaces)\n"
-                                 "  For BIT1..BIT8: 0, 1, 3, 0x3, 0b11 (unused upper bits must be zero)\n"
-                                 "\n"
-                                 "- caread 0xINDEX [v]\n"
-                                 "  Reads the whole object via complete access and prints the value of each\n"
-                                 "  subindex to CLI.\n"
-                                 "  Options:\n"
-                                 "  v   Verbose output. Prints the data type and name of each subindex in addition\n"
-                                 "      to the data.\n"
-                                 "- cawrite 0xINDEX\n"
-                                 "  Writes the whole object via complete access.\n"
-                                 "  The data that shall be written is entered using an interactive dialog.",
-                                 std::bind(&CLIAdapterBase::CLI_CommandHandler, this,
-                                           std::placeholders::_1, std::placeholders::_2)));
+  cli_.AddCommand(Command::Create(cmdName_.c_str(), " subcmd [args...]\n"
+                                  "Accesses the local object dictionary. The type of access is specified by <subcmd>:\n"
+                                  "- enum [0xFROM-0xTO]\n"
+                                  "  Enumerates objects contained in the object dictionary.\n"
+                                  "  Options:\n"
+                                  "    FROM   Index where enumeration shall start. Default: 0x0000\n"
+                                  "    TO     Index where enumeration shall end. Default: 0xFFFF\n"
+                                  "    FROM <= TO must be valid.\n"
+                                  "\n"
+                                  "- info 0xINDEX [asm]\n"
+                                  "  Prints the meta data of an object and its subindices.\n"
+                                  "  Options:\n"
+                                  "    asm   Includes application-specific meta data in the output.\n"
+                                  "\n"
+                                  "- read 0xINDEX:Subindex\n"
+                                  "  Reads the data of a subindex and prints it to CLI.\n"
+                                  "  <subindex> shall be provided in decimal format.\n"
+                                  "\n"
+                                  "- write 0xINDEX:Subindex DATA\n"
+                                  "  Writes <DATA> to a subindex. <Subindex> shall be provided in decimal format.\n"
+                                  "\n"
+                                  "  The format of <DATA> must meet the data type of the subindex:\n"
+                                  "  For BOOLEAN: TRUE, FALSE, true, false\n"
+                                  "  For REAL32/64: [+|-]digits[.][digits][(e|E)[+|-]digits]\n"
+                                  "  For VISIBLE_STRING: \"Text...\"\n"
+                                  "  For OCTET_STRING: 5B A3 ... (8bit hex values, separated by spaces)\n"
+                                  "  For UNICODE_STRING: 5B33 A6CF (16bit hex values, separated by spaces)\n"
+                                  "  For BIT1..BIT8: 0, 1, 3, 0x3, 0b11 (unused upper bits must be zero)\n"
+                                  "\n"
+                                  "- caread 0xINDEX [v]\n"
+                                  "  Reads the whole object via complete access and prints the value of each\n"
+                                  "  subindex to CLI.\n"
+                                  "  Options:\n"
+                                  "  v   Verbose output. Prints the data type and name of each subindex in addition\n"
+                                  "      to the data.\n"
+                                  "- cawrite 0xINDEX\n"
+                                  "  Writes the whole object via complete access.\n"
+                                  "  The data that shall be written is entered using an interactive dialog.",
+                                  std::bind(&CLIAdapterBase::CLI_CommandHandler, this,
+                                            std::placeholders::_1, std::placeholders::_2)));
 
   ON_SCOPE_EXIT_DISMISS(undoCMDRegistration);
 }
@@ -177,7 +177,7 @@ void CLIAdapterBase::UnregisterCLICommand(void) noexcept
 {
   try
   {
-    cli.RemoveCommand(cmdName.c_str());
+    cli_.RemoveCommand(cmdName_.c_str());
   }
   catch (...)
   {
@@ -312,16 +312,16 @@ void CLIAdapterBase::CLI_Enumerate(std::string const & restOfLine)
   // ============================================
 
   // query first object
-  auto objPtr = od.GetNextNearestObject(startIdx);
+  auto objPtr = od_.GetNextNearestObject(startIdx);
   if ((!objPtr) || (objPtr->GetIndex() > endIdx))
   {
-    cli.WriteLine("No objects");
+    cli_.WriteLine("No objects");
     return;
   }
 
   do
   {
-    cli.TestTermination();
+    cli_.TestTermination();
 
     uint16_t const index = objPtr->GetIndex();
     if (index > endIdx)
@@ -340,7 +340,7 @@ void CLIAdapterBase::CLI_Enumerate(std::string const & restOfLine)
       << Object::ObjectCodeToString(objCode) << ' '
       << StringComposer::Width(15) << DataTypeToString(dataType) << " \"" << objName << '"';
 
-    cli.WriteLine(s.Get());
+    cli_.WriteLine(s.Get());
 
     ++objPtr;
   }
@@ -384,10 +384,10 @@ void CLIAdapterBase::CLI_Info(std::string const & restOfLine)
   // ============================================
   // Query object
   // ============================================
-  auto objPtr = od.GetObject(idx);
+  auto objPtr = od_.GetObject(idx);
   if (!objPtr)
   {
-    cli.WriteLine("Error: No object with given index");
+    cli_.WriteLine("Error: No object with given index");
     return;
   }
 
@@ -400,7 +400,7 @@ void CLIAdapterBase::CLI_Info(std::string const & restOfLine)
   // -- print info about object --
   sc << "Object " << gpcc::string::ToHex(idx, 4U) << ": " << Object::ObjectCodeToString(objPtr->GetObjectCode())
       << " (" << DataTypeToString(objPtr->GetObjectDataType()) << ") \"" << objPtr->GetObjectName() << '"';
-  cli.WriteLine(sc.Get());
+  cli_.WriteLine(sc.Get());
 
 
   // small tool: Appends info about a subindex to 'sc'
@@ -410,7 +410,7 @@ void CLIAdapterBase::CLI_Info(std::string const & restOfLine)
     size_t  const bytes = s / 8U;
     uint8_t const bits  = s % 8U;
     sc << StringComposer::AlignLeft << StringComposer::Width(15U) << DataTypeToString(objPtr->GetSubIdxDataType(si)) << ' '
-        << StringComposer::Width(attributeStringMaxLength) << AttributesToStringHook(objPtr->GetSubIdxAttributes(si)) << ' '
+        << StringComposer::Width(attributeStringMaxLength_) << AttributesToStringHook(objPtr->GetSubIdxAttributes(si)) << ' '
         << StringComposer::AlignRight << StringComposer::Width(5U) << bytes << '.' << static_cast<uint32_t>(bits)
         << " Byte(s) \"" << objPtr->GetSubIdxName(si) << '"';
   };
@@ -443,14 +443,14 @@ void CLIAdapterBase::CLI_Info(std::string const & restOfLine)
     sc.Clear();
     sc << "  Subindex    " << StringComposer::AlignRight << StringComposer::Width(digitsForSubindices + 2U) << "0: ";
     appendSubIndexInfoToOSS(0U);
-    cli.WriteLine(sc.Get());
+    cli_.WriteLine(sc.Get());
 
     if (maxNbOfSIs > 1U)
     {
       sc.Clear();
       sc << "  Subindex 1.." << static_cast<uint32_t>(maxNbOfSIs - 1U) << ": ";
       appendSubIndexInfoToOSS(1U);
-      cli.WriteLine(sc.Get());
+      cli_.WriteLine(sc.Get());
     }
   }
   else
@@ -476,7 +476,7 @@ void CLIAdapterBase::CLI_Info(std::string const & restOfLine)
         appendAppSpecMetaDataToOSS(i);
       }
 
-      cli.WriteLine(sc.Get());
+      cli_.WriteLine(sc.Get());
     }
   }
 }
@@ -516,10 +516,10 @@ void CLIAdapterBase::CLI_Read(std::string const & restOfLine)
   // ============================================
   // Get object
   // ============================================
-  auto objPtr = od.GetObject(index);
+  auto objPtr = od_.GetObject(index);
   if (!objPtr)
   {
-    cli.WriteLine("Error: No object with given index");
+    cli_.WriteLine("Error: No object with given index");
     return;
   }
 
@@ -530,7 +530,7 @@ void CLIAdapterBase::CLI_Read(std::string const & restOfLine)
   size_t sizeInBit;
   size_t sizeInByte;
   uint8_t* pData = nullptr;
-  ON_SCOPE_EXIT() { delete [] pData; };
+  ON_SCOPE_EXIT(release_pData) { delete [] pData; };
 
   // this will contain the result of the read-access
   SDOAbortCode result;
@@ -539,7 +539,7 @@ void CLIAdapterBase::CLI_Read(std::string const & restOfLine)
   {
     // determine access permissions
     auto const permissions = BeginAccessHook() & Object::attr_ACCESS_RD;
-    ON_SCOPE_EXIT() { EndAccessHook(); };
+    ON_SCOPE_EXIT(invokeEndAccessHook) { EndAccessHook(); };
 
     // lock object's data
     auto locker = objPtr->LockData();
@@ -547,14 +547,14 @@ void CLIAdapterBase::CLI_Read(std::string const & restOfLine)
     // check if the subindex is existing
     if (subIdx >= objPtr->GetNbOfSubIndices())
     {
-      cli.WriteLine("Error: Subindex does not exist");
+      cli_.WriteLine("Error: Subindex does not exist");
       return;
     }
 
     // check if subindex is empty
     if (objPtr->IsSubIndexEmpty(subIdx))
     {
-      cli.WriteLine("Error: Subindex is empty");
+      cli_.WriteLine("Error: Subindex is empty");
       return;
     }
 
@@ -572,7 +572,7 @@ void CLIAdapterBase::CLI_Read(std::string const & restOfLine)
   // check for errors
   if (result != SDOAbortCode::OK)
   {
-    cli.WriteLine(std::string("Read access failed: ") + SDOAbortCodeToDescrString(result));
+    cli_.WriteLine(std::string("Read access failed: ") + SDOAbortCodeToDescrString(result));
     return;
   }
 
@@ -583,7 +583,7 @@ void CLIAdapterBase::CLI_Read(std::string const & restOfLine)
   auto str = CANopenEncodedDataToString(msr, sizeInBit, objPtr->GetSubIdxDataType(subIdx));
   msr.Close();
 
-  cli.WriteLine(str);
+  cli_.WriteLine(str);
 }
 
 /**
@@ -621,10 +621,10 @@ void CLIAdapterBase::CLI_Write(std::string const & restOfLine)
   // ============================================
   // Get object
   // ============================================
-  auto objPtr = od.GetObject(index);
+  auto objPtr = od_.GetObject(index);
   if (!objPtr)
   {
-    cli.WriteLine("Error: No object with given index");
+    cli_.WriteLine("Error: No object with given index");
     return;
   }
 
@@ -658,14 +658,14 @@ void CLIAdapterBase::CLI_Write(std::string const & restOfLine)
     // check if the subindex is existing
     if (subIdx >= objPtr->GetNbOfSubIndices())
     {
-      cli.WriteLine("Error: Subindex exceeds number of subindices");
+      cli_.WriteLine("Error: Subindex exceeds number of subindices");
       return;
     }
 
     // check if subindex is empty
     if (objPtr->IsSubIndexEmpty(subIdx))
     {
-      cli.WriteLine("Error: Subindex is empty");
+      cli_.WriteLine("Error: Subindex is empty");
       return;
     }
 
@@ -679,11 +679,11 @@ void CLIAdapterBase::CLI_Write(std::string const & restOfLine)
   // check for errors
   if (result != SDOAbortCode::OK)
   {
-    cli.WriteLine(std::string("Write access failed: ") + SDOAbortCodeToDescrString(result));
+    cli_.WriteLine(std::string("Write access failed: ") + SDOAbortCodeToDescrString(result));
   }
   else
   {
-    cli.WriteLine("OK");
+    cli_.WriteLine("OK");
   }
 }
 
@@ -719,10 +719,10 @@ void CLIAdapterBase::CLI_CARead(std::string const & restOfLine)
   // ============================================
   // Get object
   // ============================================
-  auto objPtr = od.GetObject(args.GetIndex());
+  auto objPtr = od_.GetObject(args.GetIndex());
   if (!objPtr)
   {
-    cli.WriteLine("Error: No object with given index");
+    cli_.WriteLine("Error: No object with given index");
     return;
   }
 
@@ -733,13 +733,13 @@ void CLIAdapterBase::CLI_CARead(std::string const & restOfLine)
   size_t sizeInBit;
   size_t sizeInByte;
   uint8_t* pData = nullptr;
-  ON_SCOPE_EXIT() { delete [] pData; };
+  ON_SCOPE_EXIT(release_pData) { delete [] pData; };
 
   // read the object
   {
     // determine access permissions
     auto const permissions = BeginAccessHook() & Object::attr_ACCESS_RD;
-    ON_SCOPE_EXIT() { EndAccessHook(); };
+    ON_SCOPE_EXIT(invokeEndAccessHook) { EndAccessHook(); };
 
     // lock object's data
     auto locker = objPtr->LockData();
@@ -756,7 +756,7 @@ void CLIAdapterBase::CLI_CARead(std::string const & restOfLine)
 
     if (result != SDOAbortCode::OK)
     {
-      cli.WriteLine(std::string("Read access failed: ") + SDOAbortCodeToDescrString(result));
+      cli_.WriteLine(std::string("Read access failed: ") + SDOAbortCodeToDescrString(result));
       return;
     }
   }
@@ -787,7 +787,7 @@ void CLIAdapterBase::CLI_CARead(std::string const & restOfLine)
       {
         if (s > 120U)
         {
-          cli.WriteLine("Encountered very large subindex name. Retry command without option 'v'.");
+          cli_.WriteLine("Encountered very large subindex name. Retry command without option 'v'.");
           return;
         }
 
@@ -811,7 +811,7 @@ void CLIAdapterBase::CLI_CARead(std::string const & restOfLine)
       else
         sc << CANopenEncodedDataToString(msr, objPtr->GetSubIdxMaxSize(subIdx), dataType);
 
-      cli.WriteLine(sc.Get());
+      cli_.WriteLine(sc.Get());
     }
   }
   else
@@ -827,7 +827,7 @@ void CLIAdapterBase::CLI_CARead(std::string const & restOfLine)
       else
         sc << CANopenEncodedDataToString(msr, objPtr->GetSubIdxMaxSize(subIdx), objPtr->GetSubIdxDataType(subIdx));
 
-      cli.WriteLine(sc.Get());
+      cli_.WriteLine(sc.Get());
     }
   }
 
@@ -866,10 +866,10 @@ void CLIAdapterBase::CLI_CAWrite(std::string const & restOfLine)
   // ============================================
   // Get object
   // ============================================
-  auto objPtr = od.GetObject(args.GetIndex());
+  auto objPtr = od_.GetObject(args.GetIndex());
   if (!objPtr)
   {
-    cli.WriteLine("Error: No object with given index");
+    cli_.WriteLine("Error: No object with given index");
     return;
   }
 
@@ -879,7 +879,7 @@ void CLIAdapterBase::CLI_CAWrite(std::string const & restOfLine)
   if (   (objPtr->GetObjectCode() != Object::ObjectCode::Array)
       && (objPtr->GetObjectCode() != Object::ObjectCode::Record))
   {
-    cli.WriteLine("Object type not supported.");
+    cli_.WriteLine("Object type not supported.");
     return;
   }
 
@@ -903,7 +903,7 @@ void CLIAdapterBase::CLI_CAWrite(std::string const & restOfLine)
 
     if (result != SDOAbortCode::OK)
     {
-      cli.WriteLine(std::string("Reading SI0 failed: ") + SDOAbortCodeToDescrString(result));
+      cli_.WriteLine(std::string("Reading SI0 failed: ") + SDOAbortCodeToDescrString(result));
       return;
     }
   }
@@ -918,16 +918,16 @@ void CLIAdapterBase::CLI_CAWrite(std::string const & restOfLine)
   {
     if (objPtr->GetObjectCode() != Object::ObjectCode::Array)
     {
-      cli.WriteLine("SI0 is writeable. This is only supported for ARRAY objects.");
+      cli_.WriteLine("SI0 is writeable. This is only supported for ARRAY objects.");
       return;
     }
 
-    cli.WriteLine("Current value of SI0: " + std::to_string(currSI0));
-    newSI0 = gpcc::string::DecimalToU8(cli.ReadLine("New value for SI0: "));
+    cli_.WriteLine("Current value of SI0: " + std::to_string(currSI0));
+    newSI0 = gpcc::string::DecimalToU8(cli_.ReadLine("New value for SI0: "));
 
     if (newSI0 >= objPtr->GetMaxNbOfSubindices())
     {
-      cli.WriteLine("Value for SI0 exceeds maximum number of subindices the object can have.");
+      cli_.WriteLine("Value for SI0 exceeds maximum number of subindices the object can have.");
       return;
     }
   }
@@ -969,14 +969,14 @@ void CLIAdapterBase::CLI_CAWrite(std::string const & restOfLine)
     // skip empty subindices
     if (siSize == 0U)
     {
-      cli.WriteLine("Skipping SI " + std::to_string(subIdx) + " (zero size))");
+      cli_.WriteLine("Skipping SI " + std::to_string(subIdx) + " (zero size))");
       continue;
     }
 
     // gap?
     if (dataType == DataType::null)
     {
-      cli.WriteLine("Skipping SI " + std::to_string(subIdx) + " (gap)");
+      cli_.WriteLine("Skipping SI " + std::to_string(subIdx) + " (gap)");
       msw.FillBits(siSize, false);
       continue;
     }
@@ -990,7 +990,7 @@ void CLIAdapterBase::CLI_CAWrite(std::string const & restOfLine)
     auto const attributes = objPtr->GetSubIdxAttributes(subIdx);
     if ((attributes & Object::attr_ACCESS_WR) == 0U)
     {
-      cli.WriteLine("Skipping SI " + std::to_string(subIdx) + " (pure read-only))");
+      cli_.WriteLine("Skipping SI " + std::to_string(subIdx) + " (pure read-only))");
       msw.FillBits(siSize, false);
       continue;
     }
@@ -1002,9 +1002,9 @@ void CLIAdapterBase::CLI_CAWrite(std::string const & restOfLine)
         << DataTypeToString(dataType) << ", "
         << AttributesToStringHook(objPtr->GetSubIdxAttributes(subIdx)) << ", "
         << bytes << '.' << static_cast<uint32_t>(bits) << " Byte(s), \"" << objPtr->GetSubIdxName(subIdx) << '"';
-    cli.WriteLine(sc.Get());
+    cli_.WriteLine(sc.Get());
 
-    auto val = cli.ReadLine("Value: ");
+    auto val = cli_.ReadLine("Value: ");
 
     switch (dataType)
     {
@@ -1101,8 +1101,8 @@ void CLIAdapterBase::CLI_CAWrite(std::string const & restOfLine)
   // ============================================
   // write
   // ============================================
-  cli.WriteLine("All data entered.");
-  if (cli.ReadLine("Write now? (y/n/Ctrl+C): ") == "y")
+  cli_.WriteLine("All data entered.");
+  if (cli_.ReadLine("Write now? (y/n/Ctrl+C): ") == "y")
   {
     // determine access permissions
     auto const permissions = BeginAccessHook() & Object::attr_ACCESS_WR;
@@ -1132,15 +1132,15 @@ void CLIAdapterBase::CLI_CAWrite(std::string const & restOfLine)
 
     if (result != SDOAbortCode::OK)
     {
-      cli.WriteLine(std::string("Writing object failed: ") + SDOAbortCodeToDescrString(result));
+      cli_.WriteLine(std::string("Writing object failed: ") + SDOAbortCodeToDescrString(result));
       return;
     }
 
-    cli.WriteLine("OK");
+    cli_.WriteLine("OK");
   }
   else
   {
-    cli.WriteLine("Aborted. No data written.");
+    cli_.WriteLine("Aborted. No data written.");
   }
 }
 

--- a/src/cood/data_types.cpp
+++ b/src/cood/data_types.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2018, 2024 Daniel Jerolm
+    Copyright (C) 2018, 2024, 2025 Daniel Jerolm
 */
 
 #include <gpcc/cood/data_types.hpp>
@@ -558,7 +558,7 @@ std::string CANopenEncodedDataToString(gpcc::stream::IStreamReader& sr, size_t c
     {
       float const r32 = sr.Read_float();
       char buf[32];
-      int const status = snprintf(buf, sizeof(buf), "%G", r32);
+      int const status = snprintf(buf, sizeof(buf), "%G", static_cast<double>(r32));
       if ((status < 0) || (static_cast<size_t>(status) > sizeof(buf)))
         throw std::runtime_error("CANopenEncodedDataToString: snprintf failed or requires unexpected buffer size");
 

--- a/src/cood/data_types.cpp
+++ b/src/cood/data_types.cpp
@@ -559,7 +559,7 @@ std::string CANopenEncodedDataToString(gpcc::stream::IStreamReader& sr, size_t c
       float const r32 = sr.Read_float();
       char buf[32];
       int const status = snprintf(buf, sizeof(buf), "%G", static_cast<double>(r32));
-      if ((status < 0) || (static_cast<size_t>(status) > sizeof(buf)))
+      if ((status < 0) || (static_cast<size_t>(status) >= sizeof(buf)))
         throw std::runtime_error("CANopenEncodedDataToString: snprintf failed or requires unexpected buffer size");
 
       return buf;

--- a/src/cood/remote_access/infrastructure/MultiRODACLIClientBase.cpp
+++ b/src/cood/remote_access/infrastructure/MultiRODACLIClientBase.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2021 Daniel Jerolm
+    Copyright (C) 2021, 2025 Daniel Jerolm
 */
 
 #include <gpcc/cood/remote_access/infrastructure/MultiRODACLIClientBase.hpp>
@@ -94,47 +94,47 @@ MultiRODACLIClientBase::MultiRODACLIClientBase(gpcc::cli::CLI & _cli,
 {
   using gpcc::cli::Command;
 
-  cli.AddCommand(Command::Create(cmdName.c_str(), " rodaID subcmd [args...]\n"
-                                 "Accesses the remote object dictionary referenced by <rodaID>. The type of\n"
-                                 "access is specified by <subcmd>:\n"
-                                 "- enum [0xFROM-0xTO]\n"
-                                 "  Enumerates objects contained in the object dictionary.\n"
-                                 "  Options:\n"
-                                 "    FROM   Index where enumeration shall start. Default: 0x0000\n"
-                                 "    TO     Index where enumeration shall end. Default: 0xFFFF\n"
-                                 "    FROM <= TO must be valid.\n"
-                                 "\n"
-                                 "- info 0xINDEX [asm]\n"
-                                 "  Prints the meta data of an object and its subindices.\n"
-                                 "  Options:\n"
-                                 "    asm   Includes application-specific meta data in the output.\n"
-                                 "\n"
-                                 "- read 0xINDEX:Subindex\n"
-                                 "  Reads the data of a subindex and prints it to CLI.\n"
-                                 "  <subindex> shall be provided in decimal format.\n"
-                                 "\n"
-                                 "- write 0xINDEX:Subindex DATA\n"
-                                 "  Writes <DATA> to a subindex. <Subindex> shall be provided in decimal format.\n"
-                                 "\n"
-                                 "  The format of <DATA> must meet the data type of the subindex:\n"
-                                 "  For BOOLEAN: TRUE, FALSE, true, false\n"
-                                 "  For REAL32/64: [+|-]digits[.][digits][(e|E)[+|-]digits]\n"
-                                 "  For VISIBLE_STRING: \"Text...\"\n"
-                                 "  For OCTET_STRING: 5B A3 ... (8bit hex values, separated by spaces)\n"
-                                 "  For UNICODE_STRING: 5B33 A6CF (16bit hex values, separated by spaces)\n"
-                                 "  For BIT1..BIT8: 0, 1, 3, 0x3, 0b11 (unused upper bits must be zero)\n"
-                                 "\n"
-                                 "- caread 0xINDEX [v]\n"
-                                 "  Reads the whole object via complete access and prints the value of each\n"
-                                 "  subindex to CLI.\n"
-                                 "  Options:\n"
-                                 "  v   Verbose output. Prints the data type and name of each subindex in addition\n"
-                                 "      to the data.\n"
-                                 "- cawrite 0xINDEX\n"
-                                 "  Writes the whole object via complete access.\n"
-                                 "  The data that shall be written is entered using an interactive dialog.",
-                                 std::bind(&MultiRODACLIClientBase::CLICommandHandler, this,
-                                           std::placeholders::_1, std::placeholders::_2)));
+  cli_.AddCommand(Command::Create(cmdName.c_str(), " rodaID subcmd [args...]\n"
+                                  "Accesses the remote object dictionary referenced by <rodaID>. The type of\n"
+                                  "access is specified by <subcmd>:\n"
+                                  "- enum [0xFROM-0xTO]\n"
+                                  "  Enumerates objects contained in the object dictionary.\n"
+                                  "  Options:\n"
+                                  "    FROM   Index where enumeration shall start. Default: 0x0000\n"
+                                  "    TO     Index where enumeration shall end. Default: 0xFFFF\n"
+                                  "    FROM <= TO must be valid.\n"
+                                  "\n"
+                                  "- info 0xINDEX [asm]\n"
+                                  "  Prints the meta data of an object and its subindices.\n"
+                                  "  Options:\n"
+                                  "    asm   Includes application-specific meta data in the output.\n"
+                                  "\n"
+                                  "- read 0xINDEX:Subindex\n"
+                                  "  Reads the data of a subindex and prints it to CLI.\n"
+                                  "  <subindex> shall be provided in decimal format.\n"
+                                  "\n"
+                                  "- write 0xINDEX:Subindex DATA\n"
+                                  "  Writes <DATA> to a subindex. <Subindex> shall be provided in decimal format.\n"
+                                  "\n"
+                                  "  The format of <DATA> must meet the data type of the subindex:\n"
+                                  "  For BOOLEAN: TRUE, FALSE, true, false\n"
+                                  "  For REAL32/64: [+|-]digits[.][digits][(e|E)[+|-]digits]\n"
+                                  "  For VISIBLE_STRING: \"Text...\"\n"
+                                  "  For OCTET_STRING: 5B A3 ... (8bit hex values, separated by spaces)\n"
+                                  "  For UNICODE_STRING: 5B33 A6CF (16bit hex values, separated by spaces)\n"
+                                  "  For BIT1..BIT8: 0, 1, 3, 0x3, 0b11 (unused upper bits must be zero)\n"
+                                  "\n"
+                                  "- caread 0xINDEX [v]\n"
+                                  "  Reads the whole object via complete access and prints the value of each\n"
+                                  "  subindex to CLI.\n"
+                                  "  Options:\n"
+                                  "  v   Verbose output. Prints the data type and name of each subindex in addition\n"
+                                  "      to the data.\n"
+                                  "- cawrite 0xINDEX\n"
+                                  "  Writes the whole object via complete access.\n"
+                                  "  The data that shall be written is entered using an interactive dialog.",
+                                  std::bind(&MultiRODACLIClientBase::CLICommandHandler, this,
+                                            std::placeholders::_1, std::placeholders::_2)));
 }
 
 /**
@@ -156,7 +156,7 @@ MultiRODACLIClientBase::~MultiRODACLIClientBase(void)
 {
   try
   {
-    cli.RemoveCommand(cmdName.c_str());
+    cli_.RemoveCommand(cmdName.c_str());
 
     gpcc::osal::MutexLocker rodaItfMutexLocker(rodaItfMutex);
     if (!registeredRODAItfs.empty())

--- a/src/cood/remote_access/infrastructure/Multiplexer.cpp
+++ b/src/cood/remote_access/infrastructure/Multiplexer.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2021 Daniel Jerolm
+    Copyright (C) 2021, 2025 Daniel Jerolm
 */
 
 #include <gpcc/cood/remote_access/infrastructure/Multiplexer.hpp>
@@ -23,13 +23,13 @@
 namespace gpcc {
 namespace cood {
 
-size_t constexpr Multiplexer::maxNbOfPorts;
+size_t constexpr Multiplexer::maxNbOfPorts_;
 
 /**
  * \brief Constructor.
  *
  * The created @ref Multiplexer instance has no exposed ports (RODA interfaces) yet. Use @ref CreatePort() to
- * create ports providing a RODA interfaces.
+ * create ports providing RODA interfaces.
  *
  * The created @ref Multiplexer instance is not connected to a RODA interface yet. Use @ref Connect() to connect
  * the multiplexer to an existing RODA interface.
@@ -44,21 +44,21 @@ size_t constexpr Multiplexer::maxNbOfPorts;
  */
 Multiplexer::Multiplexer(void)
 : IRemoteObjectDictionaryAccessNotifiable()
-, ownerID(0U)
-, connectMutex()
-, muxMutex()
-, portMutex()
-, state(States::notConnected)
-, pRODA(nullptr)
-, maxRequestSize(0U)
-, maxResponseSize(0U)
-, ports()
+, ownerID_(0U)
+, connectMutex_()
+, muxMutex_()
+, portMutex_()
+, state_(States::notConnected)
+, pRODA_(nullptr)
+, maxRequestSize_(0U)
+, maxResponseSize_(0U)
+, ports_()
 {
   auto const uipThis = reinterpret_cast<uintptr_t>(this);
   #if UINTPTR_WIDTH == UINT32_WIDTH
-    ownerID = static_cast<uint32_t>(uipThis);
+    ownerID_ = static_cast<uint32_t>(uipThis);
   #else
-    ownerID = (static_cast<uint32_t>(uipThis)) ^ (static_cast<uint32_t>(uipThis >> 32U));
+    ownerID_ = (static_cast<uint32_t>(uipThis)) ^ (static_cast<uint32_t>(uipThis >> 32U));
   #endif
 }
 
@@ -80,12 +80,12 @@ Multiplexer::Multiplexer(void)
  */
 Multiplexer::~Multiplexer(void)
 {
-  gpcc::osal::MutexLocker muxMutexLocker(muxMutex);
+  gpcc::osal::MutexLocker muxMutexLocker(muxMutex_);
 
-  if (state != States::notConnected)
+  if (state_ != States::notConnected)
     gpcc::osal::Panic("Multiplexer::~Multiplexer: Still connected to a RODA interface.");
 
-  for (auto const & spPort : ports)
+  for (auto const & spPort : ports_)
   {
     if (spPort.use_count() != 1U)
       gpcc::osal::Panic("Multiplexer::~Multiplexer: Port still referenced by someone.");
@@ -119,28 +119,28 @@ Multiplexer::~Multiplexer(void)
  */
 void Multiplexer::Connect(IRemoteObjectDictionaryAccess & roda)
 {
-  gpcc::osal::MutexLocker connectMutexLocker(connectMutex);
+  gpcc::osal::MutexLocker connectMutexLocker(connectMutex_);
 
   {
-    gpcc::osal::MutexLocker muxMutexLocker(muxMutex);
+    gpcc::osal::MutexLocker muxMutexLocker(muxMutex_);
 
-    if (state != States::notConnected)
+    if (state_ != States::notConnected)
       throw std::logic_error("Multiplexer::Connect: Already connected.");
 
-    gpcc::osal::MutexLocker portMutexLocker(portMutex);
-    state = States::notReady;
-    pRODA = &roda;
+    gpcc::osal::MutexLocker portMutexLocker(portMutex_);
+    state_ = States::notReady;
+    pRODA_ = &roda;
   }
 
   ON_SCOPE_EXIT(undo)
   {
-    gpcc::osal::MutexLocker muxMutexLocker(muxMutex);
-    gpcc::osal::MutexLocker portMutexLocker(portMutex);
-    pRODA = nullptr;
-    state = States::notConnected;
+    gpcc::osal::MutexLocker muxMutexLocker(muxMutex_);
+    gpcc::osal::MutexLocker portMutexLocker(portMutex_);
+    pRODA_ = nullptr;
+    state_ = States::notConnected;
   };
 
-  pRODA->Register(this);
+  pRODA_->Register(this);
 
   ON_SCOPE_EXIT_DISMISS(undo);
 }
@@ -173,56 +173,56 @@ void Multiplexer::Connect(IRemoteObjectDictionaryAccess & roda)
  */
 void Multiplexer::Disconnect(void) noexcept
 {
-  gpcc::osal::MutexLocker connectMutexLocker(connectMutex);
+  gpcc::osal::MutexLocker connectMutexLocker(connectMutex_);
 
-  gpcc::osal::AdvancedMutexLocker muxMutexLocker(muxMutex);
+  gpcc::osal::AdvancedMutexLocker muxMutexLocker(muxMutex_);
 
   // not connected -> no effect
-  if (state == States::notConnected)
+  if (state_ == States::notConnected)
     return;
 
   // sanity check
-  if (state == States::disconnecting)
+  if (state_ == States::disconnecting)
     PANIC();
 
   // Start disconnection process.
   // From now on all notifications received via the multiplexer's RODAN interface will be ignored.
   // In particular response messages will not be delivered any more.
   {
-    gpcc::osal::MutexLocker portMutexLocker(portMutex);
-    state = States::disconnecting;
+    gpcc::osal::MutexLocker portMutexLocker(portMutex_);
+    state_ = States::disconnecting;
   }
 
   // switch ports to "not ready" if required and forget about old session IDs
-  for (auto const & spPort : ports)
+  for (auto const & spPort : ports_)
   {
-    if (spPort->state == MultiplexerPort::States::ready)
+    if (spPort->state_ == MultiplexerPort::States::ready)
     {
       {
-        gpcc::osal::MutexLocker portMutexLocker(portMutex);
-        spPort->state = MultiplexerPort::States::notReady;
-        spPort->execContextRequested = false;
-        spPort->oldestUsedSessionID = spPort->sessionID;
+        gpcc::osal::MutexLocker portMutexLocker(portMutex_);
+        spPort->state_ = MultiplexerPort::States::notReady;
+        spPort->execContextRequested_ = false;
+        spPort->oldestUsedSessionID_ = spPort->sessionID_;
       }
-      spPort->pRODAN->OnDisconnected();
+      spPort->pRODAN_->OnDisconnected();
     }
     else
     {
-      gpcc::osal::MutexLocker portMutexLocker(portMutex);
-      spPort->oldestUsedSessionID = spPort->sessionID;
+      gpcc::osal::MutexLocker portMutexLocker(portMutex_);
+      spPort->oldestUsedSessionID_ = spPort->sessionID_;
     }
   }
 
-  // muxMutex must be unlocked, because Unregister() blocks until potential ongoing calls to the RODAN interface
+  // muxMutex_ must be unlocked, because Unregister() blocks until potential ongoing calls to the RODAN interface
   // exposed by the multiplexer have completed.
   muxMutexLocker.Unlock();
-  pRODA->Unregister();
+  pRODA_->Unregister();
   muxMutexLocker.Relock();
 
   // finish disconnection
-  gpcc::osal::MutexLocker portMutexLocker(portMutex);
-  pRODA = nullptr;
-  state = States::notConnected;
+  gpcc::osal::MutexLocker portMutexLocker(portMutex_);
+  pRODA_ = nullptr;
+  state_ = States::notConnected;
 }
 
 /**
@@ -231,7 +231,7 @@ void Multiplexer::Disconnect(void) noexcept
  * Under the hood, unused ports whose shared_ptr has been dropped by the user will be recycled before new ones are
  * created.
  *
- * \pre   There are less than @ref maxNbOfPorts in use.
+ * \pre   There are less than @ref maxNbOfPorts_ in use.
  *
  * - - -
  *
@@ -243,7 +243,7 @@ void Multiplexer::Disconnect(void) noexcept
  *
  * \throws std::bad_alloc       Out of memory.
  *
- * \throws std::runtime_error   @ref maxNbOfPorts ports are already in use.
+ * \throws std::runtime_error   @ref maxNbOfPorts_ ports are already in use.
  *
  * __Thread cancellation safety:__\n
  * No cancellation point included.
@@ -258,26 +258,26 @@ void Multiplexer::Disconnect(void) noexcept
  */
 std::shared_ptr<MultiplexerPort> Multiplexer::CreatePort(void)
 {
-  gpcc::osal::MutexLocker muxMutexLocker(muxMutex);
-  gpcc::osal::MutexLocker portMutexLocker(portMutex);
+  gpcc::osal::MutexLocker muxMutexLocker(muxMutex_);
+  gpcc::osal::MutexLocker portMutexLocker(portMutex_);
 
   // look for an unused port
-  for (auto const & spPort : ports)
+  for (auto const & spPort : ports_)
   {
     if (spPort.use_count() == 1U)
     {
-      if (spPort->state != MultiplexerPort::States::noClientRegistered)
+      if (spPort->state_ != MultiplexerPort::States::noClientRegistered)
         gpcc::osal::Panic("Multiplexer::CreatePort: Dropped port has still a RODAN interface registered.");
 
       return spPort;
     }
   }
 
-  if (ports.size() == maxNbOfPorts)
+  if (ports_.size() == maxNbOfPorts_)
     throw std::runtime_error("Multiplexer::CreatePort: Maximum number of ports reached.");
 
-  ports.emplace_back(std::make_shared<MultiplexerPort>(*this, ports.size()));
-  return ports.back();
+  ports_.emplace_back(std::make_shared<MultiplexerPort>(*this, ports_.size()));
+  return ports_.back();
 }
 
 // <-- IRemoteObjectDictionaryAccessNotifiable
@@ -285,9 +285,9 @@ std::shared_ptr<MultiplexerPort> Multiplexer::CreatePort(void)
 /// \copydoc gpcc::cood::IRemoteObjectDictionaryAccessNotifiable::OnReady
 void Multiplexer::OnReady(size_t const maxRequestSize, size_t const maxResponseSize) noexcept
 {
-  gpcc::osal::MutexLocker muxMutexLocker(muxMutex);
+  gpcc::osal::MutexLocker muxMutexLocker(muxMutex_);
 
-  switch (state)
+  switch (state_)
   {
     case States::notConnected:
       gpcc::osal::Panic("Multiplexer::OnReady: Not connected to any RODA interface.");
@@ -305,32 +305,32 @@ void Multiplexer::OnReady(size_t const maxRequestSize, size_t const maxResponseS
 
   // switch mutiplexer to "ready"
   {
-    gpcc::osal::MutexLocker portMutexLocker(portMutex);
+    gpcc::osal::MutexLocker portMutexLocker(portMutex_);
 
     if (maxRequestSize < (RequestBase::minimumUsefulRequestSize + ReturnStackItem::binarySize))
-      this->maxRequestSize = 0U;
+      this->maxRequestSize_ = 0U;
     else
-      this->maxRequestSize = maxRequestSize - ReturnStackItem::binarySize;
+      this->maxRequestSize_ = maxRequestSize - ReturnStackItem::binarySize;
 
     if (maxResponseSize < (ResponseBase::minimumUsefulResponseSize + ReturnStackItem::binarySize))
-      this->maxResponseSize = 0U;
+      this->maxResponseSize_ = 0U;
     else
-      this->maxResponseSize = maxResponseSize - ReturnStackItem::binarySize;
+      this->maxResponseSize_ = maxResponseSize - ReturnStackItem::binarySize;
 
-    state = States::ready;
+    state_ = States::ready;
   }
 
   // switch ports to "ready"
-  for (auto const & spPort : ports)
+  for (auto const & spPort : ports_)
   {
-    if (spPort->state == MultiplexerPort::States::notReady)
+    if (spPort->state_ == MultiplexerPort::States::notReady)
     {
       {
-        gpcc::osal::MutexLocker portMutexLocker(portMutex);
-        spPort->state = MultiplexerPort::States::ready;
+        gpcc::osal::MutexLocker portMutexLocker(portMutex_);
+        spPort->state_ = MultiplexerPort::States::ready;
       }
 
-      spPort->pRODAN->OnReady(this->maxRequestSize, this->maxResponseSize);
+      spPort->pRODAN_->OnReady(this->maxRequestSize_, this->maxResponseSize_);
     }
   }
 }
@@ -338,9 +338,9 @@ void Multiplexer::OnReady(size_t const maxRequestSize, size_t const maxResponseS
 /// \copydoc gpcc::cood::IRemoteObjectDictionaryAccessNotifiable::OnDisconnected
 void Multiplexer::OnDisconnected(void) noexcept
 {
-  gpcc::osal::MutexLocker muxMutexLocker(muxMutex);
+  gpcc::osal::MutexLocker muxMutexLocker(muxMutex_);
 
-  switch (state)
+  switch (state_)
   {
     case States::notConnected:
       gpcc::osal::Panic("Multiplexer::OnDisconnected: Not connected to any RODA interface.");
@@ -358,28 +358,28 @@ void Multiplexer::OnDisconnected(void) noexcept
 
   // switch multiplexer to "not ready"
   {
-    gpcc::osal::MutexLocker portMutexLocker(portMutex);
-    state = States::notReady;
+    gpcc::osal::MutexLocker portMutexLocker(portMutex_);
+    state_ = States::notReady;
   }
 
   // switch ports to "not ready" and reset sessionID
-  for (auto const & spPort : ports)
+  for (auto const & spPort : ports_)
   {
-    if (spPort->state == MultiplexerPort::States::ready)
+    if (spPort->state_ == MultiplexerPort::States::ready)
     {
       {
-        gpcc::osal::MutexLocker portMutexLocker(portMutex);
-        spPort->state = MultiplexerPort::States::notReady;
-        spPort->execContextRequested = false;
-        spPort->oldestUsedSessionID = spPort->sessionID;
+        gpcc::osal::MutexLocker portMutexLocker(portMutex_);
+        spPort->state_ = MultiplexerPort::States::notReady;
+        spPort->execContextRequested_ = false;
+        spPort->oldestUsedSessionID_ = spPort->sessionID_;
       }
 
-      spPort->pRODAN->OnDisconnected();
+      spPort->pRODAN_->OnDisconnected();
     }
     else
     {
-      gpcc::osal::MutexLocker portMutexLocker(portMutex);
-      spPort->oldestUsedSessionID = spPort->sessionID;
+      gpcc::osal::MutexLocker portMutexLocker(portMutex_);
+      spPort->oldestUsedSessionID_ = spPort->sessionID_;
     }
   }
 }
@@ -387,9 +387,9 @@ void Multiplexer::OnDisconnected(void) noexcept
 /// \copydoc gpcc::cood::IRemoteObjectDictionaryAccessNotifiable::OnRequestProcessed
 void Multiplexer::OnRequestProcessed(std::unique_ptr<ResponseBase> spResponse) noexcept
 {
-  gpcc::osal::MutexLocker muxMutexLocker(muxMutex);
+  gpcc::osal::MutexLocker muxMutexLocker(muxMutex_);
 
-  switch (state)
+  switch (state_)
   {
     case States::notConnected:
       gpcc::osal::Panic("Multiplexer::OnRequestProcessed: Not connected to any RODA interface.");
@@ -419,7 +419,7 @@ void Multiplexer::OnRequestProcessed(std::unique_ptr<ResponseBase> spResponse) n
 
   auto const rsi = spResponse->PopReturnStack();
 
-  if (rsi.GetID() != ownerID)
+  if (rsi.GetID() != ownerID_)
     return;
 
   // extract our information from the return stack item
@@ -432,15 +432,15 @@ void Multiplexer::OnRequestProcessed(std::unique_ptr<ResponseBase> spResponse) n
   if (gap != 0U)
     return;
 
-  if (index >= ports.size())
+  if (index >= ports_.size())
     return;
 
-  auto & spPort = ports[index];
+  auto & spPort = ports_[index];
 
   if (!myPing)
   {
-    if ((spPort->state == MultiplexerPort::States::ready) && (spPort->sessionID == sessionID))
-      spPort->pRODAN->OnRequestProcessed(std::move(spResponse));
+    if ((spPort->state_ == MultiplexerPort::States::ready) && (spPort->sessionID_ == sessionID))
+      spPort->pRODAN_->OnRequestProcessed(std::move(spResponse));
   }
   else
   {
@@ -451,20 +451,20 @@ void Multiplexer::OnRequestProcessed(std::unique_ptr<ResponseBase> spResponse) n
     if (!spResponse->IsReturnStackEmpty())
       return;
 
-    if (spPort->sessionID != sessionID)
+    if (spPort->sessionID_ != sessionID)
       return;
 
-    gpcc::osal::MutexLocker portMutexLocker(portMutex);
-    spPort->oldestUsedSessionID = spPort->sessionID;
+    gpcc::osal::MutexLocker portMutexLocker(portMutex_);
+    spPort->oldestUsedSessionID_ = spPort->sessionID_;
   }
 }
 
 /// \copydoc gpcc::cood::IRemoteObjectDictionaryAccessNotifiable::LoanExecutionContext
 void Multiplexer::LoanExecutionContext(void) noexcept
 {
-  gpcc::osal::MutexLocker muxMutexLocker(muxMutex);
+  gpcc::osal::MutexLocker muxMutexLocker(muxMutex_);
 
-  switch (state)
+  switch (state_)
   {
     case States::notConnected:
       gpcc::osal::Panic("Multiplexer::LoanExecutionContext: Not connected to any RODA interface.");
@@ -484,28 +484,28 @@ void Multiplexer::LoanExecutionContext(void) noexcept
   // - If any port is in state "not ready", then we will switch it to "ready".
   // - If a port is "ready", then we check if it has a pending request for a call to client's LoanExecutionContext()
   //   method, and -if so- we will serve the request.
-  for (auto const & spPort : ports)
+  for (auto const & spPort : ports_)
   {
-    if (spPort->state == MultiplexerPort::States::notReady)
+    if (spPort->state_ == MultiplexerPort::States::notReady)
     {
       {
-        gpcc::osal::MutexLocker portMutexLocker(portMutex);
-        spPort->state = MultiplexerPort::States::ready;
+        gpcc::osal::MutexLocker portMutexLocker(portMutex_);
+        spPort->state_ = MultiplexerPort::States::ready;
       }
 
-      spPort->pRODAN->OnReady(this->maxRequestSize, this->maxResponseSize);
+      spPort->pRODAN_->OnReady(this->maxRequestSize_, this->maxResponseSize_);
     }
-    else if (spPort->state == MultiplexerPort::States::ready)
+    else if (spPort->state_ == MultiplexerPort::States::ready)
     {
       {
-        gpcc::osal::MutexLocker portMutexLocker(portMutex);
-        if (!spPort->execContextRequested)
+        gpcc::osal::MutexLocker portMutexLocker(portMutex_);
+        if (!spPort->execContextRequested_)
           continue;
 
-        spPort->execContextRequested = false;
+        spPort->execContextRequested_ = false;
       }
 
-      spPort->pRODAN->LoanExecutionContext();
+      spPort->pRODAN_->LoanExecutionContext();
     }
     else
     {

--- a/src/cood/remote_access/infrastructure/Multiplexer.cpp
+++ b/src/cood/remote_access/infrastructure/Multiplexer.cpp
@@ -23,7 +23,7 @@
 namespace gpcc {
 namespace cood {
 
-size_t constexpr Multiplexer::maxNbOfPorts_;
+size_t constexpr Multiplexer::maxNbOfPorts;
 
 /**
  * \brief Constructor.
@@ -231,7 +231,7 @@ void Multiplexer::Disconnect(void) noexcept
  * Under the hood, unused ports whose shared_ptr has been dropped by the user will be recycled before new ones are
  * created.
  *
- * \pre   There are less than @ref maxNbOfPorts_ in use.
+ * \pre   There are less than @ref maxNbOfPorts in use.
  *
  * - - -
  *
@@ -243,7 +243,7 @@ void Multiplexer::Disconnect(void) noexcept
  *
  * \throws std::bad_alloc       Out of memory.
  *
- * \throws std::runtime_error   @ref maxNbOfPorts_ ports are already in use.
+ * \throws std::runtime_error   @ref maxNbOfPorts ports are already in use.
  *
  * __Thread cancellation safety:__\n
  * No cancellation point included.
@@ -273,7 +273,7 @@ std::shared_ptr<MultiplexerPort> Multiplexer::CreatePort(void)
     }
   }
 
-  if (ports_.size() == maxNbOfPorts_)
+  if (ports_.size() == maxNbOfPorts)
     throw std::runtime_error("Multiplexer::CreatePort: Maximum number of ports reached.");
 
   ports_.emplace_back(std::make_shared<MultiplexerPort>(*this, ports_.size()));

--- a/src/cood/remote_access/infrastructure/MultiplexerPort.cpp
+++ b/src/cood/remote_access/infrastructure/MultiplexerPort.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2021 Daniel Jerolm
+    Copyright (C) 2021, 2025 Daniel Jerolm
 */
 
 #include <gpcc/cood/remote_access/infrastructure/MultiplexerPort.hpp>
@@ -36,22 +36,22 @@ namespace cood {
  *
  * - - -
  *
- * \param _owner
+ * \param owner
  * Reference to the @ref Multiplexer instance which is the owner of the new port instance.
  *
- * \param _index
- * Index of the new port instance in `_owner.ports`.
+ * \param index
+ * Index of the new port instance in `owner.ports`.
  */
-MultiplexerPort::MultiplexerPort(Multiplexer & _owner, uint8_t const _index) noexcept
+MultiplexerPort::MultiplexerPort(Multiplexer & owner, uint8_t const index) noexcept
 : IRemoteObjectDictionaryAccess()
-, owner(_owner)
-, index(_index)
-, state(States::noClientRegistered)
-, pRODAN(nullptr)
-, sessionID(0U)
-, oldestUsedSessionID(0U)
-, sessionIDUsed(false)
-, execContextRequested(false)
+, owner_(owner)
+, index_(index)
+, state_(States::noClientRegistered)
+, pRODAN_(nullptr)
+, sessionID_(0U)
+, oldestUsedSessionID_(0U)
+, sessionIDUsed_(false)
+, execContextRequested_(false)
 {
 }
 
@@ -71,9 +71,9 @@ MultiplexerPort::MultiplexerPort(Multiplexer & _owner, uint8_t const _index) noe
  */
 MultiplexerPort::~MultiplexerPort(void)
 {
-  gpcc::osal::MutexLocker portMutexLocker(owner.portMutex);
+  gpcc::osal::MutexLocker portMutexLocker(owner_.portMutex_);
 
-  if (state != States::noClientRegistered)
+  if (state_ != States::noClientRegistered)
     gpcc::osal::Panic("MultiplexerPort::~MultiplexerPort: Client still registered.");
 }
 
@@ -98,8 +98,8 @@ MultiplexerPort::~MultiplexerPort(void)
  */
 bool MultiplexerPort::IsClientRegistered(void) const noexcept
 {
-  gpcc::osal::MutexLocker portMutexLocker(owner.portMutex);
-  return (state != States::noClientRegistered);
+  gpcc::osal::MutexLocker portMutexLocker(owner_.portMutex_);
+  return (state_ != States::noClientRegistered);
 }
 
 // <-- IRemoteObjectDictionaryAccess
@@ -110,69 +110,69 @@ void MultiplexerPort::Register(IRemoteObjectDictionaryAccessNotifiable * const p
   if (pNotifiable == nullptr)
     throw std::invalid_argument("MultiplexerPort::Register: !pNotifiable");
 
-  gpcc::osal::MutexLocker muxMutexLocker(owner.muxMutex);
+  gpcc::osal::MutexLocker muxMutexLocker(owner_.muxMutex_);
 
-  if (state != States::noClientRegistered)
+  if (state_ != States::noClientRegistered)
     throw std::logic_error("MultiplexerPort::Register: A client is already registered.");
 
   // determine potential next session ID
-  uint8_t const nextSessionID = sessionID + 1U;
-  if (nextSessionID == oldestUsedSessionID)
+  uint8_t const nextSessionID = sessionID_ + 1U;
+  if (nextSessionID == oldestUsedSessionID_)
     throw std::runtime_error("MultiplexerPort::Register: No unused session ID available.");
 
-  gpcc::osal::MutexLocker portMutexLocker(owner.portMutex);
+  gpcc::osal::MutexLocker portMutexLocker(owner_.portMutex_);
 
-  if (owner.state == Multiplexer::States::ready)
+  if (owner_.state_ == Multiplexer::States::ready)
   {
-    if (owner.pRODA == nullptr)
+    if (owner_.pRODA_ == nullptr)
       PANIC();
 
     try
     {
       // request execution context for invocation of client's OnReady()-method
-      owner.pRODA->RequestExecutionContext();
+      owner_.pRODA_->RequestExecutionContext();
 
       // send a ping if there are used session IDs
-      if (sessionIDUsed)
+      if (sessionIDUsed_)
       {
-        std::unique_ptr<RequestBase> spPing = std::make_unique<PingRequest>(owner.maxResponseSize);
-        spPing->Push(ReturnStackItem(owner.ownerID, (static_cast<uint32_t>(index) << 24U) |
+        std::unique_ptr<RequestBase> spPing = std::make_unique<PingRequest>(owner_.maxResponseSize_);
+        spPing->Push(ReturnStackItem(owner_.ownerID_, (static_cast<uint32_t>(index_) << 24U) |
                                                      0x00800000UL |
                                                      nextSessionID));
-        owner.pRODA->Send(spPing);
+        owner_.pRODA_->Send(spPing);
       }
     }
     catch (RemoteAccessServerNotReadyError const &)
     {
-      // Ignored by intention. The owner of this port will receive an OnDisconnected()-notification soon.
+      // Ignored by intention. The owner_ of this port will receive an OnDisconnected()-notification soon.
     }
   }
 
   // start using new session ID if necessary
-  if (sessionIDUsed)
+  if (sessionIDUsed_)
   {
-    sessionID = nextSessionID;
-    sessionIDUsed = false;
+    sessionID_ = nextSessionID;
+    sessionIDUsed_ = false;
   }
 
-  state = States::notReady;
-  pRODAN = pNotifiable;
+  state_ = States::notReady;
+  pRODAN_ = pNotifiable;
 }
 
 /// \copydoc gpcc::cood::IRemoteObjectDictionaryAccess::Unregister
 void MultiplexerPort::Unregister(void) noexcept
 {
-  gpcc::osal::MutexLocker muxMutexLocker(owner.muxMutex);
+  gpcc::osal::MutexLocker muxMutexLocker(owner_.muxMutex_);
 
   // no client registered -> no effect
-  if (state == States::noClientRegistered)
+  if (state_ == States::noClientRegistered)
     return;
 
-  gpcc::osal::MutexLocker portMutexLocker(owner.portMutex);
+  gpcc::osal::MutexLocker portMutexLocker(owner_.portMutex_);
 
-  state = States::noClientRegistered;
-  pRODAN = nullptr;
-  execContextRequested = false;
+  state_ = States::noClientRegistered;
+  pRODAN_ = nullptr;
+  execContextRequested_ = false;
 }
 
 /// \copydoc gpcc::cood::IRemoteObjectDictionaryAccess::Send
@@ -181,9 +181,9 @@ void MultiplexerPort::Send(std::unique_ptr<RequestBase> & spReq)
   if (!spReq)
     throw std::invalid_argument("MultiplexerPort::Send: !spReq");
 
-  gpcc::osal::MutexLocker portMutexLocker(owner.portMutex);
+  gpcc::osal::MutexLocker portMutexLocker(owner_.portMutex_);
 
-  switch (state)
+  switch (state_)
   {
     case States::noClientRegistered:
       throw std::logic_error("MultiplexerPort::Send: No client registered");
@@ -195,10 +195,10 @@ void MultiplexerPort::Send(std::unique_ptr<RequestBase> & spReq)
       break;
   }
 
-  if (owner.pRODA == nullptr)
+  if (owner_.pRODA_ == nullptr)
     PANIC();
 
-  spReq->Push(ReturnStackItem(owner.ownerID, (static_cast<uint32_t>(index) << 24U) | sessionID));
+  spReq->Push(ReturnStackItem(owner_.ownerID_, (static_cast<uint32_t>(index_) << 24U) | sessionID_));
   ON_SCOPE_EXIT(recoverRSI)
   {
     // sanity check: Server shall not consume request in case of an error
@@ -208,18 +208,18 @@ void MultiplexerPort::Send(std::unique_ptr<RequestBase> & spReq)
     spReq->UndoPush();
   };
 
-  owner.pRODA->Send(spReq);
+  owner_.pRODA_->Send(spReq);
 
   ON_SCOPE_EXIT_DISMISS(recoverRSI);
-  sessionIDUsed = true;
+  sessionIDUsed_ = true;
 }
 
 /// \copydoc gpcc::cood::IRemoteObjectDictionaryAccess::RequestExecutionContext
 void MultiplexerPort::RequestExecutionContext(void)
 {
-  gpcc::osal::MutexLocker portMutexLocker(owner.portMutex);
+  gpcc::osal::MutexLocker portMutexLocker(owner_.portMutex_);
 
-  switch (state)
+  switch (state_)
   {
     case States::noClientRegistered:
       throw std::logic_error("MultiplexerPort::RequestExecutionContext: No client registered");
@@ -231,11 +231,11 @@ void MultiplexerPort::RequestExecutionContext(void)
       break;
   }
 
-  if (owner.pRODA == nullptr)
+  if (owner_.pRODA_ == nullptr)
     PANIC();
 
-  owner.pRODA->RequestExecutionContext();
-  execContextRequested = true;
+  owner_.pRODA_->RequestExecutionContext();
+  execContextRequested_ = true;
 }
 
 // --> IRemoteObjectDictionaryAccess

--- a/src/cood/remote_access/infrastructure/RODACLIClientBase.cpp
+++ b/src/cood/remote_access/infrastructure/RODACLIClientBase.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2021, 2024 Daniel Jerolm
+    Copyright (C) 2021, 2024, 2025 Daniel Jerolm
 */
 
 #include <gpcc/cood/remote_access/infrastructure/RODACLIClientBase.hpp>
@@ -43,7 +43,7 @@
 namespace gpcc {
 namespace cood {
 
-uint16_t constexpr RODACLIClientBase::rxTimeout_ms;
+uint16_t constexpr RODACLIClientBase::rxTimeout_ms_;
 
 /**
  * \brief Constructor.
@@ -58,34 +58,34 @@ uint16_t constexpr RODACLIClientBase::rxTimeout_ms;
  *
  * - - -
  *
- * \param _cli
+ * \param cli
  * CLI where the CLI command will be registered by the derived class.
  *
- * \param _attributeStringMaxLength
+ * \param attributeStringMaxLength
  * Maximum length of any string that could be returned by @ref AttributesToStringHook().
  */
-RODACLIClientBase::RODACLIClientBase(gpcc::cli::CLI & _cli, uint8_t const _attributeStringMaxLength)
+RODACLIClientBase::RODACLIClientBase(gpcc::cli::CLI & cli, uint8_t const attributeStringMaxLength)
 : IRemoteObjectDictionaryAccessNotifiable()
-, cli(_cli)
-, attributeStringMaxLength(_attributeStringMaxLength)
-, ownerID(0U)
-, connectMutex()
-, internalMutex()
-, state(States::notRegistered)
-, pRODA(nullptr)
-, maxRequestSize(0U)
-, maxResponseSize(0U)
-, sessionCnt(0U)
-, spReceivedResponse()
-, receiveOverflow(false)
-, respReceivedConVar()
-, stateChangeConVar()
+, cli_(cli)
+, attributeStringMaxLength_(attributeStringMaxLength)
+, ownerID_(0U)
+, connectMutex_()
+, internalMutex_()
+, state_(States::notRegistered)
+, pRODA_(nullptr)
+, maxRequestSize_(0U)
+, maxResponseSize_(0U)
+, sessionCnt_(0U)
+, spReceivedResponse_()
+, receiveOverflow_(false)
+, respReceivedConVar_()
+, stateChangeConVar_()
 {
   auto const uipThis = reinterpret_cast<uintptr_t>(this);
   #if UINTPTR_MAX == 0xFFFFFFFFUL
-    ownerID = static_cast<uint32_t>(uipThis);
+    ownerID_ = static_cast<uint32_t>(uipThis);
   #elif UINTPTR_MAX == 0xFFFFFFFFFFFFFFFFULL
-    ownerID = (static_cast<uint32_t>(uipThis)) ^ (static_cast<uint32_t>(uipThis >> 32U));
+    ownerID_ = (static_cast<uint32_t>(uipThis)) ^ (static_cast<uint32_t>(uipThis >> 32U));
   #else
     #error "Cannot determine pointer size."
   #endif
@@ -106,9 +106,9 @@ RODACLIClientBase::RODACLIClientBase(gpcc::cli::CLI & _cli, uint8_t const _attri
  */
 RODACLIClientBase::~RODACLIClientBase(void)
 {
-  gpcc::osal::MutexLocker internalMutexLocker(internalMutex);
+  gpcc::osal::MutexLocker internalMutexLocker(internalMutex_);
 
-  if (state != States::notRegistered)
+  if (state_ != States::notRegistered)
     gpcc::osal::Panic("RODACLIClientBase::~RODACLIClientBase: Still connected to RODA interface!");
 }
 
@@ -139,27 +139,27 @@ RODACLIClientBase::~RODACLIClientBase(void)
  */
 void RODACLIClientBase::Connect(IRemoteObjectDictionaryAccess & rodaItf)
 {
-  gpcc::osal::MutexLocker connectMutexLocker(connectMutex);
+  gpcc::osal::MutexLocker connectMutexLocker(connectMutex_);
 
   {
-    gpcc::osal::MutexLocker internalMutexLocker(internalMutex);
+    gpcc::osal::MutexLocker internalMutexLocker(internalMutex_);
 
-    if (state != States::notRegistered)
+    if (state_ != States::notRegistered)
       throw std::logic_error("RODACLIClientBase::Connect: Already connected.");
 
-    stateChangeConVar.Signal();
-    state = States::notReady;
-    pRODA = &rodaItf;
+    stateChangeConVar_.Signal();
+    state_ = States::notReady;
+    pRODA_ = &rodaItf;
   }
 
   ON_SCOPE_EXIT(undo)
   {
-    gpcc::osal::MutexLocker internalMutexLocker(internalMutex);
-    pRODA = nullptr;
+    gpcc::osal::MutexLocker internalMutexLocker(internalMutex_);
+    pRODA_ = nullptr;
     Reset(States::notRegistered);
   };
 
-  pRODA->Register(this);
+  pRODA_->Register(this);
 
   ON_SCOPE_EXIT_DISMISS(undo);
 }
@@ -186,21 +186,21 @@ void RODACLIClientBase::Connect(IRemoteObjectDictionaryAccess & rodaItf)
  */
 void RODACLIClientBase::Disconnect(void)
 {
-  gpcc::osal::MutexLocker connectMutexLocker(connectMutex);
+  gpcc::osal::MutexLocker connectMutexLocker(connectMutex_);
 
   {
-    gpcc::osal::MutexLocker internalMutexLocker(internalMutex);
+    gpcc::osal::MutexLocker internalMutexLocker(internalMutex_);
 
-    if (state == States::notRegistered)
+    if (state_ == States::notRegistered)
       throw std::logic_error("RODACLIClientBase::Disconnect: Already disconnected");
   }
 
   try
   {
-    pRODA->Unregister();
+    pRODA_->Unregister();
 
-    gpcc::osal::MutexLocker internalMutexLocker(internalMutex);
-    pRODA = nullptr;
+    gpcc::osal::MutexLocker internalMutexLocker(internalMutex_);
+    pRODA_ = nullptr;
     Reset(States::notRegistered);
   }
   catch (...)
@@ -231,8 +231,8 @@ void RODACLIClientBase::Disconnect(void)
  */
 IRemoteObjectDictionaryAccess* RODACLIClientBase::GetCurrentlyConnectedRODAItf(void)
 {
-  gpcc::osal::MutexLocker connectMutexLocker(connectMutex);
-  return pRODA;
+  gpcc::osal::MutexLocker connectMutexLocker(connectMutex_);
+  return pRODA_;
 }
 
 /**
@@ -266,13 +266,13 @@ bool RODACLIClientBase::WaitForRODAItfReady(uint16_t const timeout_ms)
   if (timeout_ms == 0U)
     throw std::invalid_argument("RODACLIClientBase::WaitForRODAItfReady: 'timeout_ms' invalid");
 
-  gpcc::osal::MutexLocker internalMutexLocker(internalMutex);
+  gpcc::osal::MutexLocker internalMutexLocker(internalMutex_);
 
-  if (state == States::ready)
+  if (state_ == States::ready)
   {
     return true;
   }
-  else if (state == States::notRegistered)
+  else if (state_ == States::notRegistered)
   {
     throw std::logic_error("RODACLIClientBase::WaitForRODAItfReady: Not connected");
   }
@@ -281,12 +281,12 @@ bool RODACLIClientBase::WaitForRODAItfReady(uint16_t const timeout_ms)
     auto const timeout = gpcc::time::TimePoint::FromSystemClock(gpcc::osal::ConditionVariable::clockID)
                        + gpcc::time::TimeSpan::ms(timeout_ms);
 
-    while (state != States::ready)
+    while (state_ != States::ready)
     {
-      if (stateChangeConVar.TimeLimitedWait(internalMutex, timeout))
+      if (stateChangeConVar_.TimeLimitedWait(internalMutex_, timeout))
       {
         // (timeout)
-        return (state == States::ready);
+        return (state_ == States::ready);
       }
     }
 
@@ -303,7 +303,7 @@ bool RODACLIClientBase::WaitForRODAItfReady(uint16_t const timeout_ms)
  *
  * __Thread safety:__\n
  * This is thread-safe.\n
- * This is intended to be executed in the context of @ref cli only.
+ * This is intended to be executed in the context of @ref cli_ only.
  *
  * __Exception safety:__\n
  * Basic guarantee:
@@ -320,9 +320,9 @@ bool RODACLIClientBase::WaitForRODAItfReady(uint16_t const timeout_ms)
  */
 void RODACLIClientBase::CLI_Enumerate(std::string const & restOfLine)
 {
-  gpcc::osal::MutexLocker internalMutexLocker(internalMutex);
+  gpcc::osal::MutexLocker internalMutexLocker(internalMutex_);
 
-  if (state != States::ready)
+  if (state_ != States::ready)
     throw std::runtime_error("RODA interface not ready or not connected");
 
   // ============================================
@@ -338,7 +338,7 @@ void RODACLIClientBase::CLI_Enumerate(std::string const & restOfLine)
   uint16_t startIndex = args.GetFirstIndex();
   do
   {
-    cli.TestTermination();
+    cli_.TestTermination();
 
     spEnumResponse.reset();
     spEnumResponse = Enumerate(startIndex, args.GetLastIndex(), 1U, 0xFFFFU);
@@ -347,14 +347,14 @@ void RODACLIClientBase::CLI_Enumerate(std::string const & restOfLine)
     if (indices.empty())
     {
       if (firstLoopCycle)
-        cli.WriteLine("No objects");
+        cli_.WriteLine("No objects");
 
       return;
     }
 
     for (auto const index : indices)
     {
-      cli.TestTermination();
+      cli_.TestTermination();
 
       // collect some more data...
       auto const spInfoResponse = GetInfoSingleSI(index, 0U, true, false);
@@ -369,7 +369,7 @@ void RODACLIClientBase::CLI_Enumerate(std::string const & restOfLine)
           << StringComposer::AlignLeft << StringComposer::Width(Object::largestObjectCodeNameLength) << Object::ObjectCodeToString(objCode) << ' '
           << StringComposer::AlignLeft << StringComposer::Width(15) << DataTypeToString(dataType) << " \"" << objName << '"';
 
-      cli.WriteLine(sc.Get());
+      cli_.WriteLine(sc.Get());
     }
 
     firstLoopCycle = false;
@@ -384,7 +384,7 @@ void RODACLIClientBase::CLI_Enumerate(std::string const & restOfLine)
  *
  * __Thread safety:__\n
  * This is thread-safe.\n
- * This is intended to be executed in the context of @ref cli only.
+ * This is intended to be executed in the context of @ref cli_ only.
  *
  * __Exception safety:__\n
  * Basic guarantee:
@@ -403,9 +403,9 @@ void RODACLIClientBase::CLI_Enumerate(std::string const & restOfLine)
  */
 void RODACLIClientBase::CLI_Info(std::string const & restOfLine)
 {
-  gpcc::osal::MutexLocker internalMutexLocker(internalMutex);
+  gpcc::osal::MutexLocker internalMutexLocker(internalMutex_);
 
-  if (state != States::ready)
+  if (state_ != States::ready)
     throw std::runtime_error("RODA interface not ready or not connected");
 
   // ============================================
@@ -427,7 +427,7 @@ void RODACLIClientBase::CLI_Info(std::string const & restOfLine)
   // -- print info about object --
   sc << "Object " << gpcc::string::ToHex(args.GetIndex(), 4U) << ": " << Object::ObjectCodeToString(spInfo->GetObjectCode())
       << " (" << DataTypeToString(spInfo->GetObjectDataType()) << ") \"" << spInfo->GetObjectName() << '"';
-  cli.WriteLine(sc.Get());
+  cli_.WriteLine(sc.Get());
 
   // small tool: Appends info about a subindex to 'sc'
   auto appendSubIndexInfoToOSS = [&](uint_fast8_t const si)
@@ -437,7 +437,7 @@ void RODACLIClientBase::CLI_Info(std::string const & restOfLine)
     uint8_t const bits  = s % 8U;
     sc << StringComposer::AlignLeft << StringComposer::Width(15U)
         << DataTypeToString(spInfo->GetSubIdxDataType(si)) << ' '
-        << StringComposer::Width(attributeStringMaxLength)
+        << StringComposer::Width(attributeStringMaxLength_)
         << AttributesToStringHook(spInfo->GetSubIdxAttributes(si)) << ' '
         << StringComposer::AlignRight << StringComposer::Width(5U)
         << bytes << '.' << static_cast<uint32_t>(bits) << " Byte(s) \"" << spInfo->GetSubIdxName(si) << '"';
@@ -471,14 +471,14 @@ void RODACLIClientBase::CLI_Info(std::string const & restOfLine)
     sc.Clear();
     sc << "  Subindex    " << StringComposer::AlignRight << StringComposer::Width(digitsForSubindices + 2U) << "0: ";
     appendSubIndexInfoToOSS(0U);
-    cli.WriteLine(sc.Get());
+    cli_.WriteLine(sc.Get());
 
     if (maxNbOfSIs > 1U)
     {
       sc.Clear();
       sc << "  Subindex 1.." << static_cast<uint32_t>(maxNbOfSIs - 1U) << ": ";
       appendSubIndexInfoToOSS(1U);
-      cli.WriteLine(sc.Get());
+      cli_.WriteLine(sc.Get());
     }
   }
   else
@@ -504,7 +504,7 @@ void RODACLIClientBase::CLI_Info(std::string const & restOfLine)
         appendAppSpecMetaDataToOSS(i);
       }
 
-      cli.WriteLine(sc.Get());
+      cli_.WriteLine(sc.Get());
     }
   }
 }
@@ -516,7 +516,7 @@ void RODACLIClientBase::CLI_Info(std::string const & restOfLine)
  *
  * __Thread safety:__\n
  * This is thread-safe.\n
- * This is intended to be executed in the context of @ref cli only.
+ * This is intended to be executed in the context of @ref cli_ only.
  *
  * __Exception safety:__\n
  * Basic guarantee:
@@ -533,9 +533,9 @@ void RODACLIClientBase::CLI_Info(std::string const & restOfLine)
  */
 void RODACLIClientBase::CLI_Read(std::string const & restOfLine)
 {
-  gpcc::osal::MutexLocker internalMutexLocker(internalMutex);
+  gpcc::osal::MutexLocker internalMutexLocker(internalMutex_);
 
-  if (state != States::ready)
+  if (state_ != States::ready)
     throw std::runtime_error("RODA interface not ready or not connected");
 
   // ============================================
@@ -559,7 +559,7 @@ void RODACLIClientBase::CLI_Read(std::string const & restOfLine)
   auto str = CANopenEncodedDataToString(msr, spReadResponse->GetDataSize(), spSIInfo->GetSubIdxDataType(args.GetSubIndex()));
   msr.Close();
 
-  cli.WriteLine(str);
+  cli_.WriteLine(str);
 }
 
 /**
@@ -569,7 +569,7 @@ void RODACLIClientBase::CLI_Read(std::string const & restOfLine)
  *
  * __Thread safety:__\n
  * This is thread-safe.\n
- * This is intended to be executed in the context of @ref cli only.
+ * This is intended to be executed in the context of @ref cli_ only.
  *
  * __Exception safety:__\n
  * Basic guarantee:
@@ -586,9 +586,9 @@ void RODACLIClientBase::CLI_Read(std::string const & restOfLine)
  */
 void RODACLIClientBase::CLI_Write(std::string const & restOfLine)
 {
-  gpcc::osal::MutexLocker internalMutexLocker(internalMutex);
+  gpcc::osal::MutexLocker internalMutexLocker(internalMutex_);
 
-  if (state != States::ready)
+  if (state_ != States::ready)
     throw std::runtime_error("RODA interface not ready or not connected");
 
   // ============================================
@@ -612,7 +612,7 @@ void RODACLIClientBase::CLI_Write(std::string const & restOfLine)
   // write to object
   // ============================================
   Write(args.GetIndex(), args.GetSubIndex(), false, std::move(args.GetData()));
-  cli.WriteLine("OK");
+  cli_.WriteLine("OK");
 }
 
 /**
@@ -622,7 +622,7 @@ void RODACLIClientBase::CLI_Write(std::string const & restOfLine)
  *
  * __Thread safety:__\n
  * This is thread-safe.\n
- * This is intended to be executed in the context of @ref cli only.
+ * This is intended to be executed in the context of @ref cli_ only.
  *
  * __Exception safety:__\n
  * Basic guarantee:
@@ -639,9 +639,9 @@ void RODACLIClientBase::CLI_Write(std::string const & restOfLine)
  */
 void RODACLIClientBase::CLI_CARead(std::string const & restOfLine)
 {
-  gpcc::osal::MutexLocker internalMutexLocker(internalMutex);
+  gpcc::osal::MutexLocker internalMutexLocker(internalMutex_);
 
-  if (state != States::ready)
+  if (state_ != States::ready)
     throw std::runtime_error("RODA interface not ready or not connected");
 
   // ============================================
@@ -683,7 +683,7 @@ void RODACLIClientBase::CLI_CARead(std::string const & restOfLine)
       {
         if (s > 120U)
         {
-          cli.WriteLine("Encountered very large subindex name. Retry command without option 'v'.");
+          cli_.WriteLine("Encountered very large subindex name. Retry command without option 'v'.");
           return;
         }
 
@@ -707,7 +707,7 @@ void RODACLIClientBase::CLI_CARead(std::string const & restOfLine)
       else
         sc << CANopenEncodedDataToString(msr, spSIInfo->GetSubIdxMaxSize(subIdx), dataType);
 
-      cli.WriteLine(sc.Get());
+      cli_.WriteLine(sc.Get());
     }
   }
   else
@@ -723,7 +723,7 @@ void RODACLIClientBase::CLI_CARead(std::string const & restOfLine)
       else
         sc << CANopenEncodedDataToString(msr, spSIInfo->GetSubIdxMaxSize(subIdx), spSIInfo->GetSubIdxDataType(subIdx));
 
-      cli.WriteLine(sc.Get());
+      cli_.WriteLine(sc.Get());
     }
   }
 
@@ -737,7 +737,7 @@ void RODACLIClientBase::CLI_CARead(std::string const & restOfLine)
  *
  * __Thread safety:__\n
  * This is thread-safe.\n
- * This is intended to be executed in the context of @ref cli only.
+ * This is intended to be executed in the context of @ref cli_ only.
  *
  * __Exception safety:__\n
  * Basic guarantee:
@@ -754,9 +754,9 @@ void RODACLIClientBase::CLI_CARead(std::string const & restOfLine)
  */
 void RODACLIClientBase::CLI_CAWrite(std::string const & restOfLine)
 {
-  gpcc::osal::MutexLocker internalMutexLocker(internalMutex);
+  gpcc::osal::MutexLocker internalMutexLocker(internalMutex_);
 
-  if (state != States::ready)
+  if (state_ != States::ready)
     throw std::runtime_error("RODA interface not ready or not connected");
 
   // ============================================
@@ -775,7 +775,7 @@ void RODACLIClientBase::CLI_CAWrite(std::string const & restOfLine)
   if (   (spInfo->GetObjectCode() != Object::ObjectCode::Array)
       && (spInfo->GetObjectCode() != Object::ObjectCode::Record))
   {
-    cli.WriteLine("Object type not supported.");
+    cli_.WriteLine("Object type not supported.");
     return;
   }
 
@@ -795,16 +795,16 @@ void RODACLIClientBase::CLI_CAWrite(std::string const & restOfLine)
   {
     if (spInfo->GetObjectCode() != Object::ObjectCode::Array)
     {
-      cli.WriteLine("SI0 is writeable. This is only supported for ARRAY objects.");
+      cli_.WriteLine("SI0 is writeable. This is only supported for ARRAY objects.");
       return;
     }
 
-    cli.WriteLine("Current value of SI0: " + std::to_string(currSI0));
-    newSI0 = gpcc::string::DecimalToU8(cli.ReadLine("New value for SI0: "));
+    cli_.WriteLine("Current value of SI0: " + std::to_string(currSI0));
+    newSI0 = gpcc::string::DecimalToU8(cli_.ReadLine("New value for SI0: "));
 
     if (newSI0 >= spInfo->GetMaxNbOfSubindices())
     {
-      cli.WriteLine("Value for SI0 exceeds maximum number of subindices the object can have.");
+      cli_.WriteLine("Value for SI0 exceeds maximum number of subindices the object can have.");
       return;
     }
   }
@@ -846,14 +846,14 @@ void RODACLIClientBase::CLI_CAWrite(std::string const & restOfLine)
     // skip empty subindices
     if (siSize == 0U)
     {
-      cli.WriteLine("Skipping SI " + std::to_string(subIdx) + " (zero size))");
+      cli_.WriteLine("Skipping SI " + std::to_string(subIdx) + " (zero size))");
       continue;
     }
 
     // gap?
     if (dataType == DataType::null)
     {
-      cli.WriteLine("Skipping SI " + std::to_string(subIdx) + " (gap)");
+      cli_.WriteLine("Skipping SI " + std::to_string(subIdx) + " (gap)");
       msw.FillBits(siSize, false);
       continue;
     }
@@ -867,7 +867,7 @@ void RODACLIClientBase::CLI_CAWrite(std::string const & restOfLine)
     auto const attributes = spInfo->GetSubIdxAttributes(subIdx);
     if ((attributes & Object::attr_ACCESS_WR) == 0U)
     {
-      cli.WriteLine("Skipping SI " + std::to_string(subIdx) + " (pure read-only))");
+      cli_.WriteLine("Skipping SI " + std::to_string(subIdx) + " (pure read-only))");
       msw.FillBits(siSize, false);
       continue;
     }
@@ -878,9 +878,9 @@ void RODACLIClientBase::CLI_CAWrite(std::string const & restOfLine)
         << DataTypeToString(dataType) << ", "
         << AttributesToStringHook(spInfo->GetSubIdxAttributes(subIdx)) << ", "
         << bytes << '.' << static_cast<uint32_t>(bits) << " Byte(s), \"" << spInfo->GetSubIdxName(subIdx) << '"';
-    cli.WriteLine(sc.Get());
+    cli_.WriteLine(sc.Get());
 
-    auto val = cli.ReadLine("Value: ");
+    auto val = cli_.ReadLine("Value: ");
 
     switch (dataType)
     {
@@ -977,15 +977,15 @@ void RODACLIClientBase::CLI_CAWrite(std::string const & restOfLine)
   // ============================================
   // write
   // ============================================
-  cli.WriteLine("All data entered.");
-  if (cli.ReadLine("Write now? (y/n/Ctrl+C): ") == "y")
+  cli_.WriteLine("All data entered.");
+  if (cli_.ReadLine("Write now? (y/n/Ctrl+C): ") == "y")
   {
     Write(args.GetIndex(), 0U, true, std::move(data));
-    cli.WriteLine("OK");
+    cli_.WriteLine("OK");
   }
   else
   {
-    cli.WriteLine("Aborted. No data written.");
+    cli_.WriteLine("Aborted. No data written.");
   }
 }
 
@@ -1058,32 +1058,32 @@ uint_fast8_t RODACLIClientBase::DigitsInSubindex(uint8_t const si) noexcept
 /// \copydoc gpcc::cood::IRemoteObjectDictionaryAccessNotifiable::OnReady
 void RODACLIClientBase::OnReady(size_t const maxRequestSize, size_t const maxResponseSize) noexcept
 {
-  gpcc::osal::MutexLocker internalMutexLocker(internalMutex);
+  gpcc::osal::MutexLocker internalMutexLocker(internalMutex_);
 
-  if (state != States::notReady)
-    gpcc::osal::Panic("RODACLIClientBase::OnReady: 'state' invalid");
+  if (state_ != States::notReady)
+    gpcc::osal::Panic("RODACLIClientBase::OnReady: 'state_' invalid");
 
   if (maxRequestSize < (RequestBase::minimumUsefulRequestSize + ReturnStackItem::binarySize))
-    this->maxRequestSize = 0U;
+    this->maxRequestSize_ = 0U;
   else
-    this->maxRequestSize = maxRequestSize - ReturnStackItem::binarySize;
+    this->maxRequestSize_ = maxRequestSize - ReturnStackItem::binarySize;
 
   if (maxResponseSize < (ResponseBase::minimumUsefulResponseSize + ReturnStackItem::binarySize))
-    this->maxResponseSize = 0U;
+    this->maxResponseSize_ = 0U;
   else
-    this->maxResponseSize = maxResponseSize - ReturnStackItem::binarySize;
+    this->maxResponseSize_ = maxResponseSize - ReturnStackItem::binarySize;
 
-  state = States::ready;
-  stateChangeConVar.Signal();
+  state_ = States::ready;
+  stateChangeConVar_.Signal();
 }
 
 /// \copydoc gpcc::cood::IRemoteObjectDictionaryAccessNotifiable::OnDisconnected
 void RODACLIClientBase::OnDisconnected(void) noexcept
 {
-  gpcc::osal::MutexLocker internalMutexLocker(internalMutex);
+  gpcc::osal::MutexLocker internalMutexLocker(internalMutex_);
 
-  if (state != States::ready)
-    gpcc::osal::Panic("RODACLIClientBase::OnDisconnected: 'state' invalid");
+  if (state_ != States::ready)
+    gpcc::osal::Panic("RODACLIClientBase::OnDisconnected: 'state_' invalid");
 
   Reset(States::notReady);
 }
@@ -1091,11 +1091,11 @@ void RODACLIClientBase::OnDisconnected(void) noexcept
 /// \copydoc gpcc::cood::IRemoteObjectDictionaryAccessNotifiable::OnRequestProcessed
 void RODACLIClientBase::OnRequestProcessed(std::unique_ptr<ResponseBase> spResponse) noexcept
 {
-  gpcc::osal::MutexLocker internalMutexLocker(internalMutex);
+  gpcc::osal::MutexLocker internalMutexLocker(internalMutex_);
 
   // sanity check
-  if (state != States::ready)
-    gpcc::osal::Panic("RODACLIClientBase::OnDisconnected: 'state' invalid");
+  if (state_ != States::ready)
+    gpcc::osal::Panic("RODACLIClientBase::OnDisconnected: 'state_' invalid");
 
   // Extract return stack item and check:
   // - Are we the originator?
@@ -1105,19 +1105,19 @@ void RODACLIClientBase::OnRequestProcessed(std::unique_ptr<ResponseBase> spRespo
     return;
 
   auto rsi = spResponse->PopReturnStack();
-  if (rsi.GetID() != ownerID)
+  if (rsi.GetID() != ownerID_)
     return;
 
-  if (rsi.GetInfo() != sessionCnt)
+  if (rsi.GetInfo() != sessionCnt_)
     return;
 
-  // check for overflow and fetch response or set receiveOverflow
-  if (!spReceivedResponse)
-    spReceivedResponse = std::move(spResponse);
+  // check for overflow and fetch response or set receiveOverflow_
+  if (!spReceivedResponse_)
+    spReceivedResponse_ = std::move(spResponse);
   else
-    receiveOverflow = true;
+    receiveOverflow_ = true;
 
-  respReceivedConVar.Signal();
+  respReceivedConVar_.Signal();
 }
 
 /// \copydoc gpcc::cood::IRemoteObjectDictionaryAccessNotifiable::LoanExecutionContext
@@ -1131,12 +1131,12 @@ void RODACLIClientBase::LoanExecutionContext(void) noexcept
 /**
  * \brief Resets class members according to requirements when the RODA interface becomes not-ready or disconnected.
  *
- * @ref pRODA is not modified by this.
+ * @ref pRODA_ is not modified by this.
  *
  * - - -
  *
  * __Thread safety:__\n
- * The caller shall have @ref internalMutex acquired.
+ * The caller shall have @ref internalMutex_ acquired.
  *
  * __Exception safety:__\n
  * No-throw guarantee.
@@ -1147,38 +1147,38 @@ void RODACLIClientBase::LoanExecutionContext(void) noexcept
  * - - -
  *
  * \param newState
- * New value for @ref state.
+ * New value for @ref state_.
  */
 void RODACLIClientBase::Reset(States const newState) noexcept
 {
-  if (state != newState)
-    stateChangeConVar.Signal();
+  if (state_ != newState)
+    stateChangeConVar_.Signal();
 
-  state = newState;
-  maxRequestSize = 0U;
-  maxResponseSize = 0U;
-  sessionCnt = 0U;
-  spReceivedResponse.reset();
-  receiveOverflow = false;
+  state_ = newState;
+  maxRequestSize_ = 0U;
+  maxResponseSize_ = 0U;
+  sessionCnt_ = 0U;
+  spReceivedResponse_.reset();
+  receiveOverflow_ = false;
 }
 
 /**
  * \brief Blocks the calling thread until a response is received or a timeout occurrs.
  *
  * Messages are received via @ref RODACLIClientBase::OnRequestProcessed() of the private provided RODAN interface.
- * @ref OnRequestProcessed() will check @ref sessionCnt and @ref ownerID to the return stack item attached to the
+ * @ref OnRequestProcessed() will check @ref sessionCnt_ and @ref ownerID_ to the return stack item attached to the
  * response.
  *
- * In case of an error, the caller may want to increase @ref sessionCnt.
+ * In case of an error, the caller may want to increase @ref sessionCnt_.
  *
- * \post  @ref receiveOverflow is cleared.
+ * \post  @ref receiveOverflow_ is cleared.
  *
- * \post  @ref spReceivedResponse is cleared.
+ * \post  @ref spReceivedResponse_ is cleared.
  *
  * - - -
  *
  * __Thread safety:__\n
- * The caller shall have @ref internalMutex acquired.
+ * The caller shall have @ref internalMutex_ acquired.
  *
  * __Exception safety:__\n
  * Strong guarantee.
@@ -1195,17 +1195,17 @@ void RODACLIClientBase::Reset(States const newState) noexcept
  */
 std::unique_ptr<ResponseBase> RODACLIClientBase::WaitAndFetchResponse(uint32_t const timeout_ms)
 {
-  if (!spReceivedResponse)
+  if (!spReceivedResponse_)
   {
     auto const timeout = gpcc::time::TimePoint::FromSystemClock(gpcc::osal::ConditionVariable::clockID)
                        + gpcc::time::TimeSpan::ms(timeout_ms);
 
-    while (!spReceivedResponse)
+    while (!spReceivedResponse_)
     {
-      if (respReceivedConVar.TimeLimitedWait(internalMutex, timeout))
+      if (respReceivedConVar_.TimeLimitedWait(internalMutex_, timeout))
       {
         // timeout
-        if (!spReceivedResponse)
+        if (!spReceivedResponse_)
           throw std::runtime_error("RODACLIClientBase::WaitAndFetchResponse: Timeout waiting for response from remote access server");
         else
           break;
@@ -1213,14 +1213,14 @@ std::unique_ptr<ResponseBase> RODACLIClientBase::WaitAndFetchResponse(uint32_t c
     }
   }
 
-  if (receiveOverflow)
+  if (receiveOverflow_)
   {
-    spReceivedResponse.reset();
-    receiveOverflow = false;
+    spReceivedResponse_.reset();
+    receiveOverflow_ = false;
     throw std::runtime_error("RODACLIClientBase::WaitAndFetchResponse: Receive overflow");
   }
 
-  return std::move(spReceivedResponse);
+  return std::move(spReceivedResponse_);
 }
 
 /**
@@ -1229,11 +1229,11 @@ std::unique_ptr<ResponseBase> RODACLIClientBase::WaitAndFetchResponse(uint32_t c
  * - - -
  *
  * __Thread safety:__\n
- * The caller shall have @ref internalMutex acquired.
+ * The caller shall have @ref internalMutex_ acquired.
  *
  * __Exception safety:__\n
  * Basic guarantee:
- * - If the error occurred _after_ successful transmission of the request, then @ref sessionCnt will be incremented.
+ * - If the error occurred _after_ successful transmission of the request, then @ref sessionCnt_ will be incremented.
  *
  * \throws std::bad_alloc                    Out of memory.
  *
@@ -1244,7 +1244,7 @@ std::unique_ptr<ResponseBase> RODACLIClientBase::WaitAndFetchResponse(uint32_t c
  *
  * __Thread cancellation safety:__\n
  * Basic guarantee:
- * - If thread cancellation occurrs _after_ successful transmission of the request, then @ref sessionCnt will be
+ * - If thread cancellation occurrs _after_ successful transmission of the request, then @ref sessionCnt_ will be
  *   incremented.
  *
  * - - -
@@ -1262,17 +1262,17 @@ std::unique_ptr<ResponseBase> RODACLIClientBase::TxAndRx(std::unique_ptr<Request
   if (!spReq)
     throw std::invalid_argument("RODACLIClientBase::TxAndRx: !spReq");
 
-  ReturnStackItem rsi(ownerID, sessionCnt);
+  ReturnStackItem rsi(ownerID_, sessionCnt_);
   spReq->Push(rsi);
 
-  pRODA->Send(spReq);
+  pRODA_->Send(spReq);
 
   ON_SCOPE_EXIT(incSessionCount)
   {
-    ++sessionCnt;
+    ++sessionCnt_;
   };
 
-  auto resp = WaitAndFetchResponse(rxTimeout_ms);
+  auto resp = WaitAndFetchResponse(rxTimeout_ms_);
 
   ON_SCOPE_EXIT_DISMISS(incSessionCount);
 
@@ -1285,11 +1285,11 @@ std::unique_ptr<ResponseBase> RODACLIClientBase::TxAndRx(std::unique_ptr<Request
  * - - -
  *
  * __Thread safety:__\n
- * The caller shall have @ref internalMutex acquired.
+ * The caller shall have @ref internalMutex_ acquired.
  *
  * __Exception safety:__\n
  * Basic guarantee:
- * - @ref sessionCnt will be incremented if a request has been transmitted and its response is outstanding
+ * - @ref sessionCnt_ will be incremented if a request has been transmitted and its response is outstanding
  *
  * \throws std::bad_alloc                    Out of memory.
  *
@@ -1298,7 +1298,7 @@ std::unique_ptr<ResponseBase> RODACLIClientBase::TxAndRx(std::unique_ptr<Request
  *
  * __Thread cancellation safety:__\n
  * Basic guarantee:
- * - @ref sessionCnt will be incremented if a request has been transmitted and its response is outstanding
+ * - @ref sessionCnt_ will be incremented if a request has been transmitted and its response is outstanding
  *
  * - - -
  *
@@ -1311,7 +1311,7 @@ std::unique_ptr<ResponseBase> RODACLIClientBase::TxAndRx(std::unique_ptr<Request
  * Objects located at indices larger than this will not be enumerated.
  *
  * \param maxFragments
- * Each response object received from the remote access server contains @ref maxResponseSize bytes of data (both payload
+ * Each response object received from the remote access server contains @ref maxResponseSize_ bytes of data (both payload
  * and overhead). It may happen, that the indices of all objects up to `lastIndex` do not fit into the response object.
  * It that case, this method will send another request to continue enumeration. This is called a _fragmented transfer_.\n
  * \n
@@ -1343,7 +1343,7 @@ std::unique_ptr<ObjectEnumResponse> RODACLIClientBase::Enumerate(uint16_t const 
     throw std::invalid_argument("RODACLIClientBase::Enumerate: 'maxFragments' is zero");
 
   // create initial enum request
-  auto spRequest = std::make_unique<ObjectEnumRequest>(firstIndex, lastIndex, attrFilter, maxResponseSize);
+  auto spRequest = std::make_unique<ObjectEnumRequest>(firstIndex, lastIndex, attrFilter, maxResponseSize_);
 
   // this will take the first response and potential fragments will be added to it
   std::unique_ptr<ObjectEnumResponse> spFirstResponse;
@@ -1389,7 +1389,7 @@ std::unique_ptr<ObjectEnumResponse> RODACLIClientBase::Enumerate(uint16_t const 
       break;
 
     // create next request which continues the query
-    spRequest = std::make_unique<ObjectEnumRequest>(nextIndex, lastIndex, attrFilter, maxResponseSize);
+    spRequest = std::make_unique<ObjectEnumRequest>(nextIndex, lastIndex, attrFilter, maxResponseSize_);
   }
 
   return spFirstResponse;
@@ -1403,11 +1403,11 @@ std::unique_ptr<ObjectEnumResponse> RODACLIClientBase::Enumerate(uint16_t const 
  * - - -
  *
  * __Thread safety:__\n
- * The caller shall have @ref internalMutex acquired.
+ * The caller shall have @ref internalMutex_ acquired.
  *
  * __Exception safety:__\n
  * Basic guarantee:
- * - @ref sessionCnt will be incremented if a request has been transmitted and its response is outstanding
+ * - @ref sessionCnt_ will be incremented if a request has been transmitted and its response is outstanding
  *
  * \throws std::bad_alloc                    Out of memory.
  *
@@ -1416,7 +1416,7 @@ std::unique_ptr<ObjectEnumResponse> RODACLIClientBase::Enumerate(uint16_t const 
  *
  * __Thread cancellation safety:__\n
  * Basic guarantee:
- * - @ref sessionCnt will be incremented if a request has been transmitted and its response is outstanding
+ * - @ref sessionCnt_ will be incremented if a request has been transmitted and its response is outstanding
  *
  * - - -
  *
@@ -1440,14 +1440,14 @@ std::unique_ptr<ObjectInfoResponse> RODACLIClientBase::GetInfo(uint16_t const in
                                                                bool const inclASM)
 {
   // create initial info request
-  auto spRequest = std::make_unique<ObjectInfoRequest>(index, 0U, 255U, inclNames, inclASM, maxResponseSize);
+  auto spRequest = std::make_unique<ObjectInfoRequest>(index, 0U, 255U, inclNames, inclASM, maxResponseSize_);
 
   // this will take the first response and potential fragments will be added to it
   std::unique_ptr<ObjectInfoResponse> spFirstResponse;
 
   while (true)
   {
-    cli.TestTermination();
+    cli_.TestTermination();
 
     // transmit the request
     auto spResponse = TxAndRx(std::move(spRequest));
@@ -1484,7 +1484,7 @@ std::unique_ptr<ObjectInfoResponse> RODACLIClientBase::GetInfo(uint16_t const in
       break;
 
     // create next request which continues the query
-    spRequest = std::make_unique<ObjectInfoRequest>(index, nextSubIndex, 255U, inclNames, inclASM, maxResponseSize);
+    spRequest = std::make_unique<ObjectInfoRequest>(index, nextSubIndex, 255U, inclNames, inclASM, maxResponseSize_);
   }
 
   return spFirstResponse;
@@ -1496,11 +1496,11 @@ std::unique_ptr<ObjectInfoResponse> RODACLIClientBase::GetInfo(uint16_t const in
  * - - -
  *
  * __Thread safety:__\n
- * The caller shall have @ref internalMutex acquired.
+ * The caller shall have @ref internalMutex_ acquired.
  *
  * __Exception safety:__\n
  * Basic guarantee:
- * - @ref sessionCnt will be incremented if a request has been transmitted and its response is outstanding
+ * - @ref sessionCnt_ will be incremented if a request has been transmitted and its response is outstanding
  *
  * \throws std::bad_alloc                    Out of memory.
  *
@@ -1509,7 +1509,7 @@ std::unique_ptr<ObjectInfoResponse> RODACLIClientBase::GetInfo(uint16_t const in
  *
  * __Thread cancellation safety:__\n
  * Basic guarantee:
- * - @ref sessionCnt will be incremented if a request has been transmitted and its response is outstanding
+ * - @ref sessionCnt_ will be incremented if a request has been transmitted and its response is outstanding
  *
  * - - -
  *
@@ -1537,7 +1537,7 @@ std::unique_ptr<ObjectInfoResponse> RODACLIClientBase::GetInfoSingleSI(uint16_t 
                                                                        bool const inclASM)
 {
   // create info request
-  auto spRequest = std::make_unique<ObjectInfoRequest>(index, subIndex, subIndex, inclNames, inclASM, maxResponseSize);
+  auto spRequest = std::make_unique<ObjectInfoRequest>(index, subIndex, subIndex, inclNames, inclASM, maxResponseSize_);
 
   // transmit the request
   auto spResponse = TxAndRx(std::move(spRequest));
@@ -1568,11 +1568,11 @@ std::unique_ptr<ObjectInfoResponse> RODACLIClientBase::GetInfoSingleSI(uint16_t 
  * - - -
  *
  * __Thread safety:__\n
- * The caller shall have @ref internalMutex acquired.
+ * The caller shall have @ref internalMutex_ acquired.
  *
  * __Exception safety:__\n
  * Basic guarantee:
- * - @ref sessionCnt will be incremented if a request has been transmitted and its response is outstanding
+ * - @ref sessionCnt_ will be incremented if a request has been transmitted and its response is outstanding
  *
  * \throws std::bad_alloc                    Out of memory.
  *
@@ -1581,7 +1581,7 @@ std::unique_ptr<ObjectInfoResponse> RODACLIClientBase::GetInfoSingleSI(uint16_t 
  *
  * __Thread cancellation safety:__\n
  * Basic guarantee:
- * - @ref sessionCnt will be incremented if a request has been transmitted and its response is outstanding
+ * - @ref sessionCnt_ will be incremented if a request has been transmitted and its response is outstanding
  *
  * - - -
  *
@@ -1606,7 +1606,7 @@ std::unique_ptr<ReadRequestResponse> RODACLIClientBase::Read(uint16_t const inde
   auto spRequest = std::make_unique<ReadRequest>(ca ? ReadRequest::AccessType::completeAccess_SI0_8bit : ReadRequest::AccessType::singleSubindex,
                                                  index, subindex,
                                                  Object::attr_ACCESS_RD,
-                                                 maxResponseSize);
+                                                 maxResponseSize_);
 
   // transmit the request
   auto spResponse = TxAndRx(std::move(spRequest));
@@ -1637,12 +1637,12 @@ std::unique_ptr<ReadRequestResponse> RODACLIClientBase::Read(uint16_t const inde
  * - - -
  *
  * __Thread safety:__\n
- * The caller shall have @ref internalMutex acquired.
+ * The caller shall have @ref internalMutex_ acquired.
  *
  * __Exception safety:__\n
  * Basic guarantee:
  * - content of 'data' may have been moved somewhere
- * - @ref sessionCnt will be incremented if a request has been transmitted and its response is outstanding
+ * - @ref sessionCnt_ will be incremented if a request has been transmitted and its response is outstanding
  *
  * \throws std::bad_alloc                    Out of memory.
  *
@@ -1654,7 +1654,7 @@ std::unique_ptr<ReadRequestResponse> RODACLIClientBase::Read(uint16_t const inde
  * __Thread cancellation safety:__\n
  * Basic guarantee:
  * - content of 'data' may have been moved somewhere
- * - @ref sessionCnt will be incremented if a request has been transmitted and its response is outstanding
+ * - @ref sessionCnt_ will be incremented if a request has been transmitted and its response is outstanding
  *
  * - - -
  *
@@ -1682,7 +1682,7 @@ void RODACLIClientBase::Write(uint16_t const index, uint8_t const subindex, bool
                                                   index, subindex,
                                                   Object::attr_ACCESS_WR,
                                                   std::move(data),
-                                                  maxResponseSize);
+                                                  maxResponseSize_);
   // transmit the request
   auto spResponse = TxAndRx(std::move(spRequest));
 

--- a/src/cood/remote_access/infrastructure/SingleRODACLIClientBase.cpp
+++ b/src/cood/remote_access/infrastructure/SingleRODACLIClientBase.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2021 Daniel Jerolm
+    Copyright (C) 2021, 2025 Daniel Jerolm
 */
 
 #include <gpcc/cood/remote_access/infrastructure/SingleRODACLIClientBase.hpp>
@@ -61,48 +61,48 @@ SingleRODACLIClientBase::SingleRODACLIClientBase(IRemoteObjectDictionaryAccess &
 {
   using gpcc::cli::Command;
 
-  cli.AddCommand(Command::Create(cmdName.c_str(), " subcmd [args...]\n"
-                                 "Accesses the remote object dictionary. The type of access is specified by"
-                                 "<subcmd>:\n"
-                                 "- enum [0xFROM-0xTO]\n"
-                                 "  Enumerates objects contained in the object dictionary.\n"
-                                 "  Options:\n"
-                                 "    FROM   Index where enumeration shall start. Default: 0x0000\n"
-                                 "    TO     Index where enumeration shall end. Default: 0xFFFF\n"
-                                 "    FROM <= TO must be valid.\n"
-                                 "\n"
-                                 "- info 0xINDEX [asm]\n"
-                                 "  Prints the meta data of an object and its subindices.\n"
-                                 "  Options:\n"
-                                 "    asm   Includes application-specific meta data in the output.\n"
-                                 "\n"
-                                 "- read 0xINDEX:Subindex\n"
-                                 "  Reads the data of a subindex and prints it to CLI.\n"
-                                 "  <subindex> shall be provided in decimal format.\n"
-                                 "\n"
-                                 "- write 0xINDEX:Subindex DATA\n"
-                                 "  Writes <DATA> to a subindex. <Subindex> shall be provided in decimal format.\n"
-                                 "\n"
-                                 "  The format of <DATA> must meet the data type of the subindex:\n"
-                                 "  For BOOLEAN: TRUE, FALSE, true, false\n"
-                                 "  For REAL32/64: [+|-]digits[.][digits][(e|E)[+|-]digits]\n"
-                                 "  For VISIBLE_STRING: \"Text...\"\n"
-                                 "  For OCTET_STRING: 5B A3 ... (8bit hex values, separated by spaces)\n"
-                                 "  For UNICODE_STRING: 5B33 A6CF (16bit hex values, separated by spaces)\n"
-                                 "  For BIT1..BIT8: 0, 1, 3, 0x3, 0b11 (unused upper bits must be zero)\n"
-                                 "\n"
-                                 "- caread 0xINDEX [v]\n"
-                                 "  Reads the whole object via complete access and prints the value of each\n"
-                                 "  subindex to CLI.\n"
-                                 "  Options:\n"
-                                 "  v   Verbose output. Prints the data type and name of each subindex in addition\n"
-                                 "      to the data.\n"
-                                 "- cawrite 0xINDEX\n"
-                                 "  Writes the whole object via complete access.\n"
-                                 "  The data that shall be written is entered using an interactive dialog.",
-                                 std::bind(&SingleRODACLIClientBase::CLICommandHandler, this,
-                                           std::placeholders::_1, std::placeholders::_2)));
-  ON_SCOPE_EXIT(removeCliCommand) { cli.RemoveCommand(cmdName.c_str()); };
+  cli_.AddCommand(Command::Create(cmdName.c_str(), " subcmd [args...]\n"
+                                  "Accesses the remote object dictionary. The type of access is specified by"
+                                  "<subcmd>:\n"
+                                  "- enum [0xFROM-0xTO]\n"
+                                  "  Enumerates objects contained in the object dictionary.\n"
+                                  "  Options:\n"
+                                  "    FROM   Index where enumeration shall start. Default: 0x0000\n"
+                                  "    TO     Index where enumeration shall end. Default: 0xFFFF\n"
+                                  "    FROM <= TO must be valid.\n"
+                                  "\n"
+                                  "- info 0xINDEX [asm]\n"
+                                  "  Prints the meta data of an object and its subindices.\n"
+                                  "  Options:\n"
+                                  "    asm   Includes application-specific meta data in the output.\n"
+                                  "\n"
+                                  "- read 0xINDEX:Subindex\n"
+                                  "  Reads the data of a subindex and prints it to CLI.\n"
+                                  "  <subindex> shall be provided in decimal format.\n"
+                                  "\n"
+                                  "- write 0xINDEX:Subindex DATA\n"
+                                  "  Writes <DATA> to a subindex. <Subindex> shall be provided in decimal format.\n"
+                                  "\n"
+                                  "  The format of <DATA> must meet the data type of the subindex:\n"
+                                  "  For BOOLEAN: TRUE, FALSE, true, false\n"
+                                  "  For REAL32/64: [+|-]digits[.][digits][(e|E)[+|-]digits]\n"
+                                  "  For VISIBLE_STRING: \"Text...\"\n"
+                                  "  For OCTET_STRING: 5B A3 ... (8bit hex values, separated by spaces)\n"
+                                  "  For UNICODE_STRING: 5B33 A6CF (16bit hex values, separated by spaces)\n"
+                                  "  For BIT1..BIT8: 0, 1, 3, 0x3, 0b11 (unused upper bits must be zero)\n"
+                                  "\n"
+                                  "- caread 0xINDEX [v]\n"
+                                  "  Reads the whole object via complete access and prints the value of each\n"
+                                  "  subindex to CLI.\n"
+                                  "  Options:\n"
+                                  "  v   Verbose output. Prints the data type and name of each subindex in addition\n"
+                                  "      to the data.\n"
+                                  "- cawrite 0xINDEX\n"
+                                  "  Writes the whole object via complete access.\n"
+                                  "  The data that shall be written is entered using an interactive dialog.",
+                                  std::bind(&SingleRODACLIClientBase::CLICommandHandler, this,
+                                            std::placeholders::_1, std::placeholders::_2)));
+  ON_SCOPE_EXIT(removeCliCommand) { cli_.RemoveCommand(cmdName.c_str()); };
 
   Connect(rodaItf);
 
@@ -128,7 +128,7 @@ SingleRODACLIClientBase::~SingleRODACLIClientBase(void)
 {
   try
   {
-    cli.RemoveCommand(cmdName.c_str());
+    cli_.RemoveCommand(cmdName.c_str());
     Disconnect();
   }
   catch (...)

--- a/src/cood/remote_access/requests_and_responses/ObjectEnumRequest.cpp
+++ b/src/cood/remote_access/requests_and_responses/ObjectEnumRequest.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2021, 2024 Daniel Jerolm
+    Copyright (C) 2021, 2024, 2025 Daniel Jerolm
 */
 
 #include <gpcc/cood/remote_access/requests_and_responses/ObjectEnumRequest.hpp>
@@ -18,7 +18,7 @@
 namespace gpcc {
 namespace cood {
 
-size_t const ObjectEnumRequest::objectEnumRequestBinarySize;
+size_t const ObjectEnumRequest::objectEnumRequestBinarySize_;
 
 /**
  * \brief Constructor.
@@ -33,19 +33,19 @@ size_t const ObjectEnumRequest::objectEnumRequestBinarySize;
  *
  * - - -
  *
- * \param _startIndex
+ * \param startIndex
  * Index where enumeration shall start.\n
  * Objects located at indices less than this will not be enumerated.
  *
- * \param _lastIndex
+ * \param lastIndex
  * Index where enumeration shall stop.\n
  * Objects located at indices larger than this will not be enumerated.
  *
- * \param _attrFilter
+ * \param attrFilter
  * Attribute-filter for enumeration.\n
  * Only objects with at least one matching attribute bit will be enumerated.
  *
- * \param _maxResponseSize
+ * \param maxResponseSize
  * Maximum size (in byte) of the serialized response object that can be processed by the creator of this request.
  * The value should be the minimum of the capability of the creator and the maximum possible response size announced
  * by @ref IRemoteObjectDictionaryAccessNotifiable::OnReady(), parameter `maxResponseSize`.\n
@@ -61,16 +61,16 @@ size_t const ObjectEnumRequest::objectEnumRequestBinarySize;
  * \htmlonly <style>div.image img[src="cood/RODA_ReqCTOR_MaxResponseSize.png"]{width:80%;}</style> \endhtmlonly
  * \image html "cood/RODA_ReqCTOR_MaxResponseSize.png" "Maximum response size with one ReturnStackItem"
  */
-ObjectEnumRequest::ObjectEnumRequest(uint16_t                   const _startIndex,
-                                     uint16_t                   const _lastIndex,
-                                     gpcc::cood::Object::attr_t const _attrFilter,
-                                     size_t                     const _maxResponseSize)
-: RequestBase(RequestTypes::objectEnumRequest, _maxResponseSize)
-, startIndex(_startIndex)
-, lastIndex(_lastIndex)
-, attrFilter(_attrFilter)
+ObjectEnumRequest::ObjectEnumRequest(uint16_t                   const startIndex,
+                                     uint16_t                   const lastIndex,
+                                     gpcc::cood::Object::attr_t const attrFilter,
+                                     size_t                     const maxResponseSize)
+: RequestBase(RequestTypes::objectEnumRequest, maxResponseSize)
+, startIndex_(startIndex)
+, lastIndex_(lastIndex)
+, attrFilter_(attrFilter)
 {
-  if ((startIndex > lastIndex) || (attrFilter == 0U))
+  if ((startIndex_ > lastIndex_) || (attrFilter_ == 0U))
     throw std::invalid_argument("ObjectEnumRequest::ObjectEnumRequest: Invalid args");
 }
 
@@ -105,14 +105,14 @@ ObjectEnumRequest::ObjectEnumRequest(uint16_t                   const _startInde
  */
 ObjectEnumRequest::ObjectEnumRequest(gpcc::stream::IStreamReader & sr, uint8_t const versionOnHand, ObjectEnumRequestPassKey)
 : RequestBase(RequestTypes::objectEnumRequest, sr, versionOnHand)
-, startIndex(sr.Read_uint16())
-, lastIndex(sr.Read_uint16())
-, attrFilter(static_cast<gpcc::cood::Object::attr_t>(sr.Read_uint16()))
+, startIndex_(sr.Read_uint16())
+, lastIndex_(sr.Read_uint16())
+, attrFilter_(static_cast<gpcc::cood::Object::attr_t>(sr.Read_uint16()))
 {
-  if (versionOnHand != version)
+  if (versionOnHand != version_)
     throw std::runtime_error("ObjectEnumRequest::ObjectEnumRequest: Version not supported");
 
-  if ((startIndex > lastIndex) || (attrFilter == 0U))
+  if ((startIndex_ > lastIndex_) || (attrFilter_ == 0U))
     throw std::runtime_error("ObjectEnumRequest::ObjectEnumRequest: Data read from 'sr' is invalid");
 }
 
@@ -121,7 +121,7 @@ ObjectEnumRequest::ObjectEnumRequest(gpcc::stream::IStreamReader & sr, uint8_t c
 /// \copydoc gpcc::cood::RequestBase::GetBinarySize
 size_t ObjectEnumRequest::GetBinarySize(void) const
 {
-  return RequestBase::GetBinarySize() + objectEnumRequestBinarySize;
+  return RequestBase::GetBinarySize() + objectEnumRequestBinarySize_;
 }
 
 /// \copydoc gpcc::cood::RequestBase::ToBinary
@@ -129,9 +129,9 @@ void ObjectEnumRequest::ToBinary(gpcc::stream::IStreamWriter & sw) const
 {
   RequestBase::ToBinary(sw);
 
-  sw.Write_uint16(startIndex);
-  sw.Write_uint16(lastIndex);
-  sw.Write_uint16(static_cast<uint16_t>(attrFilter));
+  sw.Write_uint16(startIndex_);
+  sw.Write_uint16(lastIndex_);
+  sw.Write_uint16(static_cast<uint16_t>(attrFilter_));
 }
 
 /// \copydoc gpcc::cood::RequestBase::ToString
@@ -140,9 +140,9 @@ std::string ObjectEnumRequest::ToString(void) const
   gpcc::string::StringComposer s;
 
   s << "Object enum request. Start = "
-    << gpcc::string::ToHex(startIndex, 4U) << ", Last = "
-    << gpcc::string::ToHex(lastIndex, 4U) << ", AF = "
-    << gpcc::string::ToHex(static_cast<uint16_t>(attrFilter), 4U);
+    << gpcc::string::ToHex(startIndex_, 4U) << ", Last = "
+    << gpcc::string::ToHex(lastIndex_, 4U) << ", AF = "
+    << gpcc::string::ToHex(static_cast<uint16_t>(attrFilter_), 4U);
 
   return s.Get();
 }

--- a/src/cood/remote_access/requests_and_responses/ObjectEnumResponse.cpp
+++ b/src/cood/remote_access/requests_and_responses/ObjectEnumResponse.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2021, 2024 Daniel Jerolm
+    Copyright (C) 2021, 2024, 2025 Daniel Jerolm
 */
 
 #include <gpcc/cood/remote_access/requests_and_responses/ObjectEnumResponse.hpp>
@@ -20,8 +20,8 @@
 namespace gpcc {
 namespace cood {
 
-size_t const ObjectEnumResponse::objectEnumResponseBinarySize;
-size_t const ObjectEnumResponse::maxNbOfIndices;
+size_t const ObjectEnumResponse::objectEnumResponseBinarySize_;
+size_t const ObjectEnumResponse::maxNbOfIndices_;
 
 /**
  * \brief Constructor. Creates a response object with encapsulated result initialized with an error status.
@@ -40,17 +40,17 @@ size_t const ObjectEnumResponse::maxNbOfIndices;
  *
  * - - -
  *
- * \param _result
+ * \param result
  * Result value that shall be encapsulated in the object.\n
  * This must be a negative status code. @ref SDOAbortCode::OK is not allowed.
  */
-ObjectEnumResponse::ObjectEnumResponse(SDOAbortCode const _result)
+ObjectEnumResponse::ObjectEnumResponse(SDOAbortCode const result)
 : ResponseBase(ResponseTypes::objectEnumResponse)
-, result(_result)
-, complete(false)
-, indices()
+, result_(result)
+, complete_(false)
+, indices_()
 {
-  if (result == SDOAbortCode::OK)
+  if (result_ == SDOAbortCode::OK)
     throw std::invalid_argument("ObjectEnumResponse::ObjectEnumResponse: Negative result expected");
 }
 
@@ -85,23 +85,23 @@ ObjectEnumResponse::ObjectEnumResponse(SDOAbortCode const _result)
  */
 ObjectEnumResponse::ObjectEnumResponse(gpcc::stream::IStreamReader & sr, uint8_t const versionOnHand, ObjectEnumResponsePassKey)
 : ResponseBase(ResponseTypes::objectEnumResponse, sr, versionOnHand)
-, result(SDOAbortCode::GeneralError)
-, complete(false)
-, indices()
+, result_(SDOAbortCode::GeneralError)
+, complete_(false)
+, indices_()
 {
   auto const result_u32 = sr.Read_uint32();
   try
   {
-    result = U32ToSDOAbortCode(result_u32);
+    result_ = U32ToSDOAbortCode(result_u32);
   }
   catch (std::exception const &)
   {
     std::throw_with_nested(std::runtime_error("ObjectEnumResponse::ObjectEnumResponse: Data read from 'sr' is invalid"));
   }
 
-  if (result == SDOAbortCode::OK)
+  if (result_ == SDOAbortCode::OK)
   {
-    complete = sr.Read_bool();
+    complete_ = sr.Read_bool();
 
     // MSB...
     uint_fast32_t nbOfIndices = (sr.Read_bool()) ? (1UL << 16U) : 0U;
@@ -111,18 +111,18 @@ ObjectEnumResponse::ObjectEnumResponse(gpcc::stream::IStreamReader & sr, uint8_t
     nbOfIndices |= sr.Read_uint16();
     if (nbOfIndices != 0U)
     {
-      if (nbOfIndices > maxNbOfIndices)
+      if (nbOfIndices > maxNbOfIndices_)
         throw std::runtime_error("ObjectEnumResponse::ObjectEnumResponse: Data read from 'sr' is invalid");
 
       // if maximum number of indices is contained, then enumeration MUST be complete
-      if ((nbOfIndices == maxNbOfIndices) && (!complete))
+      if ((nbOfIndices == maxNbOfIndices_) && (!complete_))
         throw std::runtime_error("ObjectEnumResponse::ObjectEnumResponse: Data read from 'sr' is invalid");
 
-      indices.reserve(nbOfIndices);
+      indices_.reserve(nbOfIndices);
 
       // read first index
       uint16_t val = sr.Read_uint16();
-      indices.push_back(val);
+      indices_.push_back(val);
       --nbOfIndices;
 
       // read the others and check for ascending order
@@ -130,21 +130,21 @@ ObjectEnumResponse::ObjectEnumResponse(gpcc::stream::IStreamReader & sr, uint8_t
       {
         val = sr.Read_uint16();
 
-        if (val <= indices.back())
+        if (val <= indices_.back())
           throw std::runtime_error("ObjectEnumResponse::ObjectEnumResponse: Data read from 'sr' is invalid");
 
-        indices.push_back(val);
+        indices_.push_back(val);
         --nbOfIndices;
       }
 
       // if the last index is included, then enumeration MUST be complete
-      if ((!complete) && (indices.back() == 0xFFFFU))
+      if ((!complete_) && (indices_.back() == 0xFFFFU))
         throw std::runtime_error("ObjectEnumResponse::ObjectEnumResponse: Data read from 'sr' is invalid");
     }
     else
     {
       // if no index is included, then enumeration MUST be complete
-      if (!complete)
+      if (!complete_)
         throw std::runtime_error("ObjectEnumResponse::ObjectEnumResponse: Data read from 'sr' is invalid");
     }
   }
@@ -189,7 +189,7 @@ size_t ObjectEnumResponse::CalcMaxNbOfIndices(size_t const maxResponseSize, size
   size_t maxDataPayload = maxResponseSize;
 
   // subtract overhead of ResponseBase and ObjectEnumResponse
-  size_t const binarySize = baseBinarySize + objectEnumResponseBinarySize;
+  size_t const binarySize = baseBinarySize_ + objectEnumResponseBinarySize_;
   static_assert((binarySize + sizeof(uint16_t)) <= ResponseBase::minimumUsefulResponseSize,
                 "Base size of serialized ObjectEnumResponse plus one payload item exceeds ResponseBase::minimumUsefulResponseSize");
 
@@ -207,9 +207,9 @@ size_t ObjectEnumResponse::CalcMaxNbOfIndices(size_t const maxResponseSize, size
   // translate to number of indices
   size_t maxPossibleNbOfIndices = maxDataPayload / 2U;
 
-  // limit to maxNbOfIndices
-  if (maxPossibleNbOfIndices > maxNbOfIndices)
-    maxPossibleNbOfIndices = maxNbOfIndices;
+  // limit to maxNbOfIndices_
+  if (maxPossibleNbOfIndices > maxNbOfIndices_)
+    maxPossibleNbOfIndices = maxNbOfIndices_;
 
   // that's it
   return maxPossibleNbOfIndices;
@@ -227,7 +227,7 @@ size_t ObjectEnumResponse::GetBinarySize(void) const
   //       =4
   s += 4U;
 
-  if (result == SDOAbortCode::OK)
+  if (result_ == SDOAbortCode::OK)
   {
     // complete             0.1
     // MSB of indices.size  0.1
@@ -237,7 +237,7 @@ size_t ObjectEnumResponse::GetBinarySize(void) const
     //                     =3
     s += 3U;
 
-    s += indices.size() * sizeof(uint16_t);
+    s += indices_.size() * sizeof(uint16_t);
   }
 
   return s;
@@ -248,16 +248,16 @@ void ObjectEnumResponse::ToBinary(gpcc::stream::IStreamWriter & sw) const
 {
   ResponseBase::ToBinary(sw);
 
-  sw.Write_uint32(static_cast<uint32_t>(result));
+  sw.Write_uint32(static_cast<uint32_t>(result_));
 
-  if (result == SDOAbortCode::OK)
+  if (result_ == SDOAbortCode::OK)
   {
-    sw.Write_bool(complete);
-    sw.Write_bool((indices.size() & 0x10000UL) != 0U);
+    sw.Write_bool(complete_);
+    sw.Write_bool((indices_.size() & 0x10000UL) != 0U);
     sw.AlignToByteBoundary(false);
 
-    sw.Write_uint16(static_cast<uint16_t>(indices.size() & 0xFFFFUL));
-    sw.Write_uint16(indices.data(), indices.size());
+    sw.Write_uint16(static_cast<uint16_t>(indices_.size() & 0xFFFFUL));
+    sw.Write_uint16(indices_.data(), indices_.size());
   }
 }
 
@@ -265,16 +265,16 @@ void ObjectEnumResponse::ToBinary(gpcc::stream::IStreamWriter & sw) const
 std::string ObjectEnumResponse::ToString(void) const
 {
   gpcc::string::StringComposer s;
-  s << "Object enum response: " << SDOAbortCodeToDescrString(result);
+  s << "Object enum response: " << SDOAbortCodeToDescrString(result_);
 
-  if (result == SDOAbortCode::OK)
+  if (result_ == SDOAbortCode::OK)
   {
     s << ", ";
 
-    if (!complete)
+    if (!complete_)
       s << "not ";
 
-    s << "complete, " << indices.size() << " indices";
+    s << "complete, " << indices_.size() << " indices";
   }
 
   return s.Get();
@@ -300,17 +300,17 @@ std::string ObjectEnumResponse::ToString(void) const
  *
  * - - -
  *
- * \param _result
+ * \param result
  * Desired value for the encapsulated result.\n
  * An error status is expected. @ref SDOAbortCode::OK is not allowed.
  */
-void ObjectEnumResponse::SetError(SDOAbortCode const _result)
+void ObjectEnumResponse::SetError(SDOAbortCode const result)
 {
-  if (_result == SDOAbortCode::OK)
+  if (result == SDOAbortCode::OK)
     throw std::invalid_argument("ObjectEnumResponse::SetError: Negative result expected");
 
-  result = _result;
-  indices.clear();
+  result_ = result;
+  indices_.clear();
 }
 
 /**
@@ -333,40 +333,40 @@ void ObjectEnumResponse::SetError(SDOAbortCode const _result)
  *
  * - - -
  *
- * \param _indices
+ * \param indices
  * The content of the referenced vector will be moved into the response object.\n
  * The indices must be sorted in ascending order.
  * The referenced vector will be empty afterwards.
  *
- * \param _complete
+ * \param complete
  * Indicates if the enumeration request has been completely served (true), or if there are some objects left to
  * enumerate (false) whose indices did not fit into the response.
  */
-void ObjectEnumResponse::SetData(std::vector<uint16_t> && _indices, bool const _complete)
+void ObjectEnumResponse::SetData(std::vector<uint16_t> && indices, bool const complete)
 {
-  if (_indices.size() > maxNbOfIndices)
-    throw std::invalid_argument("ObjectEnumResponse::SetData: _indices is too large.");
+  if (indices.size() > maxNbOfIndices_)
+    throw std::invalid_argument("ObjectEnumResponse::SetData: indices is too large.");
 
-  if (!_complete)
+  if (!complete)
   {
-    // _indices can't be empty if the enum operation is not complete
-    if (_indices.empty())
+    // indices can't be empty if the enum operation is not complete
+    if (indices.empty())
       throw std::invalid_argument("ObjectEnumResponse::SetData: Incomplete but no item");
 
     // if the last enumerated index is 0xFFFF, then the enum operation can't be incomplete
-    if (_indices.back() == 0xFFFFU)
+    if (indices.back() == 0xFFFFU)
       throw std::invalid_argument("ObjectEnumResponse::SetData: Incomplete but 0xFFFF included");
 
     // if all possible indices are enumerated, then the enum operation can't be incomplete
-    if (_indices.size() == maxNbOfIndices)
+    if (indices.size() == maxNbOfIndices_)
       throw std::invalid_argument("ObjectEnumResponse::SetData: Incomplete but all included");
   }
 
   // check for ascending order of enumerated indices
-  if (_indices.size() > 1U)
+  if (indices.size() > 1U)
   {
     int32_t prev = -1;
-    for (int32_t const e: _indices)
+    for (int32_t const e: indices)
     {
       if (e <= prev)
         throw std::invalid_argument("ObjectEnumResponse::SetData: Not properly sorted");
@@ -374,11 +374,11 @@ void ObjectEnumResponse::SetData(std::vector<uint16_t> && _indices, bool const _
     }
   }
 
-  indices = std::move(_indices);
-  _indices.clear();
+  indices_ = std::move(indices);
+  indices.clear();
 
-  result = SDOAbortCode::OK;
-  complete = _complete;
+  result_ = SDOAbortCode::OK;
+  complete_ = complete;
 }
 
 /**
@@ -402,7 +402,7 @@ void ObjectEnumResponse::SetData(std::vector<uint16_t> && _indices, bool const _
  */
 SDOAbortCode ObjectEnumResponse::GetResult(void) const noexcept
 {
-  return result;
+  return result_;
 }
 
 /**
@@ -443,18 +443,18 @@ SDOAbortCode ObjectEnumResponse::GetResult(void) const noexcept
  */
 bool ObjectEnumResponse::IsComplete(uint16_t * const pNextIndex) const
 {
-  if (result != SDOAbortCode::OK)
+  if (result_ != SDOAbortCode::OK)
     throw std::logic_error("ObjectEnumResponse::IsComplete: Enumeration failed");
 
-  if (!complete)
+  if (!complete_)
   {
     // "indices" can't be empty if the enum operation is not complete
-    if (indices.empty())
+    if (indices_.empty())
       throw std::logic_error("ObjectEnumResponse::IsComplete: Invalid. Source of move?");
 
     if (pNextIndex != nullptr)
     {
-      uint32_t const nextIndex = indices.back() + 1UL;
+      uint32_t const nextIndex = indices_.back() + 1UL;
       if (nextIndex > 0xFFFFU)
         throw std::logic_error("ObjectEnumResponse::IsComplete: Invalid");
 
@@ -462,7 +462,7 @@ bool ObjectEnumResponse::IsComplete(uint16_t * const pNextIndex) const
     }
   }
 
-  return complete;
+  return complete_;
 }
 
 /**
@@ -496,38 +496,38 @@ bool ObjectEnumResponse::IsComplete(uint16_t * const pNextIndex) const
  */
 void ObjectEnumResponse::AddFragment(ObjectEnumResponse const & fragment)
 {
-  if (result != SDOAbortCode::OK)
+  if (result_ != SDOAbortCode::OK)
     throw std::logic_error("ObjectEnumResponse::AddFragment: Enumeration failed.");
 
-  if (complete)
+  if (complete_)
     throw std::logic_error("ObjectEnumResponse::AddFragment: Already complete");
 
-  if (fragment.result != SDOAbortCode::OK)
+  if (fragment.result_ != SDOAbortCode::OK)
     throw std::invalid_argument("ObjectEnumResponse::AddFragment: Fragment contains bad result");
 
-  if (   (!indices.empty())
-      && (!fragment.indices.empty())
-      && (indices.back() >= fragment.indices.front()))
+  if (   (!indices_.empty())
+      && (!fragment.indices_.empty())
+      && (indices_.back() >= fragment.indices_.front()))
   {
     throw std::invalid_argument("ObjectEnumResponse::AddFragment: Discontinuity");
   }
 
   // determine new size and reserve storage
-  size_t const newSize = indices.size() + fragment.indices.size();
-  if (newSize > maxNbOfIndices)
+  size_t const newSize = indices_.size() + fragment.indices_.size();
+  if (newSize > maxNbOfIndices_)
     throw std::logic_error("ObjectEnumResponse::AddFragment");
 
-  indices.reserve(newSize);
+  indices_.reserve(newSize);
 
   // prepare for rollback
-  size_t const prevSize = indices.size();
-  ON_SCOPE_EXIT(undo) { indices.resize(prevSize); };
+  size_t const prevSize = indices_.size();
+  ON_SCOPE_EXIT(undo) { indices_.resize(prevSize); };
 
-  indices.insert(indices.end(), fragment.indices.begin(), fragment.indices.end());
+  indices_.insert(indices_.end(), fragment.indices_.begin(), fragment.indices_.end());
 
   ON_SCOPE_EXIT_DISMISS(undo);
 
-  complete = fragment.complete;
+  complete_ = fragment.complete_;
 }
 
 /**
@@ -557,10 +557,10 @@ void ObjectEnumResponse::AddFragment(ObjectEnumResponse const & fragment)
  */
 std::vector<uint16_t> const & ObjectEnumResponse::GetIndices(void) const
 {
-  if (result != SDOAbortCode::OK)
+  if (result_ != SDOAbortCode::OK)
     throw std::logic_error("ObjectEnumResponse::GetIndices: Enumeration failed");
 
-  return indices;
+  return indices_;
 }
 
 } // namespace cood

--- a/src/cood/remote_access/requests_and_responses/ObjectInfoRequest.cpp
+++ b/src/cood/remote_access/requests_and_responses/ObjectInfoRequest.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2021, 2024 Daniel Jerolm
+    Copyright (C) 2021, 2024, 2025 Daniel Jerolm
 */
 
 #include <gpcc/cood/remote_access/requests_and_responses/ObjectInfoRequest.hpp>
@@ -18,7 +18,7 @@
 namespace gpcc {
 namespace cood {
 
-size_t const ObjectInfoRequest::objectInfoRequestBinarySize;
+size_t const ObjectInfoRequest::objectInfoRequestBinarySize_;
 
 /**
  * \brief Constructor.
@@ -42,24 +42,24 @@ size_t const ObjectInfoRequest::objectInfoRequestBinarySize;
  *
  * - - -
  *
- * \param _index
+ * \param index
  * Index of the object whose meta data shall be read.
  *
- * \param _firstSubIndex
+ * \param firstSubIndex
  * Number of the first subindex whose meta data shall be read.
  *
- * \param _lastSubIndex
+ * \param lastSubIndex
  * Number of the last subindex whose meta data shall be read.
  *
- * \param _inclusiveNames
+ * \param inclusiveNames
  * Controls if the names of the object and the subindices shall be included in the response (true) or not (false).\n
  * If names are included, then the size of the response may increase significantly.
  *
- * \param _inclusiveAppSpecificMetaData
+ * \param inclusiveAppSpecificMetaData
  * Controls if application specific meta data of the subindices shall be included in the response (true) or not (false).\n
  * If application specific meta data is included, then the size of the response may increase significantly.
  *
- * \param _maxResponseSize
+ * \param maxResponseSize
  * Maximum size (in byte) of the serialized response object that can be processed by the creator of this request.
  * The value should be the minimum of the capability of the creator and the maximum possible response size announced
  * by @ref IRemoteObjectDictionaryAccessNotifiable::OnReady(), parameter `maxResponseSize`.\n
@@ -75,20 +75,20 @@ size_t const ObjectInfoRequest::objectInfoRequestBinarySize;
  * \htmlonly <style>div.image img[src="cood/RODA_ReqCTOR_MaxResponseSize.png"]{width:80%;}</style> \endhtmlonly
  * \image html "cood/RODA_ReqCTOR_MaxResponseSize.png" "Maximum response size with one ReturnStackItem"
  */
-ObjectInfoRequest::ObjectInfoRequest(uint16_t const _index,
-                                     uint8_t  const _firstSubIndex,
-                                     uint8_t  const _lastSubIndex,
-                                     bool     const _inclusiveNames,
-                                     bool     const _inclusiveAppSpecificMetaData,
-                                     size_t   const _maxResponseSize)
-: RequestBase(RequestTypes::objectInfoRequest, _maxResponseSize)
-, index(_index)
-, firstSubIndex(_firstSubIndex)
-, lastSubIndex(_lastSubIndex)
-, inclusiveNames(_inclusiveNames)
-, inclusiveAppSpecificMetaData(_inclusiveAppSpecificMetaData)
+ObjectInfoRequest::ObjectInfoRequest(uint16_t const index,
+                                     uint8_t  const firstSubIndex,
+                                     uint8_t  const lastSubIndex,
+                                     bool     const inclusiveNames,
+                                     bool     const inclusiveAppSpecificMetaData,
+                                     size_t   const maxResponseSize)
+: RequestBase(RequestTypes::objectInfoRequest, maxResponseSize)
+, index_(index)
+, firstSubIndex_(firstSubIndex)
+, lastSubIndex_(lastSubIndex)
+, inclusiveNames_(inclusiveNames)
+, inclusiveAppSpecificMetaData_(inclusiveAppSpecificMetaData)
 {
-  if (firstSubIndex > lastSubIndex)
+  if (firstSubIndex_ > lastSubIndex_)
     throw std::invalid_argument("ObjectInfoRequest::ObjectInfoRequest: first/last subindex invalid");
 }
 
@@ -123,18 +123,18 @@ ObjectInfoRequest::ObjectInfoRequest(uint16_t const _index,
  */
 ObjectInfoRequest::ObjectInfoRequest(gpcc::stream::IStreamReader & sr, uint8_t const versionOnHand, ObjectInfoRequestPassKey)
 : RequestBase(RequestTypes::objectInfoRequest, sr, versionOnHand)
-, index(sr.Read_uint16())
-, firstSubIndex(sr.Read_uint8())
-, lastSubIndex(sr.Read_uint8())
-, inclusiveNames(sr.Read_bool())
-, inclusiveAppSpecificMetaData(sr.Read_bool())
+, index_(sr.Read_uint16())
+, firstSubIndex_(sr.Read_uint8())
+, lastSubIndex_(sr.Read_uint8())
+, inclusiveNames_(sr.Read_bool())
+, inclusiveAppSpecificMetaData_(sr.Read_bool())
 {
   sr.Skip(6U);
 
-  if (versionOnHand != version)
+  if (versionOnHand != version_)
     throw std::runtime_error("ObjectInfoRequest::ObjectInfoRequest: Version not supported");
 
-  if (firstSubIndex > lastSubIndex)
+  if (firstSubIndex_ > lastSubIndex_)
     throw std::runtime_error("ObjectInfoRequest::ObjectInfoRequest: Data read from 'sr' is invalid");
 }
 
@@ -143,7 +143,7 @@ ObjectInfoRequest::ObjectInfoRequest(gpcc::stream::IStreamReader & sr, uint8_t c
 /// \copydoc gpcc::cood::RequestBase::GetBinarySize
 size_t ObjectInfoRequest::GetBinarySize(void) const
 {
-  return RequestBase::GetBinarySize() + objectInfoRequestBinarySize;
+  return RequestBase::GetBinarySize() + objectInfoRequestBinarySize_;
 }
 
 /// \copydoc gpcc::cood::RequestBase::ToBinary
@@ -151,11 +151,11 @@ void ObjectInfoRequest::ToBinary(gpcc::stream::IStreamWriter & sw) const
 {
   RequestBase::ToBinary(sw);
 
-  sw.Write_uint16(index);
-  sw.Write_uint8(firstSubIndex);
-  sw.Write_uint8(lastSubIndex);
-  sw.Write_bool(inclusiveNames);
-  sw.Write_bool(inclusiveAppSpecificMetaData);
+  sw.Write_uint16(index_);
+  sw.Write_uint8(firstSubIndex_);
+  sw.Write_uint8(lastSubIndex_);
+  sw.Write_bool(inclusiveNames_);
+  sw.Write_bool(inclusiveAppSpecificMetaData_);
   sw.AlignToByteBoundary(false);
 }
 
@@ -165,15 +165,15 @@ std::string ObjectInfoRequest::ToString(void) const
   gpcc::string::StringComposer s;
 
   s << "Object info request for "
-    << gpcc::string::ToHex(index, 4U) << ", SI range "
-    << static_cast<unsigned int>(firstSubIndex) << ".." << static_cast<unsigned int>(lastSubIndex);
+    << gpcc::string::ToHex(index_, 4U) << ", SI range "
+    << static_cast<unsigned int>(firstSubIndex_) << ".." << static_cast<unsigned int>(lastSubIndex_);
 
-  if (inclusiveNames)
+  if (inclusiveNames_)
     s << ", incl. names";
   else
     s << ", excl. names";
 
-  if (inclusiveAppSpecificMetaData)
+  if (inclusiveAppSpecificMetaData_)
     s << ", incl. asm";
   else
     s << ", excl. asm";

--- a/src/cood/remote_access/requests_and_responses/ObjectInfoResponse.cpp
+++ b/src/cood/remote_access/requests_and_responses/ObjectInfoResponse.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2021, 2024 Daniel Jerolm
+    Copyright (C) 2021, 2024, 2025 Daniel Jerolm
 */
 
 #include <gpcc/cood/remote_access/requests_and_responses/ObjectInfoResponse.hpp>
@@ -94,7 +94,7 @@ ObjectInfoResponse::ObjectInfoResponse(SDOAbortCode const _result)
  * Controls if application specific meta data of the subindices shall be included in the response (true) or not (false).\n
  * If application specific meta data is included, then the size of the response may increase significantly.
  *
- * \param maxResponseSize
+ * \param _maxResponseSize
  * Maximum permitted response size in byte.\n
  * The value refers to a serialized response object incl. potential @ref ReturnStackItem objects and response payload
  * data.
@@ -108,7 +108,7 @@ ObjectInfoResponse::ObjectInfoResponse(Object const & obj,
                                        uint8_t lastSubindex,
                                        bool const _inclusiveNames,
                                        bool const _inclusiveAppSpecificMetaData,
-                                       size_t const maxResponseSize,
+                                       size_t const _maxResponseSize,
                                        size_t const returnStackSize)
 : ResponseBase(ResponseTypes::objectInfoResponse)
 , result(SDOAbortCode::OK)
@@ -158,7 +158,7 @@ ObjectInfoResponse::ObjectInfoResponse(Object const & obj,
   // We have to fill at least the information about "firstSubIndex" into "subindexDescr".
   // The remaining number of queried subindices depends on the maximum payload capacity of the remote access response.
 
-  size_t remainingCapacity = CalcRemainingPayload(maxResponseSize, returnStackSize);
+  size_t remainingCapacity = CalcRemainingPayload(_maxResponseSize, returnStackSize);
 
   subindexDescr.reserve(((lastSubindex - firstSubindex) + 1U));
 
@@ -1138,7 +1138,7 @@ void ObjectInfoResponse::ValidateObjNotEmpty(void) const
  *
  * - - -
  *
- * \param maxResponseSize
+ * \param _maxResponseSize
  * Maximum permitted response size in byte.\n
  * The value refers to a serialized response object incl. potential @ref ReturnStackItem objects and response payload
  * data.
@@ -1150,10 +1150,10 @@ void ObjectInfoResponse::ValidateObjNotEmpty(void) const
  * \return
  * Maximum size (in byte) of the data payload that could be added to this object.
  */
-size_t ObjectInfoResponse::CalcRemainingPayload(size_t const maxResponseSize, size_t const returnStackSize) const
+size_t ObjectInfoResponse::CalcRemainingPayload(size_t const _maxResponseSize, size_t const returnStackSize) const
 {
   // start
-  size_t remainingDataPayloadCapacity = maxResponseSize;
+  size_t remainingDataPayloadCapacity = _maxResponseSize;
 
   // subtract current size of the object
   auto const binarySize = GetBinarySize();

--- a/src/cood/remote_access/requests_and_responses/ObjectInfoResponse.cpp
+++ b/src/cood/remote_access/requests_and_responses/ObjectInfoResponse.cpp
@@ -33,23 +33,23 @@ namespace cood {
  *
  * - - -
  *
- * \param _result
+ * \param result
  * Result of the object meta data query operation.\n
  * @ref SDOAbortCode::OK is not allowed.
  */
-ObjectInfoResponse::ObjectInfoResponse(SDOAbortCode const _result)
+ObjectInfoResponse::ObjectInfoResponse(SDOAbortCode const result)
 : ResponseBase(ResponseTypes::objectInfoResponse)
-, result(_result)
-, inclusiveNames(false)
-, inclusiveAppSpecificMetaData(false)
-, objectCode(Object::ObjectCode::Null)
-, objType(DataType::null)
-, objName()
-, maxNbOfSubindices(0U)
-, firstSubindex(0U)
-, subindexDescr()
+, result_(result)
+, inclusiveNames_(false)
+, inclusiveAppSpecificMetaData_(false)
+, objectCode_(Object::ObjectCode::Null)
+, objType_(DataType::null)
+, objName_()
+, maxNbOfSubindices_(0U)
+, firstSubindex_(0U)
+, subindexDescr_()
 {
-  if (result == SDOAbortCode::OK)
+  if (result_ == SDOAbortCode::OK)
     throw std::invalid_argument("ObjectInfoResponse::ObjectInfoResponse: Result 'OK' not allowed for this CTOR");
 }
 
@@ -74,7 +74,7 @@ ObjectInfoResponse::ObjectInfoResponse(SDOAbortCode const _result)
  * \param obj
  * Unmodifiable reference to the object whose meta data shall be queried.
  *
- * \param _firstSubindex
+ * \param firstSubindex
  * Number of the first subindex that shall be contained in the response.\n
  * If the value exceeds the object's maximum number of subindices minus one, then this value will be reduced so that the
  * response contains the meta data of at least one subindex.
@@ -86,15 +86,15 @@ ObjectInfoResponse::ObjectInfoResponse(SDOAbortCode const _result)
  * The value returned by @ref GetLastQueriedSubindex() may be larger than this if the queried object is an ARRAY and if
  * application specific meta data is not included in the query.
  *
- * \param _inclusiveNames
+ * \param inclusiveNames
  * Controls if the names of the object and the subindices shall be included in the response (true) or not (false).\n
  * If names are included, then the size of the response may increase significantly.
  *
- * \param _inclusiveAppSpecificMetaData
+ * \param inclusiveAppSpecificMetaData
  * Controls if application specific meta data of the subindices shall be included in the response (true) or not (false).\n
  * If application specific meta data is included, then the size of the response may increase significantly.
  *
- * \param _maxResponseSize
+ * \param maximumResponseSize
  * Maximum permitted response size in byte.\n
  * The value refers to a serialized response object incl. potential @ref ReturnStackItem objects and response payload
  * data.
@@ -104,44 +104,44 @@ ObjectInfoResponse::ObjectInfoResponse(SDOAbortCode const _result)
  * response object.
  */
 ObjectInfoResponse::ObjectInfoResponse(Object const & obj,
-                                       uint8_t const _firstSubindex,
+                                       uint8_t const firstSubindex,
                                        uint8_t lastSubindex,
-                                       bool const _inclusiveNames,
-                                       bool const _inclusiveAppSpecificMetaData,
-                                       size_t const _maxResponseSize,
+                                       bool const inclusiveNames,
+                                       bool const inclusiveAppSpecificMetaData,
+                                       size_t const maximumResponseSize,
                                        size_t const returnStackSize)
 : ResponseBase(ResponseTypes::objectInfoResponse)
-, result(SDOAbortCode::OK)
-, inclusiveNames(_inclusiveNames)
-, inclusiveAppSpecificMetaData(_inclusiveAppSpecificMetaData)
-, objectCode(obj.GetObjectCode())
-, objType(obj.GetObjectDataType())
-, objName()
-, maxNbOfSubindices(obj.GetMaxNbOfSubindices())
-, firstSubindex(_firstSubindex)
-, subindexDescr()
+, result_(SDOAbortCode::OK)
+, inclusiveNames_(inclusiveNames)
+, inclusiveAppSpecificMetaData_(inclusiveAppSpecificMetaData)
+, objectCode_(obj.GetObjectCode())
+, objType_(obj.GetObjectDataType())
+, objName_()
+, maxNbOfSubindices_(obj.GetMaxNbOfSubindices())
+, firstSubindex_(firstSubindex)
+, subindexDescr_()
 {
-  if (firstSubindex > lastSubindex)
+  if (firstSubindex_ > lastSubindex)
     throw std::invalid_argument("ObjectInfoResponse::ObjectInfoResponse: Subindex range is invalid");
 
-  if ((maxNbOfSubindices == 0U) || (maxNbOfSubindices > 256U))
+  if ((maxNbOfSubindices_ == 0U) || (maxNbOfSubindices_ > 256U))
     throw std::logic_error("ObjectInfoResponse::ObjectInfoResponse: obj.GetMaxNbOfSubindices() returns invalid value");
 
-  if (inclusiveNames)
-    objName = obj.GetObjectName();
+  if (inclusiveNames_)
+    objName_ = obj.GetObjectName();
 
-  if (firstSubindex >= maxNbOfSubindices)
-    firstSubindex = maxNbOfSubindices - 1U;
+  if (firstSubindex_ >= maxNbOfSubindices_)
+    firstSubindex_ = maxNbOfSubindices_ - 1U;
 
   // ARRAY is special:
   // If application specific meta data is NOT included in the response, then all SIs have same properties. In that case
   // it is sufficient to collect information about SI0 and SI1 only. The information collected about SI1 can be used for
   // all other SIs too.
-  if ((objectCode == Object::ObjectCode::Array) && (!inclusiveAppSpecificMetaData))
+  if ((objectCode_ == Object::ObjectCode::Array) && (!inclusiveAppSpecificMetaData_))
   {
-    if (firstSubindex > 1U)
+    if (firstSubindex_ > 1U)
     {
-      firstSubindex = 1U;
+      firstSubindex_ = 1U;
       lastSubindex = 1U;
     }
     else if (lastSubindex > 1U)
@@ -150,36 +150,36 @@ ObjectInfoResponse::ObjectInfoResponse(Object const & obj,
     }
   }
 
-  if (lastSubindex >= maxNbOfSubindices)
-    lastSubindex = maxNbOfSubindices - 1U;
+  if (lastSubindex >= maxNbOfSubindices_)
+    lastSubindex = maxNbOfSubindices_ - 1U;
 
 
-  // Now [firstSubindex; lastSubindex] is the range of subindices we have to query and fill into "subindexDescr".
-  // We have to fill at least the information about "firstSubIndex" into "subindexDescr".
+  // Now [firstSubindex_; lastSubindex] is the range of subindices we have to query and fill into "subindexDescr_".
+  // We have to fill at least the information about "firstSubIndex" into "subindexDescr_".
   // The remaining number of queried subindices depends on the maximum payload capacity of the remote access response.
 
-  size_t remainingCapacity = CalcRemainingPayload(_maxResponseSize, returnStackSize);
+  size_t remainingCapacity = CalcRemainingPayload(maximumResponseSize, returnStackSize);
 
-  subindexDescr.reserve(((lastSubindex - firstSubindex) + 1U));
+  subindexDescr_.reserve(((lastSubindex - firstSubindex_) + 1U));
 
-  for (uint_fast16_t i = firstSubindex; i <= lastSubindex; i++)
+  for (uint_fast16_t i = firstSubindex_; i <= lastSubindex; i++)
   {
     // Query meta data from SI and determine binary size of the container created for the subindex' meta data.
-    subindexDescr.emplace_back(obj, i, inclusiveNames, inclusiveAppSpecificMetaData);
-    auto const s = subindexDescr.back().GetBinarySize();
+    subindexDescr_.emplace_back(obj, i, inclusiveNames_, inclusiveAppSpecificMetaData_);
+    auto const s = subindexDescr_.back().GetBinarySize();
 
     // capacity of response exceeded?
     if (s > remainingCapacity)
     {
       // Is it the first subindex description? -> :-( we have to deliver at least one description
-      if (i == firstSubindex)
+      if (i == firstSubindex_)
       {
         throw std::runtime_error("ObjectInfoResponse::ObjectInfoResponse: No space for at least one SI description");
       }
       else
       {
         // remove the last item and finish
-        subindexDescr.pop_back();
+        subindexDescr_.pop_back();
         break;
       }
     }
@@ -221,65 +221,65 @@ ObjectInfoResponse::ObjectInfoResponse(Object const & obj,
  */
 ObjectInfoResponse::ObjectInfoResponse(gpcc::stream::IStreamReader & sr, uint8_t const versionOnHand, ObjectInfoResponsePassKey)
 : ResponseBase(ResponseTypes::objectInfoResponse, sr, versionOnHand)
-, result(SDOAbortCode::GeneralError)
-, inclusiveNames(false)
-, inclusiveAppSpecificMetaData(false)
-, objectCode(Object::ObjectCode::Null)
-, objType(DataType::null)
-, objName()
-, maxNbOfSubindices(0U)
-, firstSubindex(0U)
-, subindexDescr()
+, result_(SDOAbortCode::GeneralError)
+, inclusiveNames_(false)
+, inclusiveAppSpecificMetaData_(false)
+, objectCode_(Object::ObjectCode::Null)
+, objType_(DataType::null)
+, objName_()
+, maxNbOfSubindices_(0U)
+, firstSubindex_(0U)
+, subindexDescr_()
 {
   try
   {
-    result = U32ToSDOAbortCode(sr.Read_uint32());
-    if (result != SDOAbortCode::OK)
+    result_ = U32ToSDOAbortCode(sr.Read_uint32());
+    if (result_ != SDOAbortCode::OK)
       return;
 
-    inclusiveNames = sr.Read_bool();
-    inclusiveAppSpecificMetaData = sr.Read_bool();
+    inclusiveNames_ = sr.Read_bool();
+    inclusiveAppSpecificMetaData_ = sr.Read_bool();
 
-    objectCode = Object::ToObjectCode(sr.Read_uint8());
-    objType    = ToDataType(sr.Read_uint16());
+    objectCode_ = Object::ToObjectCode(sr.Read_uint8());
+    objType_    = ToDataType(sr.Read_uint16());
 
-    if (inclusiveNames)
-      objName = sr.Read_string();
+    if (inclusiveNames_)
+      objName_ = sr.Read_string();
 
-    maxNbOfSubindices = sr.Read_uint16();
-    if ((maxNbOfSubindices == 0U) || (maxNbOfSubindices > 256U))
+    maxNbOfSubindices_ = sr.Read_uint16();
+    if ((maxNbOfSubindices_ == 0U) || (maxNbOfSubindices_ > 256U))
       throw std::runtime_error("Data read from 'sr' is invalid");
 
-    firstSubindex = sr.Read_uint8();
-    if (firstSubindex >= maxNbOfSubindices)
+    firstSubindex_ = sr.Read_uint8();
+    if (firstSubindex_ >= maxNbOfSubindices_)
       throw std::runtime_error("Data read from 'sr' is invalid");
 
     uint_fast16_t s = sr.Read_uint16();
     if ((s == 0U) || (s > 256U))
       throw std::runtime_error("Data read from 'sr' is invalid");
 
-    if ((objectCode == Object::ObjectCode::Array) && (!inclusiveAppSpecificMetaData))
+    if ((objectCode_ == Object::ObjectCode::Array) && (!inclusiveAppSpecificMetaData_))
     {
-      if (firstSubindex > 1U)
+      if (firstSubindex_ > 1U)
         throw std::runtime_error("Data read from 'sr' is invalid");
 
-      if ((firstSubindex + s) > 2U)
+      if ((firstSubindex_ + s) > 2U)
         throw std::runtime_error("Data read from 'sr' is invalid");
     }
     else
     {
-      if ((firstSubindex + s) > maxNbOfSubindices)
+      if ((firstSubindex_ + s) > maxNbOfSubindices_)
         throw std::runtime_error("Data read from 'sr' is invalid");
     }
 
-    subindexDescr.reserve(s);
+    subindexDescr_.reserve(s);
 
     do
     {
-      subindexDescr.emplace_back(sr);
+      subindexDescr_.emplace_back(sr);
 
-      if (   (subindexDescr.back().inclName != inclusiveNames)
-          || (subindexDescr.back().inclASM  != inclusiveAppSpecificMetaData))
+      if (   (subindexDescr_.back().inclName != inclusiveNames_)
+          || (subindexDescr_.back().inclASM  != inclusiveAppSpecificMetaData_))
       {
         throw std::runtime_error("Data read from 'sr' is invalid");
       }
@@ -300,31 +300,31 @@ size_t ObjectInfoResponse::GetBinarySize(void) const
 {
   size_t s = ResponseBase::GetBinarySize();
 
-  // result              4
-  // ---------------------
-  //                    =4
+  // result_              4
+  // ----------------------
+  //                     =4
   s += 4U;
-  if (result != SDOAbortCode::OK)
+  if (result_ != SDOAbortCode::OK)
     return s;
 
-  // inclusiveNames               0.1
-  // inclusiveAppSpecificMetaData 0.1
-  //                              0.6
-  // objectCode                   +1
-  // objType                      +2
-  // objName                      variable
-  // maxNbOfSubindices            +2
-  // firstSubindex                +1
-  // subindexDescr.size           +2
+  // inclusiveNames_               0.1
+  // inclusiveAppSpecificMetaData_ 0.1
+  //                               0.6
+  // objectCode_                   +1
+  // objType_                      +2
+  // objName_                      variable
+  // maxNbOfSubindices_            +2
+  // firstSubindex_                +1
+  // subindexDescr_.size           +2
   // --------------------------------
-  //                              =9 + objName
+  //                               =9 + objName_
   s += 9U;
 
-  if (inclusiveNames)
-    s += objName.length() + 1U; // (incl. null-terminator)
+  if (inclusiveNames_)
+    s += objName_.length() + 1U; // (incl. null-terminator)
 
-  // subindexDescr
-  for (auto const & e: subindexDescr)
+  // subindexDescr_
+  for (auto const & e: subindexDescr_)
     s += e.GetBinarySize();
 
   return s;
@@ -335,27 +335,27 @@ void ObjectInfoResponse::ToBinary(gpcc::stream::IStreamWriter & sw) const
 {
   ResponseBase::ToBinary(sw);
 
-  sw.Write_uint32(static_cast<uint32_t>(result));
+  sw.Write_uint32(static_cast<uint32_t>(result_));
 
-  if (result != SDOAbortCode::OK)
+  if (result_ != SDOAbortCode::OK)
     return;
 
   ValidateObjNotEmpty();
 
-  sw.Write_bool(inclusiveNames);
-  sw.Write_bool(inclusiveAppSpecificMetaData);
+  sw.Write_bool(inclusiveNames_);
+  sw.Write_bool(inclusiveAppSpecificMetaData_);
 
-  sw.Write_uint8(Object::ToUint8(objectCode));
-  sw.Write_uint16(ToUint16(objType));
+  sw.Write_uint8(Object::ToUint8(objectCode_));
+  sw.Write_uint16(ToUint16(objType_));
 
-  if (inclusiveNames)
-    sw.Write_string(objName);
+  if (inclusiveNames_)
+    sw.Write_string(objName_);
 
-  sw.Write_uint16(maxNbOfSubindices);
-  sw.Write_uint8(firstSubindex);
-  sw.Write_uint16(subindexDescr.size());
+  sw.Write_uint16(maxNbOfSubindices_);
+  sw.Write_uint8(firstSubindex_);
+  sw.Write_uint16(subindexDescr_.size());
 
-  for (auto const & e: subindexDescr)
+  for (auto const & e: subindexDescr_)
     e.ToBinary(sw);
 }
 
@@ -363,11 +363,11 @@ void ObjectInfoResponse::ToBinary(gpcc::stream::IStreamWriter & sw) const
 std::string ObjectInfoResponse::ToString(void) const
 {
   gpcc::string::StringComposer s;
-  s << "Object info response (" << SDOAbortCodeToDescrString(result) << ')';
-  if (result == SDOAbortCode::OK)
+  s << "Object info response (" << SDOAbortCodeToDescrString(result_) << ')';
+  if (result_ == SDOAbortCode::OK)
   {
     ValidateObjNotEmpty();
-    s << ", incl. " << subindexDescr.size() << " subindex descriptions";
+    s << ", incl. " << subindexDescr_.size() << " subindex descriptions";
   }
 
   return s.Get();
@@ -405,12 +405,12 @@ std::string ObjectInfoResponse::ToString(void) const
  */
 void ObjectInfoResponse::AddFragment(ObjectInfoResponse && fragment)
 {
-  if (result != SDOAbortCode::OK)
+  if (result_ != SDOAbortCode::OK)
     throw std::logic_error("ObjectInfoResponse::AddFragment: Query failed");
 
   ValidateObjNotEmpty();
 
-  if (objectCode == Object::ObjectCode::Variable)
+  if (objectCode_ == Object::ObjectCode::Variable)
     throw std::logic_error("ObjectInfoResponse::AddFragment: Call not expected for VARIABLE object.");
 
   uint8_t nextSI;
@@ -418,42 +418,42 @@ void ObjectInfoResponse::AddFragment(ObjectInfoResponse && fragment)
     throw std::logic_error("ObjectInfoResponse::AddFragment: Object is already complete.");
 
 
-  if (fragment.result != SDOAbortCode::OK)
+  if (fragment.result_ != SDOAbortCode::OK)
     throw std::invalid_argument("ObjectInfoResponse::AddFragment: Fragment has bad result code.");
 
   fragment.ValidateObjNotEmpty();
 
 
-  if (   (fragment.inclusiveNames != inclusiveNames)
-      || (fragment.inclusiveAppSpecificMetaData != inclusiveAppSpecificMetaData)
-      || (fragment.objectCode != objectCode)
-      || (fragment.objType != objType)
-      || (fragment.maxNbOfSubindices != maxNbOfSubindices))
+  if (   (fragment.inclusiveNames_ != inclusiveNames_)
+      || (fragment.inclusiveAppSpecificMetaData_ != inclusiveAppSpecificMetaData_)
+      || (fragment.objectCode_ != objectCode_)
+      || (fragment.objType_ != objType_)
+      || (fragment.maxNbOfSubindices_ != maxNbOfSubindices_))
   {
     throw std::invalid_argument("ObjectInfoResponse::AddFragment: Queried objects do not match");
   }
 
-  if (fragment.firstSubindex != nextSI)
+  if (fragment.firstSubindex_ != nextSI)
     throw std::invalid_argument("ObjectInfoResponse::AddFragment: Discontinuity");
 
-  if ((objectCode == Object::ObjectCode::Array) && (!inclusiveAppSpecificMetaData))
+  if ((objectCode_ == Object::ObjectCode::Array) && (!inclusiveAppSpecificMetaData_))
   {
-    if ((fragment.firstSubindex != 1U) || (fragment.subindexDescr.size() != 1U))
+    if ((fragment.firstSubindex_ != 1U) || (fragment.subindexDescr_.size() != 1U))
       throw std::invalid_argument("ObjectInfoResponse::AddFragment: Fragment invalid");
   }
   else
   {
-    if (firstSubindex + subindexDescr.size() + fragment.subindexDescr.size() > maxNbOfSubindices)
+    if (firstSubindex_ + subindexDescr_.size() + fragment.subindexDescr_.size() > maxNbOfSubindices_)
       throw std::logic_error("ObjectInfoResponse::AddFragment: Merge would result in invalid object");
   }
 
-  if (subindexDescr.capacity() < (subindexDescr.size() + fragment.subindexDescr.size()))
+  if (subindexDescr_.capacity() < (subindexDescr_.size() + fragment.subindexDescr_.size()))
     throw std::logic_error("ObjectInfoResponse::AddFragment: Capacity invalid");
 
-  for (auto & e: fragment.subindexDescr)
-    subindexDescr.emplace_back(std::move(e));
+  for (auto & e: fragment.subindexDescr_)
+    subindexDescr_.emplace_back(std::move(e));
 
-  fragment.subindexDescr.clear();
+  fragment.subindexDescr_.clear();
 }
 
 /**
@@ -477,7 +477,7 @@ void ObjectInfoResponse::AddFragment(ObjectInfoResponse && fragment)
  */
 SDOAbortCode ObjectInfoResponse::GetResult(void) const noexcept
 {
-  return result;
+  return result_;
 }
 
 /**
@@ -501,7 +501,7 @@ SDOAbortCode ObjectInfoResponse::GetResult(void) const noexcept
  */
 bool ObjectInfoResponse::IsInclusiveNames(void) const noexcept
 {
-  return inclusiveNames;
+  return inclusiveNames_;
 }
 
 /**
@@ -525,7 +525,7 @@ bool ObjectInfoResponse::IsInclusiveNames(void) const noexcept
  */
 bool ObjectInfoResponse::IsInclusiveAppSpecificMetaData(void) const noexcept
 {
-  return inclusiveAppSpecificMetaData;
+  return inclusiveAppSpecificMetaData_;
 }
 
 /**
@@ -551,10 +551,10 @@ bool ObjectInfoResponse::IsInclusiveAppSpecificMetaData(void) const noexcept
  */
 uint8_t ObjectInfoResponse::GetFirstQueriedSubindex(void) const
 {
-  if (result != SDOAbortCode::OK)
+  if (result_ != SDOAbortCode::OK)
     throw std::logic_error("ObjectInfoResponse::GetFirstQueriedSubindex: Query failed");
 
-  return firstSubindex;
+  return firstSubindex_;
 }
 
 /**
@@ -582,24 +582,24 @@ uint8_t ObjectInfoResponse::GetFirstQueriedSubindex(void) const
  */
 uint8_t ObjectInfoResponse::GetLastQueriedSubindex(void) const
 {
-  if (result != SDOAbortCode::OK)
+  if (result_ != SDOAbortCode::OK)
     throw std::logic_error("ObjectInfoResponse::GetLastQueriedSubindex: Query failed");
 
   ValidateObjNotEmpty();
 
-  if ((objectCode == Object::ObjectCode::Array) && (!inclusiveAppSpecificMetaData))
+  if ((objectCode_ == Object::ObjectCode::Array) && (!inclusiveAppSpecificMetaData_))
   {
     // If application specific meta data is not included, then for ARRAY objects SI1..SIn have the same meta data,
     // so SI1's meta data can be used for all subindices.
 
-    if ((firstSubindex + (subindexDescr.size() - 1U)) >= 1U)
-      return maxNbOfSubindices - 1U;
+    if ((firstSubindex_ + (subindexDescr_.size() - 1U)) >= 1U)
+      return maxNbOfSubindices_ - 1U;
     else
       return 0U;
   }
   else
   {
-    return (firstSubindex + (subindexDescr.size() - 1U));
+    return (firstSubindex_ + (subindexDescr_.size() - 1U));
   }
 }
 
@@ -636,20 +636,20 @@ uint8_t ObjectInfoResponse::GetLastQueriedSubindex(void) const
  */
 bool ObjectInfoResponse::IsComplete(uint8_t * const pNextSubindex) const
 {
-  if (result != SDOAbortCode::OK)
+  if (result_ != SDOAbortCode::OK)
     throw std::logic_error("ObjectInfoResponse::IsComplete: Query failed");
 
   ValidateObjNotEmpty();
 
-  uint_fast16_t const nextSI = firstSubindex + subindexDescr.size();
+  uint_fast16_t const nextSI = firstSubindex_ + subindexDescr_.size();
 
-  if ((objectCode == Object::ObjectCode::Array) && (!inclusiveAppSpecificMetaData))
+  if ((objectCode_ == Object::ObjectCode::Array) && (!inclusiveAppSpecificMetaData_))
   {
     // Note:
-    // If application specific meta data is not included, then for ARRAY objects, firstSubindex is 0..1,
-    // subindexDescr.size() is 1..2 and the sum of both is always equal to or less than 2.
-    // This means: The first condition may only come true if maxNbOfSubindices is 1.
-    if ((nextSI == maxNbOfSubindices) || (nextSI == 2U))
+    // If application specific meta data is not included, then for ARRAY objects, firstSubindex_ is 0..1,
+    // subindexDescr_.size() is 1..2 and the sum of both is always equal to or less than 2.
+    // This means: The first condition may only come true if maxNbOfSubindices_ is 1.
+    if ((nextSI == maxNbOfSubindices_) || (nextSI == 2U))
     {
       return true;
     }
@@ -663,7 +663,7 @@ bool ObjectInfoResponse::IsComplete(uint8_t * const pNextSubindex) const
   }
   else
   {
-    if (nextSI == maxNbOfSubindices)
+    if (nextSI == maxNbOfSubindices_)
     {
       return true;
     }
@@ -700,10 +700,10 @@ bool ObjectInfoResponse::IsComplete(uint8_t * const pNextSubindex) const
  */
 Object::ObjectCode ObjectInfoResponse::GetObjectCode(void) const
 {
-  if (result != SDOAbortCode::OK)
+  if (result_ != SDOAbortCode::OK)
     throw std::logic_error("ObjectInfoResponse::GetObjectCode: Query failed");
 
-  return objectCode;
+  return objectCode_;
 }
 
 /**
@@ -729,10 +729,10 @@ Object::ObjectCode ObjectInfoResponse::GetObjectCode(void) const
  */
 DataType ObjectInfoResponse::GetObjectDataType(void) const
 {
-  if (result != SDOAbortCode::OK)
+  if (result_ != SDOAbortCode::OK)
     throw std::logic_error("ObjectInfoResponse::GetObjectDataType: Query failed");
 
-  return objType;
+  return objType_;
 }
 
 /**
@@ -762,13 +762,13 @@ DataType ObjectInfoResponse::GetObjectDataType(void) const
  */
 std::string const & ObjectInfoResponse::GetObjectName(void) const
 {
-  if (result != SDOAbortCode::OK)
+  if (result_ != SDOAbortCode::OK)
     throw std::logic_error("ObjectInfoResponse::GetObjectName: Query failed");
 
-  if (!inclusiveNames)
+  if (!inclusiveNames_)
     throw std::logic_error("ObjectInfoResponse::GetObjectName: No names");
 
-  return objName;
+  return objName_;
 }
 
 /**
@@ -794,10 +794,10 @@ std::string const & ObjectInfoResponse::GetObjectName(void) const
  */
 uint16_t ObjectInfoResponse::GetMaxNbOfSubindices(void) const
 {
-  if (result != SDOAbortCode::OK)
+  if (result_ != SDOAbortCode::OK)
     throw std::logic_error("ObjectInfoResponse::GetMaxNbOfSubindices: Query failed");
 
-  return maxNbOfSubindices;
+  return maxNbOfSubindices_;
 }
 
 /**
@@ -834,7 +834,7 @@ bool ObjectInfoResponse::IsSubIndexEmpty(uint8_t const subIdx) const
   // precondition "not source of move-operation" is checked by MapSubindexToSubIndexDescr()
 
   uint8_t const i = MapSubindexToSubIndexDescr(subIdx);
-  return subindexDescr[i].empty;
+  return subindexDescr_[i].empty;
 }
 
 /**
@@ -871,7 +871,7 @@ DataType ObjectInfoResponse::GetSubIdxDataType(uint8_t const subIdx) const
   // precondition "not source of move-operation" is checked by MapSubindexToSubIndexDescr()
 
   uint8_t const i = MapSubindexToSubIndexDescr(subIdx);
-  return subindexDescr[i].dataType;
+  return subindexDescr_[i].dataType;
 }
 
 /**
@@ -908,7 +908,7 @@ Object::attr_t ObjectInfoResponse::GetSubIdxAttributes(uint8_t const subIdx) con
   // precondition "not source of move-operation" is checked by MapSubindexToSubIndexDescr()
 
   uint8_t const i = MapSubindexToSubIndexDescr(subIdx);
-  return subindexDescr[i].attributes;
+  return subindexDescr_[i].attributes;
 }
 
 /**
@@ -945,7 +945,7 @@ size_t ObjectInfoResponse::GetSubIdxMaxSize(uint8_t const subIdx) const
   // precondition "not source of move-operation" is checked by MapSubindexToSubIndexDescr()
 
   uint8_t const i = MapSubindexToSubIndexDescr(subIdx);
-  return subindexDescr[i].maxSize;
+  return subindexDescr_[i].maxSize;
 }
 
 /**
@@ -985,19 +985,19 @@ std::string ObjectInfoResponse::GetSubIdxName(uint8_t const subIdx) const
 
   uint8_t const i = MapSubindexToSubIndexDescr(subIdx);
 
-  if (!subindexDescr[i].inclName)
+  if (!subindexDescr_[i].inclName)
     throw std::logic_error("ObjectInfoResponse::GetSubIdxName: No names");
 
-  if ((objectCode == Object::ObjectCode::Array) && (!inclusiveAppSpecificMetaData))
+  if ((objectCode_ == Object::ObjectCode::Array) && (!inclusiveAppSpecificMetaData_))
   {
     if (subIdx == 0U)
-      return subindexDescr[0].name;
+      return subindexDescr_[0].name;
     else
       return "Subindex " + std::to_string(static_cast<unsigned int>(subIdx));
   }
   else
   {
-    return subindexDescr[i].name;
+    return subindexDescr_[i].name;
   }
 }
 
@@ -1040,10 +1040,10 @@ size_t ObjectInfoResponse::GetAppSpecificMetaDataSize(uint8_t const subIdx) cons
 
   uint8_t const i = MapSubindexToSubIndexDescr(subIdx);
 
-  if (!subindexDescr[i].inclASM)
+  if (!subindexDescr_[i].inclASM)
     throw std::logic_error("ObjectInfoResponse::GetAppSpecificMetaDataSize: No ASM");
 
-  return subindexDescr[i].appSpecMetaData.size();
+  return subindexDescr_[i].appSpecMetaData.size();
 }
 
 /**
@@ -1083,10 +1083,10 @@ std::vector<uint8_t> ObjectInfoResponse::GetAppSpecificMetaData(uint8_t const su
 
   uint8_t const i = MapSubindexToSubIndexDescr(subIdx);
 
-  if (!subindexDescr[i].inclASM)
+  if (!subindexDescr_[i].inclASM)
     throw std::logic_error("ObjectInfoResponse::GetAppSpecificMetaData: No ASM");
 
-  return subindexDescr[i].appSpecMetaData;
+  return subindexDescr_[i].appSpecMetaData;
 }
 
 /**
@@ -1108,7 +1108,7 @@ std::vector<uint8_t> ObjectInfoResponse::GetAppSpecificMetaData(uint8_t const su
  */
 void ObjectInfoResponse::ValidateObjNotEmpty(void) const
 {
-  if (subindexDescr.empty())
+  if (subindexDescr_.empty())
     throw std::logic_error("ObjectInfoResponse::ValidateObjNotEmpty: Object was source of move-operation.");
 }
 
@@ -1138,7 +1138,7 @@ void ObjectInfoResponse::ValidateObjNotEmpty(void) const
  *
  * - - -
  *
- * \param _maxResponseSize
+ * \param maximumResponseSize
  * Maximum permitted response size in byte.\n
  * The value refers to a serialized response object incl. potential @ref ReturnStackItem objects and response payload
  * data.
@@ -1150,10 +1150,10 @@ void ObjectInfoResponse::ValidateObjNotEmpty(void) const
  * \return
  * Maximum size (in byte) of the data payload that could be added to this object.
  */
-size_t ObjectInfoResponse::CalcRemainingPayload(size_t const _maxResponseSize, size_t const returnStackSize) const
+size_t ObjectInfoResponse::CalcRemainingPayload(size_t const maximumResponseSize, size_t const returnStackSize) const
 {
   // start
-  size_t remainingDataPayloadCapacity = _maxResponseSize;
+  size_t remainingDataPayloadCapacity = maximumResponseSize;
 
   // subtract current size of the object
   auto const binarySize = GetBinarySize();
@@ -1173,7 +1173,7 @@ size_t ObjectInfoResponse::CalcRemainingPayload(size_t const _maxResponseSize, s
 }
 
 /**
- * \brief Determines the index in @ref subindexDescr that contains the meta data of a given subindex.
+ * \brief Determines the index in @ref subindexDescr_ that contains the meta data of a given subindex.
  *
  * \pre   The result of the query is @ref SDOAbortCode::OK.
  *
@@ -1201,39 +1201,39 @@ size_t ObjectInfoResponse::CalcRemainingPayload(size_t const _maxResponseSize, s
  * Subindex.
  *
  * \return
- * Index in @ref subindexDescr that contains the meta data of the object's subindex referenced by `subindex`.
+ * Index in @ref subindexDescr_ that contains the meta data of the object's subindex referenced by `subindex`.
  */
 uint8_t ObjectInfoResponse::MapSubindexToSubIndexDescr(uint8_t const subindex) const
 {
-  if (result != SDOAbortCode::OK)
+  if (result_ != SDOAbortCode::OK)
     throw std::logic_error("ObjectInfoResponse::MapSubindexToSubIndexDescr: Query failed");
 
   ValidateObjNotEmpty();
 
-  if (subindex >= maxNbOfSubindices)
+  if (subindex >= maxNbOfSubindices_)
     throw SubindexNotExistingError();
 
-  if ((objectCode == Object::ObjectCode::Array) && (!inclusiveAppSpecificMetaData))
+  if ((objectCode_ == Object::ObjectCode::Array) && (!inclusiveAppSpecificMetaData_))
   {
-    // note: firstSubindex is 0 or 1
+    // note: firstSubindex_ is 0 or 1
 
-    if (subindex < firstSubindex)
+    if (subindex < firstSubindex_)
       throw std::logic_error("ObjectInfoResponse::MapSubindexToSubIndexDescr: No information about 'subIdx'");
 
-    if (subindex == firstSubindex)
+    if (subindex == firstSubindex_)
       return 0U;
 
-    if ((firstSubindex == 0U) && (subindexDescr.size() == 1U))
+    if ((firstSubindex_ == 0U) && (subindexDescr_.size() == 1U))
       throw std::logic_error("ObjectInfoResponse::MapSubindexToSubIndexDescr: No information about 'subIdx'");
 
-    return (firstSubindex == 0U) ? 1U : 0U;
+    return (firstSubindex_ == 0U) ? 1U : 0U;
   }
   else
   {
-    if ((subindex < firstSubindex) || (subindex > (firstSubindex + (subindexDescr.size() - 1U))))
+    if ((subindex < firstSubindex_) || (subindex > (firstSubindex_ + (subindexDescr_.size() - 1U))))
       throw std::logic_error("ObjectInfoResponse::MapSubindexToSubIndexDescr: No information about 'subIdx'");
 
-    return subindex - firstSubindex;
+    return subindex - firstSubindex_;
   }
 }
 

--- a/src/cood/remote_access/requests_and_responses/PingRequest.cpp
+++ b/src/cood/remote_access/requests_and_responses/PingRequest.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2021 Daniel Jerolm
+    Copyright (C) 2021, 2025 Daniel Jerolm
 */
 
 #include <gpcc/cood/remote_access/requests_and_responses/PingRequest.hpp>
@@ -27,7 +27,7 @@ namespace cood {
  *
  * - - -
  *
- * \param _maxResponseSize
+ * \param maxResponseSize
  * Maximum size (in byte) of the serialized response object that can be processed by the creator of this request.
  * The value should be the minimum of the capability of the creator and the maximum possible response size announced
  * by @ref IRemoteObjectDictionaryAccessNotifiable::OnReady(), parameter `maxResponseSize`.\n
@@ -43,8 +43,8 @@ namespace cood {
  * \htmlonly <style>div.image img[src="cood/RODA_ReqCTOR_MaxResponseSize.png"]{width:80%;}</style> \endhtmlonly
  * \image html "cood/RODA_ReqCTOR_MaxResponseSize.png" "Maximum response size with one ReturnStackItem"
  */
-PingRequest::PingRequest(size_t const _maxResponseSize)
-: RequestBase(RequestTypes::pingRequest, _maxResponseSize)
+PingRequest::PingRequest(size_t const maxResponseSize)
+: RequestBase(RequestTypes::pingRequest, maxResponseSize)
 {
 }
 
@@ -80,7 +80,7 @@ PingRequest::PingRequest(size_t const _maxResponseSize)
 PingRequest::PingRequest(gpcc::stream::IStreamReader & sr, uint8_t const versionOnHand, PingRequestPassKey)
 : RequestBase(RequestTypes::pingRequest, sr, versionOnHand)
 {
-  if (versionOnHand != version)
+  if (versionOnHand != version_)
     throw std::runtime_error("PingRequest::PingRequest: Version not supported");
 }
 

--- a/src/cood/remote_access/requests_and_responses/ReadRequest.cpp
+++ b/src/cood/remote_access/requests_and_responses/ReadRequest.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2021, 2024 Daniel Jerolm
+    Copyright (C) 2021, 2024, 2025 Daniel Jerolm
 */
 
 #include <gpcc/cood/remote_access/requests_and_responses/ReadRequest.hpp>
@@ -19,7 +19,7 @@
 namespace gpcc {
 namespace cood {
 
-size_t const ReadRequest::readRequestBinarySize;
+size_t const ReadRequest::readRequestBinarySize_;
 
 /**
  * \brief Constructor.
@@ -34,23 +34,23 @@ size_t const ReadRequest::readRequestBinarySize;
  *
  * - - -
  *
- * \param _accessType
+ * \param accessType
  * Access type.
  *
- * \param _index
+ * \param index
  * Index of the object that shall be read.
  *
- * \param _subindex
+ * \param subindex
  * Subindex that shall be read.\n
  * In case of a complete access, this is the first subindex being read. It must be zero or one.
  *
- * \param _permissions
+ * \param permissions
  * Permissions for the read-operation provided by the originator of the read request.\n
  * This shall be composed by logical-or-combination of one or multiple Object::attr_ACCESS_xxx values.\n
  * The composed value shall have at least one read permission (@ref Object::attr_ACCESS_RD) bit set.\n
  * There shall be no other bits set except for read permission bits.
  *
- * \param _maxResponseSize
+ * \param maxResponseSize
  * Maximum size (in byte) of the serialized response object that can be processed by the creator of this request.
  * The value should be the minimum of the capability of the creator and the maximum possible response size announced
  * by @ref IRemoteObjectDictionaryAccessNotifiable::OnReady(), parameter `maxResponseSize`.\n
@@ -66,22 +66,22 @@ size_t const ReadRequest::readRequestBinarySize;
  * \htmlonly <style>div.image img[src="cood/RODA_ReqCTOR_MaxResponseSize.png"]{width:80%;}</style> \endhtmlonly
  * \image html "cood/RODA_ReqCTOR_MaxResponseSize.png" "Maximum response size with one ReturnStackItem"
  */
-ReadRequest::ReadRequest(AccessType     const _accessType,
-                         uint16_t       const _index,
-                         uint8_t        const _subindex,
-                         Object::attr_t const _permissions,
-                         size_t         const _maxResponseSize)
-: RequestBase(RequestTypes::readRequest, _maxResponseSize)
-, accessType(_accessType)
-, index(_index)
-, subindex(_subindex)
-, permissions(_permissions)
+ReadRequest::ReadRequest(AccessType     const accessType,
+                         uint16_t       const index,
+                         uint8_t        const subindex,
+                         Object::attr_t const permissions,
+                         size_t         const maxResponseSize)
+: RequestBase(RequestTypes::readRequest, maxResponseSize)
+, accessType_(accessType)
+, index_(index)
+, subindex_(subindex)
+, permissions_(permissions)
 {
-  if ((accessType != AccessType::singleSubindex) && (subindex > 1U))
+  if ((accessType_ != AccessType::singleSubindex) && (subindex_ > 1U))
     throw std::invalid_argument("ReadRequest::ReadRequest: Complete access requires '_subindex' in range 0..1");
 
-  if (   ((permissions & Object::attr_ACCESS_RD) == 0U)
-      || ((permissions & Object::attr_ACCESS_RD) != permissions))
+  if (   ((permissions_ & Object::attr_ACCESS_RD) == 0U)
+      || ((permissions_ & Object::attr_ACCESS_RD) != permissions_))
   {
     throw std::invalid_argument("ReadRequest::ReadRequest: '_permissions' invalid.");
   }
@@ -118,19 +118,19 @@ ReadRequest::ReadRequest(AccessType     const _accessType,
  */
 ReadRequest::ReadRequest(gpcc::stream::IStreamReader & sr, uint8_t const versionOnHand, ReadRequestPassKey)
 : RequestBase(RequestTypes::readRequest, sr, versionOnHand)
-, accessType(U8_to_AccessType(sr.Read_uint8()))
-, index(sr.Read_uint16())
-, subindex(sr.Read_uint8())
-, permissions(static_cast<Object::attr_t>(sr.Read_uint16()))
+, accessType_(U8_to_AccessType(sr.Read_uint8()))
+, index_(sr.Read_uint16())
+, subindex_(sr.Read_uint8())
+, permissions_(static_cast<Object::attr_t>(sr.Read_uint16()))
 {
-  if (versionOnHand != version)
+  if (versionOnHand != version_)
     throw std::runtime_error("ReadRequest::ReadRequest: Version not supported");
 
-  if ((accessType != AccessType::singleSubindex) && (subindex > 1U))
+  if ((accessType_ != AccessType::singleSubindex) && (subindex_ > 1U))
     throw std::runtime_error("ReadRequest::ReadRequest: Data read from 'sr' is invalid");
 
-  if (   ((permissions & Object::attr_ACCESS_RD) == 0U)
-      || ((permissions & Object::attr_ACCESS_RD) != permissions))
+  if (   ((permissions_ & Object::attr_ACCESS_RD) == 0U)
+      || ((permissions_ & Object::attr_ACCESS_RD) != permissions_))
   {
     throw std::runtime_error("ReadRequest::ReadRequest: Data read from 'sr' is invalid");
   }
@@ -180,7 +180,7 @@ size_t ReadRequest::CalcMaxDataPayloadInResponse(size_t const maxResponseSize, b
 /// \copydoc gpcc::cood::RequestBase::GetBinarySize
 size_t ReadRequest::GetBinarySize(void) const
 {
-  return RequestBase::GetBinarySize() + readRequestBinarySize;
+  return RequestBase::GetBinarySize() + readRequestBinarySize_;
 }
 
 /// \copydoc gpcc::cood::RequestBase::ToBinary
@@ -188,10 +188,10 @@ void ReadRequest::ToBinary(gpcc::stream::IStreamWriter & sw) const
 {
   RequestBase::ToBinary(sw);
 
-  sw.Write_uint8(static_cast<uint8_t>(accessType));
-  sw.Write_uint16(index);
-  sw.Write_uint8(subindex);
-  sw.Write_uint16(permissions);
+  sw.Write_uint8(static_cast<uint8_t>(accessType_));
+  sw.Write_uint16(index_);
+  sw.Write_uint8(subindex_);
+  sw.Write_uint16(permissions_);
 }
 
 /// \copydoc gpcc::cood::RequestBase::ToString
@@ -201,7 +201,7 @@ std::string ReadRequest::ToString(void) const
 
   s << "Read request (";
 
-  switch (accessType)
+  switch (accessType_)
   {
     case AccessType::singleSubindex:
       s << "single subindex";
@@ -216,8 +216,8 @@ std::string ReadRequest::ToString(void) const
       break;
   }
 
-  s << ") for " << gpcc::string::ToHex(index, 4U) << ':' << static_cast<unsigned int>(subindex) << ", "
-       "Permission = " << gpcc::string::ToHex(static_cast<uint16_t>(permissions), 4U);
+  s << ") for " << gpcc::string::ToHex(index_, 4U) << ':' << static_cast<unsigned int>(subindex_) << ", "
+       "Permission = " << gpcc::string::ToHex(static_cast<uint16_t>(permissions_), 4U);
 
   return s.Get();
 }

--- a/src/cood/remote_access/requests_and_responses/ReadRequestResponse.cpp
+++ b/src/cood/remote_access/requests_and_responses/ReadRequestResponse.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2021, 2024 Daniel Jerolm
+    Copyright (C) 2021, 2024, 2025 Daniel Jerolm
 */
 
 #include <gpcc/cood/remote_access/requests_and_responses/ReadRequestResponse.hpp>
@@ -20,7 +20,7 @@
 namespace gpcc {
 namespace cood {
 
-size_t const ReadRequestResponse::readRequestResponseBinarySize;
+size_t const ReadRequestResponse::readRequestResponseBinarySize_;
 
 /**
  * \brief Constructor. Creates a response object with encapsulated result initialized with an error value.
@@ -38,17 +38,17 @@ size_t const ReadRequestResponse::readRequestResponseBinarySize;
  *
  * - - -
  *
- * \param _result
+ * \param result
  * Result value that shall be encapsulated in the object.\n
  * This must be a negative status code. @ref SDOAbortCode::OK is not allowed.
  */
-ReadRequestResponse::ReadRequestResponse(SDOAbortCode const _result)
+ReadRequestResponse::ReadRequestResponse(SDOAbortCode const result)
 : ResponseBase(ResponseTypes::readRequestResponse)
-, result(_result)
-, data()
-, sizeInBit(0U)
+, result_(result)
+, data_()
+, sizeInBit_(0U)
 {
-  if (result == SDOAbortCode::OK)
+  if (result_ == SDOAbortCode::OK)
     throw std::invalid_argument("ReadRequestResponse::ReadRequestResponse: Negative result expected");
 }
 
@@ -83,20 +83,20 @@ ReadRequestResponse::ReadRequestResponse(SDOAbortCode const _result)
  */
 ReadRequestResponse::ReadRequestResponse(gpcc::stream::IStreamReader & sr, uint8_t const versionOnHand, ReadRequestResponsePassKey)
 : ResponseBase(ResponseTypes::readRequestResponse, sr, versionOnHand)
-, data()
-, sizeInBit(0U)
+, data_()
+, sizeInBit_(0U)
 {
   auto const result_u32 = sr.Read_uint32();
   try
   {
-    result = U32ToSDOAbortCode(result_u32);
+    result_ = U32ToSDOAbortCode(result_u32);
   }
   catch (std::exception const &)
   {
     std::throw_with_nested(std::runtime_error("ReadRequestResponse::ReadRequestResponse: Data read from 'sr' is invalid"));
   }
 
-  if (result != SDOAbortCode::OK)
+  if (result_ != SDOAbortCode::OK)
     return;
 
   // s = number of bytes
@@ -108,12 +108,12 @@ ReadRequestResponse::ReadRequestResponse(gpcc::stream::IStreamReader & sr, uint8
   {
     if ((b == 0U) || (b > 8U))
       throw std::runtime_error("ReadRequestResponse::ReadRequestResponse: Data read from 'sr' is invalid");
-    sizeInBit = ((s - 1UL) * 8UL) + b;
+    sizeInBit_ = ((s - 1UL) * 8UL) + b;
 
-    data.reserve(s);
+    data_.reserve(s);
     while (s != 0U)
     {
-      data.push_back(sr.Read_uint8());
+      data_.push_back(sr.Read_uint8());
       --s;
     }
   }
@@ -143,12 +143,12 @@ ReadRequestResponse::ReadRequestResponse(gpcc::stream::IStreamReader & sr, uint8
  */
 ReadRequestResponse::ReadRequestResponse(ReadRequestResponse && other) noexcept
 : ResponseBase(std::move(other))
-, result(other.result)
-, data(std::move(other.data))
-, sizeInBit(other.sizeInBit)
+, result_(other.result_)
+, data_(std::move(other.data_))
+, sizeInBit_(other.sizeInBit_)
 {
-  other.data.clear();
-  other.sizeInBit = 0U;
+  other.data_.clear();
+  other.sizeInBit_ = 0U;
 }
 
 /**
@@ -188,7 +188,7 @@ size_t ReadRequestResponse::CalcMaxDataPayload(size_t const maxResponseSize, siz
   size_t maxDataPayload = maxResponseSize;
 
   // subtract overhead of ResponseBase and ReadRequestResponse
-  size_t const binarySize = baseBinarySize + readRequestResponseBinarySize;
+  size_t const binarySize = baseBinarySize_ + readRequestResponseBinarySize_;
   static_assert(binarySize <= ResponseBase::minimumUsefulResponseSize,
                 "Base size of serialized ReadRequestResponse exceeds ResponseBase::minimumUsefulResponseSize");
 
@@ -219,11 +219,11 @@ size_t ReadRequestResponse::GetBinarySize(void) const
   size_t s = ResponseBase::GetBinarySize();
 
   s += 4U;
-  if (result != SDOAbortCode::OK)
+  if (result_ != SDOAbortCode::OK)
     return s;
 
   s += 3U;
-  s += data.size();
+  s += data_.size();
   return s;
 }
 
@@ -232,29 +232,29 @@ void ReadRequestResponse::ToBinary(gpcc::stream::IStreamWriter & sw) const
 {
   ResponseBase::ToBinary(sw);
 
-  sw.Write_uint32(static_cast<uint32_t>(result));
+  sw.Write_uint32(static_cast<uint32_t>(result_));
 
-  if (result != SDOAbortCode::OK)
+  if (result_ != SDOAbortCode::OK)
     return;
 
   // number of bytes
-  sw.Write_uint16(static_cast<uint16_t>(data.size()));
+  sw.Write_uint16(static_cast<uint16_t>(data_.size()));
 
   // number of bits in LAST byte
-  if (data.empty())
+  if (data_.empty())
   {
     sw.Write_uint8(0U);
   }
   else
   {
-    uint8_t b = sizeInBit % 8U;
+    uint8_t b = sizeInBit_ % 8U;
     if (b == 0U)
       b = 8U;
     sw.Write_uint8(b);
   }
 
   // data
-  sw.Write_uint8(data.data(), data.size());
+  sw.Write_uint8(data_.data(), data_.size());
 }
 
 /// \copydoc gpcc::cood::ResponseBase::ToString
@@ -262,23 +262,23 @@ std::string ReadRequestResponse::ToString(void) const
 {
   using gpcc::string::StringComposer;
   StringComposer s;
-  s << "Read request response: " << SDOAbortCodeToDescrString(result);
+  s << "Read request response: " << SDOAbortCodeToDescrString(result_);
 
-  if (result == SDOAbortCode::OK)
+  if (result_ == SDOAbortCode::OK)
   {
-    s << ", " << (sizeInBit / 8U) << '.' << (sizeInBit % 8U) << " byte(s) of data";
+    s << ", " << (sizeInBit_ / 8U) << '.' << (sizeInBit_ % 8U) << " byte(s) of data";
 
-    if (data.size() <= 16U)
+    if (data_.size() <= 16U)
     {
       s << ':' << gpcc::osal::endl;
 
       s << StringComposer::BaseHex << StringComposer::Uppercase << StringComposer::AlignRightPadZero;
-      for (uint_fast8_t i = 0U; i < data.size(); i++)
+      for (uint_fast8_t i = 0U; i < data_.size(); i++)
       {
         if (i != 0U)
           s << ' ';
 
-        s << "0x" << StringComposer::Width(2) << static_cast<unsigned int>(data[i]);
+        s << "0x" << StringComposer::Width(2) << static_cast<unsigned int>(data_[i]);
       }
     }
   }
@@ -306,18 +306,18 @@ std::string ReadRequestResponse::ToString(void) const
  *
  * - - -
  *
- * \param _result
+ * \param result
  * Desired value for the encapsulated result.\n
  * An error status is expected. @ref SDOAbortCode::OK is not allowed.
  */
-void ReadRequestResponse::SetError(SDOAbortCode const _result)
+void ReadRequestResponse::SetError(SDOAbortCode const result)
 {
-  if (_result == SDOAbortCode::OK)
+  if (result == SDOAbortCode::OK)
     throw std::invalid_argument("ReadRequestResponse::SetError: Negative result expected");
 
-  result = _result;
-  data.clear();
-  sizeInBit = 0U;
+  result_ = result;
+  data_.clear();
+  sizeInBit_ = 0U;
 }
 
 /**
@@ -340,27 +340,27 @@ void ReadRequestResponse::SetError(SDOAbortCode const _result)
  *
  * - - -
  *
- * \param _data
+ * \param data
  * The content of the referenced vector will be moved into the response object.\n
  * The referenced vector will be empty afterwards.
  *
- * \param _sizeInBit
+ * \param sizeInBit
  * Size of the data in bit.
  */
-void ReadRequestResponse::SetData(std::vector<uint8_t> && _data, size_t const _sizeInBit)
+void ReadRequestResponse::SetData(std::vector<uint8_t> && data, size_t const sizeInBit)
 {
-  if (_data.size() > std::numeric_limits<uint16_t>::max())
-    throw std::invalid_argument("ReadRequestResponse::SetData: _data too large.");
+  if (data.size() > std::numeric_limits<uint16_t>::max())
+    throw std::invalid_argument("ReadRequestResponse::SetData: data too large.");
 
-  if (_data.size() != ((_sizeInBit + 7U) / 8U))
-    throw std::invalid_argument("ReadRequestResponse::SetData: _data and _sizeInBit do not match.");
+  if (data.size() != ((sizeInBit + 7U) / 8U))
+    throw std::invalid_argument("ReadRequestResponse::SetData: data and sizeInBit do not match.");
 
-  data = std::move(_data);
-  _data.clear();
+  data_ = std::move(data);
+  data.clear();
 
-  sizeInBit = _sizeInBit;
+  sizeInBit_ = sizeInBit;
 
-  result = SDOAbortCode::OK;
+  result_ = SDOAbortCode::OK;
 }
 
 /**
@@ -384,7 +384,7 @@ void ReadRequestResponse::SetData(std::vector<uint8_t> && _data, size_t const _s
  */
 SDOAbortCode ReadRequestResponse::GetResult(void) const noexcept
 {
-  return result;
+  return result_;
 }
 
 /**
@@ -410,10 +410,10 @@ SDOAbortCode ReadRequestResponse::GetResult(void) const noexcept
  */
 size_t ReadRequestResponse::GetDataSize(void) const
 {
-  if (result != SDOAbortCode::OK)
+  if (result_ != SDOAbortCode::OK)
     throw std::logic_error("ReadRequestResponse::GetDataSize: Read failed");
 
-  return sizeInBit;
+  return sizeInBit_;
 }
 
 /**
@@ -441,10 +441,10 @@ size_t ReadRequestResponse::GetDataSize(void) const
  */
 std::vector<uint8_t> const & ReadRequestResponse::GetData(void) const
 {
-  if (result != SDOAbortCode::OK)
+  if (result_ != SDOAbortCode::OK)
     throw std::logic_error("ReadRequestResponse::GetData: Read failed");
 
-  return data;
+  return data_;
 }
 
 } // namespace cood

--- a/src/cood/remote_access/requests_and_responses/RequestBase.cpp
+++ b/src/cood/remote_access/requests_and_responses/RequestBase.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2021 Daniel Jerolm
+    Copyright (C) 2021, 2025 Daniel Jerolm
 */
 
 #include <gpcc/cood/remote_access/requests_and_responses/RequestBase.hpp>
@@ -25,8 +25,8 @@ namespace cood {
 
 size_t  const RequestBase::minimumUsefulRequestSize;
 size_t  const RequestBase::maxRequestSize;
-uint8_t const RequestBase::version;
-size_t  const RequestBase::baseBinarySize;
+uint8_t const RequestBase::version_;
+size_t  const RequestBase::baseBinarySize_;
 
 /**
  * \brief Destructor.
@@ -86,8 +86,8 @@ RequestBase::~RequestBase(void)
 std::unique_ptr<RequestBase> RequestBase::FromBinary(gpcc::stream::IStreamReader & sr)
 {
   // check version
-  auto const _version = sr.Read_uint8();
-  if (_version != version)
+  auto const version = sr.Read_uint8();
+  if (version != version_)
     throw std::runtime_error("RequestBase::FromBinary: Version of serialized object is not supported");
 
   // check type and delegate to appropriate subclass
@@ -95,19 +95,19 @@ std::unique_ptr<RequestBase> RequestBase::FromBinary(gpcc::stream::IStreamReader
   switch (_type)
   {
     case RequestTypes::objectEnumRequest:
-      return std::make_unique<ObjectEnumRequest>(sr, _version, ObjectEnumRequestPassKey());
+      return std::make_unique<ObjectEnumRequest>(sr, version, ObjectEnumRequestPassKey());
 
     case RequestTypes::objectInfoRequest:
-      return std::make_unique<ObjectInfoRequest>(sr, _version, ObjectInfoRequestPassKey());
+      return std::make_unique<ObjectInfoRequest>(sr, version, ObjectInfoRequestPassKey());
 
     case RequestTypes::pingRequest:
-      return std::make_unique<PingRequest>(sr, _version, PingRequestPassKey());
+      return std::make_unique<PingRequest>(sr, version, PingRequestPassKey());
 
     case RequestTypes::readRequest:
-      return std::make_unique<ReadRequest>(sr, _version, ReadRequestPassKey());
+      return std::make_unique<ReadRequest>(sr, version, ReadRequestPassKey());
 
     case RequestTypes::writeRequest:
-      return std::make_unique<WriteRequest>(sr, _version, WriteRequestPassKey());
+      return std::make_unique<WriteRequest>(sr, version, WriteRequestPassKey());
   }
 
   throw std::logic_error("RequestBase::FromBinary: Internal error (no create-method)");
@@ -145,10 +145,10 @@ size_t RequestBase::GetBinarySize(void) const
 {
   static_assert(RequestBase::maxRequestSize > RequestBase::minimumUsefulRequestSize,
     "Maximum request size is less than the minimum useful size");
-  static_assert(RequestBase::baseBinarySize < RequestBase::minimumUsefulRequestSize,
+  static_assert(RequestBase::baseBinarySize_ < RequestBase::minimumUsefulRequestSize,
     "No payload left for subclass");
 
-  return baseBinarySize + (returnStack.size() * ReturnStackItem::binarySize);
+  return baseBinarySize_ + (returnStack_.size() * ReturnStackItem::binarySize);
 }
 
 /**
@@ -187,14 +187,14 @@ size_t RequestBase::GetBinarySize(void) const
 void RequestBase::ToBinary(gpcc::stream::IStreamWriter & sw) const
 {
   // to be read by FromBinary()
-  sw.Write_uint8(version);
-  sw.Write_uint8(static_cast<uint8_t>(type));
+  sw.Write_uint8(version_);
+  sw.Write_uint8(static_cast<uint8_t>(type_));
 
   // to be read by CTOR
-  sw.Write_uint32(maxResponseSize);
+  sw.Write_uint32(maxResponseSize_);
 
-  sw.Write_uint8(returnStack.size());
-  for (auto const & e: returnStack)
+  sw.Write_uint8(returnStack_.size());
+  for (auto const & e: returnStack_)
     e.ToBinary(sw);
 }
 
@@ -228,14 +228,14 @@ void RequestBase::ToBinary(gpcc::stream::IStreamWriter & sw) const
  */
 void RequestBase::Push(ReturnStackItem const & rsi)
 {
-  if (returnStack.size() == std::numeric_limits<uint8_t>::max())
+  if (returnStack_.size() == std::numeric_limits<uint8_t>::max())
     throw std::runtime_error("RequestBase::Push: Stack size at maximum");
 
-  if (maxResponseSize > (ResponseBase::maxResponseSize - ReturnStackItem::binarySize))
+  if (maxResponseSize_ > (ResponseBase::maxResponseSize - ReturnStackItem::binarySize))
     throw std::logic_error("RequestBase::Push: 'maxResponseSize' would overflow");
 
-  returnStack.emplace_back(rsi);
-  maxResponseSize += ReturnStackItem::binarySize;
+  returnStack_.emplace_back(rsi);
+  maxResponseSize_ += ReturnStackItem::binarySize;
 }
 
 /**
@@ -259,11 +259,11 @@ void RequestBase::Push(ReturnStackItem const & rsi)
  */
 void RequestBase::UndoPush(void)
 {
-  if (returnStack.empty())
+  if (returnStack_.empty())
     throw std::logic_error("RequestBase::UndoPush: Empty");
 
-  returnStack.pop_back();
-  maxResponseSize -= ReturnStackItem::binarySize;
+  returnStack_.pop_back();
+  maxResponseSize_ -= ReturnStackItem::binarySize;
 }
 
 /**
@@ -289,8 +289,8 @@ void RequestBase::UndoPush(void)
  */
 void RequestBase::ExtractReturnStack(std::vector<ReturnStackItem> & dest) noexcept
 {
-  dest = std::move(returnStack);
-  returnStack.clear();
+  dest = std::move(returnStack_);
+  returnStack_.clear();
 }
 
 /**
@@ -315,7 +315,7 @@ void RequestBase::ExtractReturnStack(std::vector<ReturnStackItem> & dest) noexce
  */
 size_t RequestBase::GetReturnStackSize(void) const noexcept
 {
-  return returnStack.size() * ReturnStackItem::binarySize;
+  return returnStack_.size() * ReturnStackItem::binarySize;
 }
 
 /**
@@ -331,10 +331,10 @@ size_t RequestBase::GetReturnStackSize(void) const noexcept
  *
  * - - -
  *
- * \param _type
+ * \param type
  * Type of request.
  *
- * \param _maxResponseSize
+ * \param maxResponseSize
  * Maximum size (in byte) of the serialized response object that can be processed by the creator of this request.
  * The value should be the minimum of the capability of the creator and the maximum possible response size announced
  * by @ref IRemoteObjectDictionaryAccessNotifiable::OnReady(), parameter `maxResponseSize`.\n
@@ -350,15 +350,15 @@ size_t RequestBase::GetReturnStackSize(void) const noexcept
  * \htmlonly <style>div.image img[src="cood/RODA_ReqCTOR_MaxResponseSize.png"]{width:80%;}</style> \endhtmlonly
  * \image html "cood/RODA_ReqCTOR_MaxResponseSize.png" "Maximum response size with one ReturnStackItem"
  */
-RequestBase::RequestBase(RequestTypes const _type, size_t const _maxResponseSize)
-: type(_type)
+RequestBase::RequestBase(RequestTypes const type, size_t const maxResponseSize)
+: type_(type)
 , pPrevInIntrusiveDList(nullptr)
 , pNextInIntrusiveDList(nullptr)
-, maxResponseSize(_maxResponseSize)
-, returnStack()
+, maxResponseSize_(maxResponseSize)
+, returnStack_()
 {
-  if (   (maxResponseSize < ResponseBase::minimumUsefulResponseSize)
-      || (maxResponseSize > ResponseBase::maxResponseSize))
+  if (   (maxResponseSize_ < ResponseBase::minimumUsefulResponseSize)
+      || (maxResponseSize_ > ResponseBase::maxResponseSize))
   {
     throw std::invalid_argument("RequestBase::RequestBase: '_maxResponseSize' invalid");
   }
@@ -382,7 +382,7 @@ RequestBase::RequestBase(RequestTypes const _type, size_t const _maxResponseSize
  *
  * - - -
  *
- * \param _type
+ * \param type
  * Type of request.
  *
  * \param sr
@@ -391,27 +391,27 @@ RequestBase::RequestBase(RequestTypes const _type, size_t const _maxResponseSize
  * \param versionOnHand
  * Version of serialized object read from `sr`.
  */
-RequestBase::RequestBase(RequestTypes const _type, gpcc::stream::IStreamReader & sr, uint8_t const versionOnHand)
-: type(_type)
+RequestBase::RequestBase(RequestTypes const type, gpcc::stream::IStreamReader & sr, uint8_t const versionOnHand)
+: type_(type)
 , pPrevInIntrusiveDList(nullptr)
 , pNextInIntrusiveDList(nullptr)
-, returnStack()
+, returnStack_()
 {
-  if (versionOnHand != version)
+  if (versionOnHand != version_)
     throw std::runtime_error("RequestBase::RequestBase: Version not supported");
 
-  maxResponseSize = sr.Read_uint32();
-  if (   (maxResponseSize < ResponseBase::minimumUsefulResponseSize)
-      || (maxResponseSize > ResponseBase::maxResponseSize))
+  maxResponseSize_ = sr.Read_uint32();
+  if (   (maxResponseSize_ < ResponseBase::minimumUsefulResponseSize)
+      || (maxResponseSize_ > ResponseBase::maxResponseSize))
   {
     throw std::runtime_error("RequestBase::RequestBase: 'maxResponseSize' invalid");
   }
 
   uint_fast8_t n = sr.Read_uint8();
-  returnStack.reserve(n);
+  returnStack_.reserve(n);
   while (n != 0U)
   {
-    returnStack.emplace_back(sr);
+    returnStack_.emplace_back(sr);
     --n;
   }
 }
@@ -435,11 +435,11 @@ RequestBase::RequestBase(RequestTypes const _type, gpcc::stream::IStreamReader &
  * @ref RequestBase object that shall be copied.
  */
 RequestBase::RequestBase(RequestBase const & other)
-: type(other.type)
+: type_(other.type_)
 , pPrevInIntrusiveDList(nullptr)
 , pNextInIntrusiveDList(nullptr)
-, maxResponseSize(other.maxResponseSize)
-, returnStack(other.returnStack)
+, maxResponseSize_(other.maxResponseSize_)
+, returnStack_(other.returnStack_)
 {
 }
 
@@ -461,11 +461,11 @@ RequestBase::RequestBase(RequestBase const & other)
  * Afterwards, the stack of @ref ReturnStackItem objects of `other` will be empty.
  */
 RequestBase::RequestBase(RequestBase && other) noexcept
-: type(other.type)
+: type_(other.type_)
 , pPrevInIntrusiveDList(nullptr)
 , pNextInIntrusiveDList(nullptr)
-, maxResponseSize(other.maxResponseSize)
-, returnStack(std::move(other.returnStack))
+, maxResponseSize_(other.maxResponseSize_)
+, returnStack_(std::move(other.returnStack_))
 {
 }
 
@@ -492,14 +492,14 @@ RequestBase& RequestBase::operator=(RequestBase const & rhv)
 {
   if (&rhv != this)
   {
-    if (type != rhv.type)
+    if (type_ != rhv.type_)
       throw std::logic_error("RequestBase::operator=(&): Different types");
 
     // not sure if copy-assignment provides the strong guarantee, so we use two steps here...
-    auto copyOfReturnStack = rhv.returnStack;
-    returnStack = std::move(copyOfReturnStack);
+    auto copyOfReturnStack = rhv.returnStack_;
+    returnStack_ = std::move(copyOfReturnStack);
 
-    maxResponseSize = rhv.maxResponseSize;
+    maxResponseSize_ = rhv.maxResponseSize_;
   }
 
   return *this;
@@ -527,13 +527,13 @@ RequestBase& RequestBase::operator=(RequestBase && rhv)
 {
   if (&rhv != this)
   {
-    if (type != rhv.type)
+    if (type_ != rhv.type_)
       throw std::logic_error("RequestBase::operator=(&&): Different types");
 
-    returnStack = std::move(rhv.returnStack);
-    rhv.returnStack.clear();
+    returnStack_ = std::move(rhv.returnStack_);
+    rhv.returnStack_.clear();
 
-    maxResponseSize = rhv.maxResponseSize;
+    maxResponseSize_ = rhv.maxResponseSize_;
   }
 
   return *this;

--- a/src/cood/remote_access/requests_and_responses/ResponseBase.cpp
+++ b/src/cood/remote_access/requests_and_responses/ResponseBase.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2021 Daniel Jerolm
+    Copyright (C) 2021, 2025 Daniel Jerolm
 */
 
 #include <gpcc/cood/remote_access/requests_and_responses/ResponseBase.hpp>
@@ -24,8 +24,8 @@ namespace cood {
 
 size_t  const ResponseBase::minimumUsefulResponseSize;
 size_t  const ResponseBase::maxResponseSize;
-uint8_t const ResponseBase::version;
-size_t  const ResponseBase::baseBinarySize;
+uint8_t const ResponseBase::version_;
+size_t  const ResponseBase::baseBinarySize_;
 
 
 /**
@@ -86,8 +86,8 @@ ResponseBase::~ResponseBase(void)
 std::unique_ptr<ResponseBase> ResponseBase::FromBinary(gpcc::stream::IStreamReader & sr)
 {
   // check version
-  auto const _version = sr.Read_uint8();
-  if (_version != version)
+  auto const version = sr.Read_uint8();
+  if (version != version_)
     throw std::runtime_error("ResponseBase::FromBinary: Version of serialized object is not supported");
 
   // check type and delegate to appropriate subclass
@@ -95,19 +95,19 @@ std::unique_ptr<ResponseBase> ResponseBase::FromBinary(gpcc::stream::IStreamRead
   switch (_type)
   {
     case ResponseTypes::objectEnumResponse:
-      return std::make_unique<ObjectEnumResponse>(sr, _version, ObjectEnumResponsePassKey());
+      return std::make_unique<ObjectEnumResponse>(sr, version, ObjectEnumResponsePassKey());
 
     case ResponseTypes::objectInfoResponse:
-      return std::make_unique<ObjectInfoResponse>(sr, _version, ObjectInfoResponsePassKey());
+      return std::make_unique<ObjectInfoResponse>(sr, version, ObjectInfoResponsePassKey());
 
     case ResponseTypes::pingResponse:
-      return std::make_unique<PingResponse>(sr, _version, PingResponsePassKey());
+      return std::make_unique<PingResponse>(sr, version, PingResponsePassKey());
 
     case ResponseTypes::readRequestResponse:
-      return std::make_unique<ReadRequestResponse>(sr, _version, ReadRequestResponsePassKey());
+      return std::make_unique<ReadRequestResponse>(sr, version, ReadRequestResponsePassKey());
 
     case ResponseTypes::writeRequestResponse:
-      return std::make_unique<WriteRequestResponse>(sr, _version, WriteRequestResponsePassKey());
+      return std::make_unique<WriteRequestResponse>(sr, version, WriteRequestResponsePassKey());
   }
 
   throw std::logic_error("ResponseBase::FromBinary: Internal error (no create method)");
@@ -143,7 +143,7 @@ std::unique_ptr<ResponseBase> ResponseBase::FromBinary(gpcc::stream::IStreamRead
  */
 size_t ResponseBase::GetBinarySize(void) const
 {
-  return baseBinarySize + (returnStack.size() * ReturnStackItem::binarySize);
+  return baseBinarySize_ + (returnStack_.size() * ReturnStackItem::binarySize);
 }
 
 /**
@@ -182,12 +182,12 @@ size_t ResponseBase::GetBinarySize(void) const
 void ResponseBase::ToBinary(gpcc::stream::IStreamWriter & sw) const
 {
   // to be read by FromBinary()
-  sw.Write_uint8(version);
-  sw.Write_uint8(static_cast<uint8_t>(type));
+  sw.Write_uint8(version_);
+  sw.Write_uint8(static_cast<uint8_t>(type_));
 
   // to be read by CTOR
-  sw.Write_uint8(returnStack.size());
-  for (auto const & e: returnStack)
+  sw.Write_uint8(returnStack_.size());
+  for (auto const & e: returnStack_)
     e.ToBinary(sw);
 }
 
@@ -217,13 +217,13 @@ void ResponseBase::ToBinary(gpcc::stream::IStreamWriter & sw) const
  */
 void ResponseBase::SetReturnStack(std::vector<ReturnStackItem> && rs)
 {
-  if (!returnStack.empty())
+  if (!returnStack_.empty())
     throw std::logic_error("ResponseBase::SetReturnStack: Stack not empty");
 
   if (rs.size() > std::numeric_limits<uint8_t>::max())
     throw std::invalid_argument("ResponseBase::SetReturnStack: Two many items in 'rs'");
 
-  returnStack = std::move(rs);
+  returnStack_ = std::move(rs);
   rs.clear();
 }
 
@@ -248,7 +248,7 @@ void ResponseBase::SetReturnStack(std::vector<ReturnStackItem> && rs)
  */
 bool ResponseBase::IsReturnStackEmpty(void) const noexcept
 {
-  return returnStack.empty();
+  return returnStack_.empty();
 }
 
 /**
@@ -276,11 +276,11 @@ bool ResponseBase::IsReturnStackEmpty(void) const noexcept
  */
 ReturnStackItem ResponseBase::PopReturnStack(void)
 {
-  if (returnStack.empty())
+  if (returnStack_.empty())
     throw std::runtime_error("ResponseBase::PopReturnStack: Stack empty");
 
-  ReturnStackItem rsi = returnStack.back();
-  returnStack.pop_back();
+  ReturnStackItem rsi = returnStack_.back();
+  returnStack_.pop_back();
   return rsi;
 }
 
@@ -305,7 +305,7 @@ ReturnStackItem ResponseBase::PopReturnStack(void)
  */
 ResponseBase::ResponseTypes ResponseBase::GetType(void) const noexcept
 {
-  return type;
+  return type_;
 }
 
 /**
@@ -321,14 +321,14 @@ ResponseBase::ResponseTypes ResponseBase::GetType(void) const noexcept
  *
  * - - -
  *
- * \param _type
+ * \param type
  * Type of response.
  */
-ResponseBase::ResponseBase(ResponseTypes const _type)
-: type(_type)
+ResponseBase::ResponseBase(ResponseTypes const type)
+: type_(type)
 , pPrevInIntrusiveDList(nullptr)
 , pNextInIntrusiveDList(nullptr)
-, returnStack()
+, returnStack_()
 {
 }
 
@@ -350,7 +350,7 @@ ResponseBase::ResponseBase(ResponseTypes const _type)
  *
  * - - -
  *
- * \param _type
+ * \param type
  * Type of request.
  *
  * \param sr
@@ -359,20 +359,20 @@ ResponseBase::ResponseBase(ResponseTypes const _type)
  * \param versionOnHand
  * Version of serialized object read from `sr`.
  */
-ResponseBase::ResponseBase(ResponseTypes const _type, gpcc::stream::IStreamReader & sr, uint8_t const versionOnHand)
-: type(_type)
+ResponseBase::ResponseBase(ResponseTypes const type, gpcc::stream::IStreamReader & sr, uint8_t const versionOnHand)
+: type_(type)
 , pPrevInIntrusiveDList(nullptr)
 , pNextInIntrusiveDList(nullptr)
-, returnStack()
+, returnStack_()
 {
-  if (versionOnHand != version)
+  if (versionOnHand != version_)
     throw std::runtime_error("ResponseBase::ResponseBase: Version not supported");
 
   uint_fast8_t n = sr.Read_uint8();
-  returnStack.reserve(n);
+  returnStack_.reserve(n);
   while (n != 0U)
   {
-    returnStack.emplace_back(sr);
+    returnStack_.emplace_back(sr);
     --n;
   }
 }
@@ -396,10 +396,10 @@ ResponseBase::ResponseBase(ResponseTypes const _type, gpcc::stream::IStreamReade
  * @ref ResponseBase object that shall be copied.
  */
 ResponseBase::ResponseBase(ResponseBase const & other)
-: type(other.type)
+: type_(other.type_)
 , pPrevInIntrusiveDList(nullptr)
 , pNextInIntrusiveDList(nullptr)
-, returnStack(other.returnStack)
+, returnStack_(other.returnStack_)
 {
 }
 
@@ -421,10 +421,10 @@ ResponseBase::ResponseBase(ResponseBase const & other)
  * Afterwards, the stack of @ref ReturnStackItem objects of `other` will be empty.
  */
 ResponseBase::ResponseBase(ResponseBase && other) noexcept
-: type(other.type)
+: type_(other.type_)
 , pPrevInIntrusiveDList(nullptr)
 , pNextInIntrusiveDList(nullptr)
-, returnStack(std::move(other.returnStack))
+, returnStack_(std::move(other.returnStack_))
 {
 }
 
@@ -451,12 +451,12 @@ ResponseBase& ResponseBase::operator=(ResponseBase const & rhv)
 {
   if (&rhv != this)
   {
-    if (type != rhv.type)
+    if (type_ != rhv.type_)
       throw std::logic_error("ResponseBase::operator=(&): Different types");
 
     // not sure if copy-assignment provides the strong guarantee, so we use two steps here...
-    auto copyOfReturnStack = rhv.returnStack;
-    returnStack = std::move(copyOfReturnStack);
+    auto copyOfReturnStack = rhv.returnStack_;
+    returnStack_ = std::move(copyOfReturnStack);
   }
 
   return *this;
@@ -484,11 +484,11 @@ ResponseBase& ResponseBase::operator=(ResponseBase && rhv)
 {
   if (&rhv != this)
   {
-    if (type != rhv.type)
+    if (type_ != rhv.type_)
       throw std::logic_error("ResponseBase::operator=(&&): Different types");
 
-    returnStack = std::move(rhv.returnStack);
-    rhv.returnStack.clear();
+    returnStack_ = std::move(rhv.returnStack_);
+    rhv.returnStack_.clear();
   }
 
   return *this;

--- a/src/cood/remote_access/requests_and_responses/WriteRequest.cpp
+++ b/src/cood/remote_access/requests_and_responses/WriteRequest.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2021, 2024 Daniel Jerolm
+    Copyright (C) 2021, 2024, 2025 Daniel Jerolm
 */
 
 #include <gpcc/cood/remote_access/requests_and_responses/WriteRequest.hpp>
@@ -19,7 +19,7 @@
 namespace gpcc {
 namespace cood {
 
-size_t const WriteRequest::writeRequestBinarySize;
+size_t const WriteRequest::writeRequestBinarySize_;
 
 /**
  * \brief Constructor.
@@ -34,22 +34,22 @@ size_t const WriteRequest::writeRequestBinarySize;
  *
  * - - -
  *
- * \param _accessType
+ * \param accessType
  * Access type.
  *
- * \param _index
+ * \param index
  * Index of the object that shall be written.
  *
- * \param _subindex
+ * \param subindex
  * Subindex that shall be written.
  *
- * \param _permissions
+ * \param permissions
  * Permissions for the write-operation provided by the originator of the write request.\n
  * This shall be composed by logical-or-combination of one or multiple Object::attr_ACCESS_xxx values.\n
  * The composed value shall have at least one write permission (@ref Object::attr_ACCESS_WR) bit set.\n
  * There shall be no other bits set except for write permission bits.
  *
- * \param _data
+ * \param data
  * Universal reference to an `std::vector<uint8_t>` containing the data that shall be written.\n
  * The data shall be encoded in CANopen format.\n
  * The vector shall contain at least one or two byte of data (depending on _accessType and _subindex) and no more than
@@ -59,7 +59,7 @@ size_t const WriteRequest::writeRequestBinarySize;
  * Afterwards the referenced vector will be in a valid but undefined state.\n
  * \n
  *
- * \param _maxResponseSize
+ * \param maxResponseSize
  * Maximum size (in byte) of the serialized response object that can be processed by the creator of this request.
  * The value should be the minimum of the capability of the creator and the maximum possible response size announced
  * by @ref IRemoteObjectDictionaryAccessNotifiable::OnReady(), parameter `maxResponseSize`.\n
@@ -75,34 +75,34 @@ size_t const WriteRequest::writeRequestBinarySize;
  * \htmlonly <style>div.image img[src="cood/RODA_ReqCTOR_MaxResponseSize.png"]{width:80%;}</style> \endhtmlonly
  * \image html "cood/RODA_ReqCTOR_MaxResponseSize.png" "Maximum response size with one ReturnStackItem"
  */
-WriteRequest::WriteRequest(AccessType           const _accessType,
-                           uint16_t             const _index,
-                           uint8_t              const _subindex,
-                           Object::attr_t       const _permissions,
-                           std::vector<uint8_t> &&    _data,
-                           size_t               const _maxResponseSize)
-: RequestBase(RequestTypes::writeRequest, _maxResponseSize)
-, accessType(_accessType)
-, index(_index)
-, subindex(_subindex)
-, permissions(_permissions)
-, data()
+WriteRequest::WriteRequest(AccessType           const accessType,
+                           uint16_t             const index,
+                           uint8_t              const subindex,
+                           Object::attr_t       const permissions,
+                           std::vector<uint8_t> &&    data,
+                           size_t               const maxResponseSize)
+: RequestBase(RequestTypes::writeRequest, maxResponseSize)
+, accessType_(accessType)
+, index_(index)
+, subindex_(subindex)
+, permissions_(permissions)
+, data_()
 {
-  if ((accessType != AccessType::singleSubindex) && (subindex > 1U))
+  if ((accessType_ != AccessType::singleSubindex) && (subindex_ > 1U))
     throw std::invalid_argument("WriteRequest::WriteRequest: Complete access requires '_subindex' in range 0..1");
 
-  if (   ((permissions & Object::attr_ACCESS_WR) == 0U)
-      || ((permissions & Object::attr_ACCESS_WR) != permissions))
+  if (   ((permissions_ & Object::attr_ACCESS_WR) == 0U)
+      || ((permissions_ & Object::attr_ACCESS_WR) != permissions_))
   {
     throw std::invalid_argument("WriteRequest::WriteRequest: '_permissions' invalid.");
   }
 
-  size_t const minReqData = ((accessType == AccessType::completeAccess_SI0_16bit) && (subindex == 0U)) ? 2U : 1U;
+  size_t const minReqData = ((accessType_ == AccessType::completeAccess_SI0_16bit) && (subindex_ == 0U)) ? 2U : 1U;
 
-  if ((_data.size() < minReqData) || (_data.size() > std::numeric_limits<uint16_t>::max()))
-    throw std::invalid_argument("WriteRequest::WriteRequest: '_data' is too small or too large");
+  if ((data.size() < minReqData) || (data.size() > std::numeric_limits<uint16_t>::max()))
+    throw std::invalid_argument("WriteRequest::WriteRequest: 'data' is too small or too large");
 
-  data = std::move(_data);
+  data_ = std::move(data);
 }
 
 /**
@@ -136,34 +136,34 @@ WriteRequest::WriteRequest(AccessType           const _accessType,
  */
 WriteRequest::WriteRequest(gpcc::stream::IStreamReader & sr, uint8_t const versionOnHand, WriteRequestPassKey)
 : RequestBase(RequestTypes::writeRequest, sr, versionOnHand)
-, accessType(U8_to_AccessType(sr.Read_uint8()))
-, index(sr.Read_uint16())
-, subindex(sr.Read_uint8())
-, permissions(static_cast<Object::attr_t>(sr.Read_uint16()))
-, data()
+, accessType_(U8_to_AccessType(sr.Read_uint8()))
+, index_(sr.Read_uint16())
+, subindex_(sr.Read_uint8())
+, permissions_(static_cast<Object::attr_t>(sr.Read_uint16()))
+, data_()
 {
-  if (versionOnHand != version)
+  if (versionOnHand != version_)
     throw std::runtime_error("WriteRequest::WriteRequest: Version not supported");
 
-  if ((accessType != AccessType::singleSubindex) && (subindex > 1U))
+  if ((accessType_ != AccessType::singleSubindex) && (subindex_ > 1U))
     throw std::runtime_error("WriteRequest::WriteRequest: Data read from 'sr' is invalid");
 
-  if (   ((permissions & Object::attr_ACCESS_WR) == 0U)
-      || ((permissions & Object::attr_ACCESS_WR) != permissions))
+  if (   ((permissions_ & Object::attr_ACCESS_WR) == 0U)
+      || ((permissions_ & Object::attr_ACCESS_WR) != permissions_))
   {
     throw std::runtime_error("WriteRequest::WriteRequest: Data read from 'sr' is invalid");
   }
 
-  size_t const minReqData = ((accessType == AccessType::completeAccess_SI0_16bit) && (subindex == 0U)) ? 2U : 1U;
+  size_t const minReqData = ((accessType_ == AccessType::completeAccess_SI0_16bit) && (subindex_ == 0U)) ? 2U : 1U;
 
   uint_fast16_t s = sr.Read_uint16();
   if (s < minReqData)
     throw std::runtime_error("WriteRequest::WriteRequest: Data read from 'sr' is invalid");
 
-  data.reserve(s);
+  data_.reserve(s);
   while (s != 0U)
   {
-    data.push_back(sr.Read_uint8());
+    data_.push_back(sr.Read_uint8());
     --s;
   }
 }
@@ -204,7 +204,7 @@ size_t WriteRequest::CalcMaxDataPayload(size_t const maxRequestSize, bool const 
   size_t maxDataPayload = maxRequestSize;
 
   // subtract overhead of base class RequestBase and class WriteRequest
-  size_t const binarySize = baseBinarySize + writeRequestBinarySize;
+  size_t const binarySize = baseBinarySize_ + writeRequestBinarySize_;
   if (maxDataPayload <= binarySize)
     return 0U;
   else
@@ -232,23 +232,23 @@ size_t WriteRequest::CalcMaxDataPayload(size_t const maxRequestSize, bool const 
 /// \copydoc gpcc::cood::RequestBase::GetBinarySize
 size_t WriteRequest::GetBinarySize(void) const
 {
-  return RequestBase::GetBinarySize() + writeRequestBinarySize + data.size();
+  return RequestBase::GetBinarySize() + writeRequestBinarySize_ + data_.size();
 }
 
 /// \copydoc gpcc::cood::RequestBase::ToBinary
 void WriteRequest::ToBinary(gpcc::stream::IStreamWriter & sw) const
 {
-  if (data.empty())
+  if (data_.empty())
     throw std::logic_error("WriteRequest::ToBinary: Object empty. Was it involved in a move-operation?");
 
   RequestBase::ToBinary(sw);
 
-  sw.Write_uint8(static_cast<uint8_t>(accessType));
-  sw.Write_uint16(index);
-  sw.Write_uint8(subindex);
-  sw.Write_uint16(permissions);
-  sw.Write_uint16(data.size());
-  sw.Write_uint8(data.data(), data.size());
+  sw.Write_uint8(static_cast<uint8_t>(accessType_));
+  sw.Write_uint16(index_);
+  sw.Write_uint8(subindex_);
+  sw.Write_uint16(permissions_);
+  sw.Write_uint16(data_.size());
+  sw.Write_uint8(data_.data(), data_.size());
 }
 
 /// \copydoc gpcc::cood::RequestBase::ToString
@@ -259,7 +259,7 @@ std::string WriteRequest::ToString(void) const
 
   s << "Write request (";
 
-  switch (accessType)
+  switch (accessType_)
   {
     case AccessType::singleSubindex:
       s << "single subindex";
@@ -274,21 +274,21 @@ std::string WriteRequest::ToString(void) const
       break;
   }
 
-  s << ") for " << gpcc::string::ToHex(index, 4U) << ':' << static_cast<unsigned int>(subindex) << ", "
-       "Permission = " << gpcc::string::ToHex(static_cast<uint16_t>(permissions), 4U) << ", "
-    << data.size() << " byte(s) of data";
+  s << ") for " << gpcc::string::ToHex(index_, 4U) << ':' << static_cast<unsigned int>(subindex_) << ", "
+       "Permission = " << gpcc::string::ToHex(static_cast<uint16_t>(permissions_), 4U) << ", "
+    << data_.size() << " byte(s) of data";
 
-  if (data.size() <= 16U)
+  if (data_.size() <= 16U)
   {
     s << ':' << gpcc::osal::endl;
 
     s << StringComposer::BaseHex << StringComposer::Uppercase << StringComposer::AlignRightPadZero;
-    for (uint_fast8_t i = 0U; i < data.size(); i++)
+    for (uint_fast8_t i = 0U; i < data_.size(); i++)
     {
       if (i != 0U)
         s << ' ';
 
-      s << "0x" << StringComposer::Width(2) << static_cast<unsigned int>(data[i]);
+      s << "0x" << StringComposer::Width(2) << static_cast<unsigned int>(data_[i]);
     }
   }
 
@@ -321,10 +321,10 @@ std::string WriteRequest::ToString(void) const
  */
 std::vector<uint8_t> const & WriteRequest::GetData(void) const
 {
-  if (data.empty())
+  if (data_.empty())
     throw std::logic_error("WriteRequest::GetData: Object empty. Was it involved in a move-operation?");
 
-  return data;
+  return data_;
 }
 
 /**

--- a/src/cood/remote_access/requests_and_responses/WriteRequestResponse.cpp
+++ b/src/cood/remote_access/requests_and_responses/WriteRequestResponse.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2021, 2024 Daniel Jerolm
+    Copyright (C) 2021, 2024, 2025 Daniel Jerolm
 */
 
 #include <gpcc/cood/remote_access/requests_and_responses/WriteRequestResponse.hpp>
@@ -18,7 +18,7 @@
 namespace gpcc {
 namespace cood {
 
-size_t const WriteRequestResponse::writeRequestResponseBinarySize;
+size_t const WriteRequestResponse::writeRequestResponseBinarySize_;
 
 /**
  * \brief Constructor.
@@ -33,12 +33,12 @@ size_t const WriteRequestResponse::writeRequestResponseBinarySize;
  *
  * - - -
  *
- * \param _result
+ * \param result
  * Result value that shall be encapsulated in the object.
  */
-WriteRequestResponse::WriteRequestResponse(SDOAbortCode const _result)
+WriteRequestResponse::WriteRequestResponse(SDOAbortCode const result)
 : ResponseBase(ResponseTypes::writeRequestResponse)
-, result(_result)
+, result_(result)
 {
 }
 
@@ -77,7 +77,7 @@ WriteRequestResponse::WriteRequestResponse(gpcc::stream::IStreamReader & sr, uin
   auto const result_u32 = sr.Read_uint32();
   try
   {
-    result = U32ToSDOAbortCode(result_u32);
+    result_ = U32ToSDOAbortCode(result_u32);
   }
   catch (std::exception const &)
   {
@@ -90,7 +90,7 @@ WriteRequestResponse::WriteRequestResponse(gpcc::stream::IStreamReader & sr, uin
 /// \copydoc gpcc::cood::ResponseBase::GetBinarySize
 size_t WriteRequestResponse::GetBinarySize(void) const
 {
-  return ResponseBase::GetBinarySize() + writeRequestResponseBinarySize;
+  return ResponseBase::GetBinarySize() + writeRequestResponseBinarySize_;
 }
 
 /// \copydoc gpcc::cood::ResponseBase::ToBinary
@@ -98,14 +98,14 @@ void WriteRequestResponse::ToBinary(gpcc::stream::IStreamWriter & sw) const
 {
   ResponseBase::ToBinary(sw);
 
-  sw.Write_uint32(static_cast<uint32_t>(result));
+  sw.Write_uint32(static_cast<uint32_t>(result_));
 }
 
 /// \copydoc gpcc::cood::ResponseBase::ToString
 std::string WriteRequestResponse::ToString(void) const
 {
   gpcc::string::StringComposer s;
-  s << "Write request response: " << SDOAbortCodeToDescrString(result);
+  s << "Write request response: " << SDOAbortCodeToDescrString(result_);
 
   return s.Get();
 }

--- a/src/execution/cyclic/TriggeredThreadedCyclicExec.cpp
+++ b/src/execution/cyclic/TriggeredThreadedCyclicExec.cpp
@@ -25,33 +25,33 @@ namespace cyclic {
  * After creation of the object, @ref StartThread() must be called to start the object's thread. After that,
  * cyclic sampling can be started and stopped via @ref RequestStartSampling() and @ref RequestStopSampling().
  *
- * ---
+ * - - -
  *
  * __Exception safety:__\n
  * Strong guarantee.
  *
  * __Thread cancellation safety:__\n
- * Deferred cancellation is safe.
+ * Strong guarantee.
  *
- * ---
+ * - - -
  *
  * \param pThreadName
- * Pointer to a null-terminated c-string with the name for the object's thread.\n
- * _No copy is generated._\n
- * _The referenced string must not change during lifetime of the TriggeredThreadedCyclicExec object._\n
- * _nullptr is not allowed._
+ * Name for the object's thread. This must point to a null-terminated string.
+ * `nullptr` is not allowed.
+ *
  * \param trigger
- * Reference to an [IIRQ2ThreadWakeup](@ref gpcc::stdif::IIRQ2ThreadWakeup) subclass instance that shall be
- * used to deliver the cyclic trigger.
+ * Reference to an [IIRQ2ThreadWakeup](@ref gpcc::stdif::IIRQ2ThreadWakeup) interface that shall be used to deliver the
+ * cyclic trigger.
+ *
  * \param timeout
- * Reference to a [TimeSpan](@ref gpcc::time::TimeSpan) instance providing the timeout for monitoring the cyclic
- * trigger. This should be approximately the expected period plus a reasonable safety-margin.\n
- * _A copy is generated._
+ * Timeout for monitoring the cyclic trigger.\n
+ * This should be approximately the expected period plus a reasonable safety-margin.
+ *
  * \param isPllLockedFunc
- * Functor to a function/method that shall be used to retrieve if the PLL driving `_trigger` is in the locked
- * state or not.\n
- * If no PLL is used to drive `_trigger`, or if the lock state shall not be monitored, then no function/method
- * must be referenced. For details please refer to the documentation of @ref tIsPllLocked. \n
+ * Functor to a function/method that shall be used to query if the PLL driving @p trigger is in the locked state or
+ * not.\n
+ * If no PLL is used to drive @p trigger, or if the lock state shall not be monitored, then no function/method
+ * shall be referenced. For details please refer to the documentation of @ref tIsPllLocked. \n
  * _A copy is generated._
  */
 TriggeredThreadedCyclicExec::TriggeredThreadedCyclicExec(char const * const pThreadName,
@@ -65,84 +65,90 @@ TriggeredThreadedCyclicExec::TriggeredThreadedCyclicExec(char const * const pThr
 , mutex_()
 , asyncReqFlags_(static_cast<uint8_t>(AsyncReqFlags::none))
 , state_(States::stopped)
-, startDelayCnt_(0)
+, startDelayCnt_(0U)
 {
 }
 
 /**
  * \brief Destructor.
  *
- * The following must be ensured:
- * - The object must be in state @ref States::stopped
- * - the object's thread must be terminated (call to @ref StopThread())
+ * \pre   The object must be in state @ref States::stopped.
  *
- * ---
+ * \pre   The object's thread must be terminated (call to @ref StopThread()).
+ *
+ * - - -
  *
  * __Exception safety:__\n
  * No-throw guarantee.
  *
  * __Thread cancellation safety:__\n
- * Safe, no cancellation point included.
+ * No cancellation point included.
  */
 TriggeredThreadedCyclicExec::~TriggeredThreadedCyclicExec(void)
 {
   gpcc::osal::MutexLocker mutexLocker(mutex_);
   if (state_ != States::stopped)
-    osal::Panic("TriggeredThreadedCyclicExec::~TriggeredThreadedCyclicExec: Still running");
+    PANIC();
 }
 
 /**
  * \brief Retrieves a null-terminated c-string with the name of an @ref States value.
  *
+ * - - -
+ *
  * __Thread safety:__\n
  * This is thread-safe.
  *
  * __Exception safety:__\n
- * Strong guarantee.
+ * No-throw guarantee.
  *
  * __Thread cancellation safety:__\n
- * Safe, no cancellation point included.
+ * No cancellation point included.
  *
- * ---
+ * - - -
  *
  * \param state
  * @ref States value for which a null-terminated c-string with the value's name shall be retrieved.
+ *
  * \return
- * Pointer to a null-terminated c-string with the name of the @ref States value specified by parameter 'state'.
+ * Pointer to a null-terminated c-string with the name of the @ref States value specified by @p state.
  */
-char const * TriggeredThreadedCyclicExec::State2String(States const state)
+char const * TriggeredThreadedCyclicExec::State2String(States const state) noexcept
 {
   switch (state)
   {
-    case States::stopped:   return "stopped";
-    case States::starting:     return "start";
-    case States::waitLock:  return "waitLock";
-    case States::running:       return "run";
-    default:
-      throw std::invalid_argument("TriggeredThreadedCyclicExec::State2String: unknown state");
+    case States::stopped:  return "stopped";
+    case States::starting: return "start";
+    case States::waitLock: return "waitLock";
+    case States::running:  return "run";
   } // switch (state)
+
+  PANIC();
 }
 
 /**
  * \brief Retrieves a null-terminated c-string with the name of an @ref StopReasons value.
  *
+ * - - -
+ *
  * __Thread safety:__\n
  * This is thread-safe.
  *
  * __Exception safety:__\n
- * Strong guarantee.
+ * No-throw guarantee.
  *
  * __Thread cancellation safety:__\n
- * Safe, no cancellation point included.
+ * No cancellation point included.
  *
- * ---
+ * - - -
  *
  * \param code
  * @ref StopReasons value for which a null-terminated c-string with the value's name shall be retrieved.
+ *
  * \return
- * Pointer to a null-terminated c-string with a the name of the @ref StopReasons value specified by parameter 'code'.
+ * Pointer to a null-terminated c-string with a the name of the @ref StopReasons value specified by @p code.
  */
-char const * TriggeredThreadedCyclicExec::StopReasons2String(StopReasons const code)
+char const * TriggeredThreadedCyclicExec::StopReasons2String(StopReasons const code) noexcept
 {
   switch (code)
   {
@@ -151,32 +157,34 @@ char const * TriggeredThreadedCyclicExec::StopReasons2String(StopReasons const c
     case StopReasons::triggerTimeout:  return "triggerTimeout";
     case StopReasons::pllLossOfLock:   return "pllLossOfLock";
     case StopReasons::sampleRetFalse:  return "sampleRetFalse";
-    default:
-      throw std::invalid_argument("TriggeredThreadedCyclicExec::StopReasons2String: unknown code");
   }
+
+  PANIC();
 }
 
 /**
  * \brief Retrieves a textual description for an @ref StopReasons value.
  *
+ * - - -
+ *
  * __Thread safety:__\n
  * This is thread-safe.
  *
  * __Exception safety:__\n
- * Strong guarantee.
+ * No-throw guarantee.
  *
  * __Thread cancellation safety:__\n
- * Safe, no cancellation point included.
+ * No cancellation point included.
  *
- * ---
+ * - - -
  *
  * \param code
  * @ref StopReasons value for which a textual description shall be retrieved.
+ *
  * \return
- * Pointer to a null-terminated c-string with a textual description of the @ref StopReasons value
- * specified by parameter 'code'.
+ * Pointer to a null-terminated c-string with a textual description of the @ref StopReasons value specified by @p code.
  */
-char const * TriggeredThreadedCyclicExec::StopReasons2Description(StopReasons const code)
+char const * TriggeredThreadedCyclicExec::StopReasons2Description(StopReasons const code) noexcept
 {
   switch (code)
   {
@@ -185,18 +193,17 @@ char const * TriggeredThreadedCyclicExec::StopReasons2Description(StopReasons co
     case StopReasons::triggerTimeout:  return "Trigger timeout";
     case StopReasons::pllLossOfLock:   return "PLL loss of lock";
     case StopReasons::sampleRetFalse:  return "Sample() returned false";
-    default:
-      throw std::invalid_argument("TriggeredThreadedCyclicExec::StopReasons2String: unknown code");
   }
+
+  PANIC();
 }
 
 /**
  * \brief Starts the object's thread. This does not yet start sampling.
  *
- * The thread must not yet be running.\n
- * After calling this, sampling can be enabled by calling @ref RequestStartSampling() if not yet done.
+ * \pre   The thread must not yet be running.
  *
- * ---
+ * - - -
  *
  * __Thread safety:__\n
  * This is thread-safe.
@@ -205,17 +212,19 @@ char const * TriggeredThreadedCyclicExec::StopReasons2Description(StopReasons co
  * Strong guarantee.
  *
  * __Thread cancellation safety:__\n
- * Deferred cancellation is safe.
+ * Strong guarantee.
  *
- * ---
+ * - - -
  *
  * \param schedPolicy
  * Scheduling policy that shall be used for the new thread. See @ref gpcc::osal::Thread::SchedPolicy for details.
+ *
  * \param priority
  * Priority level: 0 (low) .. 31 (high)\n
  * This is only relevant for the scheduling policies @ref gpcc::osal::Thread::SchedPolicy::Fifo and
  * @ref gpcc::osal::Thread::SchedPolicy::RR. \n
  * _For the other scheduling policies this must be zero._
+ *
  * \param stackSize
  * Size of the stack of the new thread in byte.\n
  * _This must be a multiple of `gpcc::osal::Thread::GetStackAlign()`._\n
@@ -230,17 +239,11 @@ void TriggeredThreadedCyclicExec::StartThread(osal::Thread::SchedPolicy const sc
 }
 
 /**
- * \brief Cancels the object's thread and waits until the thread has terminated and joined.
+ * \brief Stops the object's thread and waits until the thread has terminated and joined.
  *
- * Note:\n
- * Sampling is not stopped gracefully. Instead the object's thread is cancelled using deferred cancellation.
+ * \pre   The thread is running.
  *
- * The thread must not yet be stopped.
- *
- * This will block until the object's thread has terminated and has been cleaned-up (joined).\n
- * After this has returned, it is safe to restart the object's thread via @ref StartThread() or to destroy the object.
- *
- * ---
+ * - - -
  *
  * __Thread safety:__\n
  * This is thread-safe.
@@ -253,40 +256,36 @@ void TriggeredThreadedCyclicExec::StartThread(osal::Thread::SchedPolicy const sc
  */
 void TriggeredThreadedCyclicExec::StopThread(void) noexcept
 {
-  try
-  {
-    thread_.Cancel();
-    (void)thread_.Join();
-  }
-  catch (...)
-  {
-    PANIC();
-  }
+  thread_.Cancel();
+  (void)thread_.Join();
 }
 
 /**
  * \brief Requests start of sampling.
  *
- * The current state must be @ref States::stopped and there must be no pending start or stop request.\n
- * It is not mandatory, that the object's thread is running.
+ * It is not mandatory, that the object's thread is running. The thread may be started after calling this.
  *
- * ---
+ * \pre   The current state is @ref States::stopped.
+ *
+ * \pre   There is no pending start or stop request.
+ *
+ * - - -
  *
  * __Thread safety:__\n
  * This is thread-safe.\n
- * This may even be called in the context of the object's own thread.
+ * This may be called in the context of the object's own thread.
  *
  * __Exception safety:__\n
  * Strong guarantee.
  *
  * __Thread cancellation safety:__\n
- * Deferred cancellation is safe.
+ * No cancellation point included.
  *
- * ---
+ * - - -
  *
  * \param startDelay
  * Number of extra cycles the @ref TriggeredThreadedCyclicExec instance shall remain in state @ref States::starting
- * before moving to @ref States::waitLock. If this is zero, then one cycle is spend in state @ref States::starting.
+ * before switching to @ref States::waitLock. If this is zero, then one cycle is spend in state @ref States::starting.
  */
 void TriggeredThreadedCyclicExec::RequestStartSampling(uint8_t const startDelay)
 {
@@ -295,7 +294,7 @@ void TriggeredThreadedCyclicExec::RequestStartSampling(uint8_t const startDelay)
   if (state_ != States::stopped)
     throw std::logic_error("TriggeredThreadedCyclicExec::RequestStartSampling: Current state must be \"Stopped\"");
 
-  if ((asyncReqFlags_ & (static_cast<uint8_t>(AsyncReqFlags::start) | static_cast<uint8_t>(AsyncReqFlags::stop))) != 0)
+  if ((asyncReqFlags_ & (static_cast<uint8_t>(AsyncReqFlags::start) | static_cast<uint8_t>(AsyncReqFlags::stop))) != 0U)
     throw std::logic_error("TriggeredThreadedCyclicExec::RequestStartSampling: Start/Stop request already pending");
 
   asyncReqFlags_ |= static_cast<uint8_t>(AsyncReqFlags::start);
@@ -305,33 +304,36 @@ void TriggeredThreadedCyclicExec::RequestStartSampling(uint8_t const startDelay)
 /**
  * \brief Requests stop of sampling and removes a potential pending start request.
  *
- * There must be no pending stop request. Any pending start request is canceled.
+ * \pre   There must be no pending stop request.
  *
- * ---
+ * - - -
  *
  * __Thread safety:__\n
  * This is thread-safe.\n
- * This may even be called in the context of the object's own thread.
+ * This may be called in the context of the object's own thread.
  *
  * __Exception safety:__\n
  * Strong guarantee.
  *
  * __Thread cancellation safety:__\n
- * Deferred cancellation is safe.
+ * No cancellation point included.
  */
 void TriggeredThreadedCyclicExec::RequestStopSampling(void)
 {
   osal::MutexLocker mutexLocker(mutex_);
 
-  if ((asyncReqFlags_ & static_cast<uint8_t>(AsyncReqFlags::stop)) != 0)
+  if ((asyncReqFlags_ & static_cast<uint8_t>(AsyncReqFlags::stop)) != 0U)
     throw std::logic_error("TriggeredThreadedCyclicExec::RequestStopSampling: Stop request already pending");
 
   // set stop request flag and clear a potential start request flag
-  asyncReqFlags_ = (asyncReqFlags_ | static_cast<uint8_t>(AsyncReqFlags::stop)) & static_cast<uint8_t>(~static_cast<uint8_t>(AsyncReqFlags::start));
+  asyncReqFlags_ =   (asyncReqFlags_ | static_cast<uint8_t>(AsyncReqFlags::stop))
+                   & static_cast<uint8_t>(~static_cast<uint8_t>(AsyncReqFlags::start));
 }
 
 /**
  * \brief Retrieves the current state of the @ref TriggeredThreadedCyclicExec instance.
+ *
+ * - - -
  *
  * __Thread safety:__\n
  * This is thread-safe.
@@ -340,9 +342,9 @@ void TriggeredThreadedCyclicExec::RequestStopSampling(void)
  * Strong guarantee.
  *
  * __Thread cancellation safety:__\n
- * Deferred cancellation is safe.
+ * No cancellation point included.
  *
- * ---
+ * - - -
  *
  * \return
  * Current state of the @ref TriggeredThreadedCyclicExec instance.
@@ -356,6 +358,8 @@ TriggeredThreadedCyclicExec::States TriggeredThreadedCyclicExec::GetCurrentState
 /**
  * \brief Entry function for the object's thread.
  *
+ * - - -
+ *
  * __Thread safety:__\n
  * Not applicable. Program logic ensures that there can only be one thread at any time.
  *
@@ -363,9 +367,9 @@ TriggeredThreadedCyclicExec::States TriggeredThreadedCyclicExec::GetCurrentState
  * No-throw guarantee.
  *
  * __Thread cancellation safety:__\n
- * Deferred cancellation is safe.
+ * Strong guarantee.
  *
- * ---
+ * - - -
  *
  * \return
  * Always nullptr.

--- a/src/execution/cyclic/TriggeredThreadedCyclicExec.cpp
+++ b/src/execution/cyclic/TriggeredThreadedCyclicExec.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011 Daniel Jerolm
+    Copyright (C) 2011, 2025 Daniel Jerolm
 */
 
 #include <gpcc/execution/cyclic/TriggeredThreadedCyclicExec.hpp>
@@ -384,8 +384,8 @@ void* TriggeredThreadedCyclicExec::InternalThreadEntry(void)
     {
       // wait for trigger
       stdif::IIRQ2ThreadWakeup::Result const result = trigger.WaitWithTimeout(timeout);
-      bool const overrun = (result == stdif::IIRQ2ThreadWakeup::Result::AlreadySignalled);
-      bool const timeout = (result == stdif::IIRQ2ThreadWakeup::Result::Timeout);
+      bool const result_overrun = (result == stdif::IIRQ2ThreadWakeup::Result::AlreadySignalled);
+      bool const result_timeout = (result == stdif::IIRQ2ThreadWakeup::Result::Timeout);
 
       mutexLocker.Relock();
 
@@ -441,7 +441,7 @@ void* TriggeredThreadedCyclicExec::InternalThreadEntry(void)
 
         case States::waitLock:
         {
-          if (timeout)
+          if (result_timeout)
           {
             state = States::stopped;
             mutexLocker.Unlock();
@@ -470,7 +470,7 @@ void* TriggeredThreadedCyclicExec::InternalThreadEntry(void)
 
         case States::running:
         {
-          if (timeout)
+          if (result_timeout)
           {
             state = States::stopped;
             mutexLocker.Unlock();
@@ -496,7 +496,7 @@ void* TriggeredThreadedCyclicExec::InternalThreadEntry(void)
           {
             mutexLocker.Unlock();
 
-            if (!Sample(overrun))
+            if (!Sample(result_overrun))
             {
               mutexLocker.Relock();
               state = States::stopped;

--- a/src/execution/cyclic/TriggeredThreadedCyclicExec.cpp
+++ b/src/execution/cyclic/TriggeredThreadedCyclicExec.cpp
@@ -40,14 +40,14 @@ namespace cyclic {
  * _No copy is generated._\n
  * _The referenced string must not change during lifetime of the TriggeredThreadedCyclicExec object._\n
  * _nullptr is not allowed._
- * \param _trigger
+ * \param trigger
  * Reference to an [IIRQ2ThreadWakeup](@ref gpcc::stdif::IIRQ2ThreadWakeup) subclass instance that shall be
  * used to deliver the cyclic trigger.
- * \param _timeout
+ * \param timeout
  * Reference to a [TimeSpan](@ref gpcc::time::TimeSpan) instance providing the timeout for monitoring the cyclic
  * trigger. This should be approximately the expected period plus a reasonable safety-margin.\n
  * _A copy is generated._
- * \param _isPllLockedFunc
+ * \param isPllLockedFunc
  * Functor to a function/method that shall be used to retrieve if the PLL driving `_trigger` is in the locked
  * state or not.\n
  * If no PLL is used to drive `_trigger`, or if the lock state shall not be monitored, then no function/method
@@ -55,17 +55,17 @@ namespace cyclic {
  * _A copy is generated._
  */
 TriggeredThreadedCyclicExec::TriggeredThreadedCyclicExec(char const * const pThreadName,
-                                                         stdif::IIRQ2ThreadWakeup & _trigger,
-                                                         time::TimeSpan const & _timeout,
-                                                         tIsPllLocked const & _isPllLockedFunc)
-: trigger(_trigger)
-, timeout(_timeout)
-, isPllLockedFunc(_isPllLockedFunc)
-, thread(pThreadName)
-, mutex()
-, asyncReqFlags(static_cast<uint8_t>(AsyncReqFlags::none))
-, state(States::stopped)
-, startDelayCnt(0)
+                                                         stdif::IIRQ2ThreadWakeup & trigger,
+                                                         time::TimeSpan const & timeout,
+                                                         tIsPllLocked const & isPllLockedFunc)
+: trigger_(trigger)
+, timeout_(timeout)
+, isPllLockedFunc_(isPllLockedFunc)
+, thread_(pThreadName)
+, mutex_()
+, asyncReqFlags_(static_cast<uint8_t>(AsyncReqFlags::none))
+, state_(States::stopped)
+, startDelayCnt_(0)
 {
 }
 
@@ -86,8 +86,8 @@ TriggeredThreadedCyclicExec::TriggeredThreadedCyclicExec(char const * const pThr
  */
 TriggeredThreadedCyclicExec::~TriggeredThreadedCyclicExec(void)
 {
-  gpcc::osal::MutexLocker mutexLocker(mutex);
-  if (state != States::stopped)
+  gpcc::osal::MutexLocker mutexLocker(mutex_);
+  if (state_ != States::stopped)
     osal::Panic("TriggeredThreadedCyclicExec::~TriggeredThreadedCyclicExec: Still running");
 }
 
@@ -226,7 +226,7 @@ void TriggeredThreadedCyclicExec::StartThread(osal::Thread::SchedPolicy const sc
                                               osal::Thread::priority_t const priority,
                                               size_t const stackSize)
 {
-  thread.Start(std::bind(&TriggeredThreadedCyclicExec::InternalThreadEntry, this), schedPolicy, priority, stackSize);
+  thread_.Start(std::bind(&TriggeredThreadedCyclicExec::InternalThreadEntry, this), schedPolicy, priority, stackSize);
 }
 
 /**
@@ -255,8 +255,8 @@ void TriggeredThreadedCyclicExec::StopThread(void) noexcept
 {
   try
   {
-    thread.Cancel();
-    (void)thread.Join();
+    thread_.Cancel();
+    (void)thread_.Join();
   }
   catch (...)
   {
@@ -290,16 +290,16 @@ void TriggeredThreadedCyclicExec::StopThread(void) noexcept
  */
 void TriggeredThreadedCyclicExec::RequestStartSampling(uint8_t const startDelay)
 {
-  osal::MutexLocker mutexLocker(mutex);
+  osal::MutexLocker mutexLocker(mutex_);
 
-  if (state != States::stopped)
+  if (state_ != States::stopped)
     throw std::logic_error("TriggeredThreadedCyclicExec::RequestStartSampling: Current state must be \"Stopped\"");
 
-  if ((asyncReqFlags & (static_cast<uint8_t>(AsyncReqFlags::start) | static_cast<uint8_t>(AsyncReqFlags::stop))) != 0)
+  if ((asyncReqFlags_ & (static_cast<uint8_t>(AsyncReqFlags::start) | static_cast<uint8_t>(AsyncReqFlags::stop))) != 0)
     throw std::logic_error("TriggeredThreadedCyclicExec::RequestStartSampling: Start/Stop request already pending");
 
-  asyncReqFlags |= static_cast<uint8_t>(AsyncReqFlags::start);
-  startDelayCnt = startDelay;
+  asyncReqFlags_ |= static_cast<uint8_t>(AsyncReqFlags::start);
+  startDelayCnt_ = startDelay;
 }
 
 /**
@@ -321,13 +321,13 @@ void TriggeredThreadedCyclicExec::RequestStartSampling(uint8_t const startDelay)
  */
 void TriggeredThreadedCyclicExec::RequestStopSampling(void)
 {
-  osal::MutexLocker mutexLocker(mutex);
+  osal::MutexLocker mutexLocker(mutex_);
 
-  if ((asyncReqFlags & static_cast<uint8_t>(AsyncReqFlags::stop)) != 0)
+  if ((asyncReqFlags_ & static_cast<uint8_t>(AsyncReqFlags::stop)) != 0)
     throw std::logic_error("TriggeredThreadedCyclicExec::RequestStopSampling: Stop request already pending");
 
   // set stop request flag and clear a potential start request flag
-  asyncReqFlags = (asyncReqFlags | static_cast<uint8_t>(AsyncReqFlags::stop)) & static_cast<uint8_t>(~static_cast<uint8_t>(AsyncReqFlags::start));
+  asyncReqFlags_ = (asyncReqFlags_ | static_cast<uint8_t>(AsyncReqFlags::stop)) & static_cast<uint8_t>(~static_cast<uint8_t>(AsyncReqFlags::start));
 }
 
 /**
@@ -349,8 +349,8 @@ void TriggeredThreadedCyclicExec::RequestStopSampling(void)
  */
 TriggeredThreadedCyclicExec::States TriggeredThreadedCyclicExec::GetCurrentState(void) const
 {
-  osal::MutexLocker mutexLocker(mutex);
-  return state;
+  osal::MutexLocker mutexLocker(mutex_);
+  return state_;
 }
 
 /**
@@ -375,34 +375,34 @@ void* TriggeredThreadedCyclicExec::InternalThreadEntry(void)
   try
   {
     // always start in state stopped
-    osal::AdvancedMutexLocker mutexLocker(mutex);
-    state = States::stopped;
+    osal::AdvancedMutexLocker mutexLocker(mutex_);
+    state_ = States::stopped;
     mutexLocker.Unlock();
 
     // loop until thread cancellation is requested
-    while (!thread.IsCancellationPending())
+    while (!thread_.IsCancellationPending())
     {
       // wait for trigger
-      stdif::IIRQ2ThreadWakeup::Result const result = trigger.WaitWithTimeout(timeout);
+      stdif::IIRQ2ThreadWakeup::Result const result = trigger_.WaitWithTimeout(timeout_);
       bool const result_overrun = (result == stdif::IIRQ2ThreadWakeup::Result::AlreadySignalled);
       bool const result_timeout = (result == stdif::IIRQ2ThreadWakeup::Result::Timeout);
 
       mutexLocker.Relock();
 
-      switch (state)
+      switch (state_)
       {
         case States::stopped:
         {
-          if ((asyncReqFlags & static_cast<uint8_t>(AsyncReqFlags::stop)) != 0)
+          if ((asyncReqFlags_ & static_cast<uint8_t>(AsyncReqFlags::stop)) != 0)
           {
-            asyncReqFlags &= static_cast<uint8_t>(~static_cast<uint8_t>(AsyncReqFlags::stop));
+            asyncReqFlags_ &= static_cast<uint8_t>(~static_cast<uint8_t>(AsyncReqFlags::stop));
             mutexLocker.Unlock();
             OnStateChange(States::stopped, StopReasons::reqStopSampling);
           }
-          else if ((asyncReqFlags & static_cast<uint8_t>(AsyncReqFlags::start)) != 0)
+          else if ((asyncReqFlags_ & static_cast<uint8_t>(AsyncReqFlags::start)) != 0)
           {
-            asyncReqFlags &= static_cast<uint8_t>(~static_cast<uint8_t>(AsyncReqFlags::start));
-            state = States::starting;
+            asyncReqFlags_ &= static_cast<uint8_t>(~static_cast<uint8_t>(AsyncReqFlags::start));
+            state_ = States::starting;
             mutexLocker.Unlock();
             OnStateChange(States::starting, StopReasons::none);
           }
@@ -415,24 +415,24 @@ void* TriggeredThreadedCyclicExec::InternalThreadEntry(void)
 
         case States::starting:
         {
-          if ((asyncReqFlags & static_cast<uint8_t>(AsyncReqFlags::stop)) != 0)
+          if ((asyncReqFlags_ & static_cast<uint8_t>(AsyncReqFlags::stop)) != 0)
           {
-            asyncReqFlags &= static_cast<uint8_t>(~static_cast<uint8_t>(AsyncReqFlags::stop));
-            state = States::stopped;
+            asyncReqFlags_ &= static_cast<uint8_t>(~static_cast<uint8_t>(AsyncReqFlags::stop));
+            state_ = States::stopped;
             mutexLocker.Unlock();
             OnStateChange(States::stopped, StopReasons::reqStopSampling);
           }
           else
           {
-            if (startDelayCnt == 0)
+            if (startDelayCnt_ == 0)
             {
-              state = States::waitLock;
+              state_ = States::waitLock;
               mutexLocker.Unlock();
               OnStateChange(States::waitLock, StopReasons::none);
             }
             else
             {
-              startDelayCnt--;
+              startDelayCnt_--;
               mutexLocker.Unlock();
             }
           }
@@ -443,20 +443,20 @@ void* TriggeredThreadedCyclicExec::InternalThreadEntry(void)
         {
           if (result_timeout)
           {
-            state = States::stopped;
+            state_ = States::stopped;
             mutexLocker.Unlock();
             OnStateChange(States::stopped, StopReasons::triggerTimeout);
           }
-          else if ((asyncReqFlags & static_cast<uint8_t>(AsyncReqFlags::stop)) != 0)
+          else if ((asyncReqFlags_ & static_cast<uint8_t>(AsyncReqFlags::stop)) != 0)
           {
-            asyncReqFlags &= static_cast<uint8_t>(~static_cast<uint8_t>(AsyncReqFlags::stop));
-            state = States::stopped;
+            asyncReqFlags_ &= static_cast<uint8_t>(~static_cast<uint8_t>(AsyncReqFlags::stop));
+            state_ = States::stopped;
             mutexLocker.Unlock();
             OnStateChange(States::stopped, StopReasons::reqStopSampling);
           }
-          else if ((!isPllLockedFunc) || (isPllLockedFunc()))
+          else if ((!isPllLockedFunc_) || (isPllLockedFunc_()))
           {
-            state = States::running;
+            state_ = States::running;
             mutexLocker.Unlock();
             OnStateChange(States::running, StopReasons::none);
             OnStart();
@@ -472,22 +472,22 @@ void* TriggeredThreadedCyclicExec::InternalThreadEntry(void)
         {
           if (result_timeout)
           {
-            state = States::stopped;
+            state_ = States::stopped;
             mutexLocker.Unlock();
             OnStop();
             OnStateChange(States::stopped, StopReasons::triggerTimeout);
           }
-          else if ((isPllLockedFunc) && (!isPllLockedFunc()))
+          else if ((isPllLockedFunc_) && (!isPllLockedFunc_()))
           {
-            state = States::stopped;
+            state_ = States::stopped;
             mutexLocker.Unlock();
             OnStop();
             OnStateChange(States::stopped, StopReasons::pllLossOfLock);
           }
-          else if ((asyncReqFlags & static_cast<uint8_t>(AsyncReqFlags::stop)) != 0)
+          else if ((asyncReqFlags_ & static_cast<uint8_t>(AsyncReqFlags::stop)) != 0)
           {
-            asyncReqFlags &= static_cast<uint8_t>(~static_cast<uint8_t>(AsyncReqFlags::stop));
-            state = States::stopped;
+            asyncReqFlags_ &= static_cast<uint8_t>(~static_cast<uint8_t>(AsyncReqFlags::stop));
+            state_ = States::stopped;
             mutexLocker.Unlock();
             OnStop();
             OnStateChange(States::stopped, StopReasons::reqStopSampling);
@@ -499,7 +499,7 @@ void* TriggeredThreadedCyclicExec::InternalThreadEntry(void)
             if (!Sample(result_overrun))
             {
               mutexLocker.Relock();
-              state = States::stopped;
+              state_ = States::stopped;
               mutexLocker.Unlock();
               OnStop();
               OnStateChange(States::stopped, StopReasons::sampleRetFalse);
@@ -507,10 +507,10 @@ void* TriggeredThreadedCyclicExec::InternalThreadEntry(void)
           }
           break;
         }
-      } // switch (state)
+      } // switch (state_)
 
       Cyclic();
-    } // while (!thread.IsCancellationPending())
+    } // while (!thread_.IsCancellationPending())
   }
   catch (std::exception const & e)
   {

--- a/src/file_systems/linux_fs/internal/tools.cpp
+++ b/src/file_systems/linux_fs/internal/tools.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011 Daniel Jerolm
+    Copyright (C) 2011, 2025 Daniel Jerolm
 */
 
 #if defined(OS_LINUX_ARM) || defined(OS_LINUX_ARM_TFC) || defined(OS_LINUX_X64) || defined(OS_LINUX_X64_TFC) || defined(__DOXYGEN__)
@@ -681,9 +681,9 @@ bool CheckFileName(std::string const & name, bool const acceptPath, bool const c
   else
   {
     // check all directory names and the file name for portability
-    for (auto const & name: names)
+    for (auto const & n: names)
     {
-      if (!CheckFileOrDirNameElement(name))
+      if (!CheckFileOrDirNameElement(n))
         return false;
     }
   }
@@ -782,9 +782,9 @@ bool CheckDirectoryName(std::string const & name, bool const checkDirectoryOnly)
   else
   {
     // check all directory names for portability
-    for (auto const & name: names)
+    for (auto const & n: names)
     {
-      if (!CheckFileOrDirNameElement(name))
+      if (!CheckFileOrDirNameElement(n))
         return false;
     }
   }

--- a/src/string/StringComposer.cpp
+++ b/src/string/StringComposer.cpp
@@ -1016,12 +1016,16 @@ void StringComposer::PrintToBuffer(char* const buffer, size_t const bufferSize, 
   char fmt[maxFmtStrBufSize];
   int status;
 
+  // fmt is generated. Don't complain.
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wformat-nonliteral"
+
   if (std::is_same<T, float>::value == false)
   {
-  if (!SetupFormatString(fmt, type))
-    status = snprintf(buffer, bufferSize, fmt, width, value);
-  else
-    status = snprintf(buffer, bufferSize, fmt, width, prec_, value);
+    if (!SetupFormatString(fmt, type))
+      status = snprintf(buffer, bufferSize, fmt, width, value);
+    else
+      status = snprintf(buffer, bufferSize, fmt, width, prec_, value);
   }
   else
   {
@@ -1032,6 +1036,8 @@ void StringComposer::PrintToBuffer(char* const buffer, size_t const bufferSize, 
     else
       status = snprintf(buffer, bufferSize, fmt, width, prec_, static_cast<double>(value));
   }
+
+  #pragma GCC diagnostic pop
 
   if (status < 0)
     throw std::logic_error("snprintf failed");

--- a/src/string/StringComposer.cpp
+++ b/src/string/StringComposer.cpp
@@ -5,12 +5,13 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2024 Daniel Jerolm
+    Copyright (C) 2024, 2025 Daniel Jerolm
 */
 
 #include <gpcc/string/StringComposer.hpp>
 #include <gpcc/osal/Panic.hpp>
 #include <stdexcept>
+#include <type_traits>
 #include <cstdio>
 #include <cstring>
 
@@ -1014,10 +1015,23 @@ void StringComposer::PrintToBuffer(char* const buffer, size_t const bufferSize, 
 
   char fmt[maxFmtStrBufSize];
   int status;
+
+  if (std::is_same<T, float>::value == false)
+  {
   if (!SetupFormatString(fmt, type))
     status = snprintf(buffer, bufferSize, fmt, width, value);
   else
     status = snprintf(buffer, bufferSize, fmt, width, prec_, value);
+  }
+  else
+  {
+    // float is implicitly promoted to double when passed to *printf().
+    // We make the cast explicit to prevent findings from -Wdouble-promotion.
+    if (!SetupFormatString(fmt, type))
+      status = snprintf(buffer, bufferSize, fmt, width, static_cast<double>(value));
+    else
+      status = snprintf(buffer, bufferSize, fmt, width, prec_, static_cast<double>(value));
+  }
 
   if (status < 0)
     throw std::logic_error("snprintf failed");

--- a/testcases/callback/TestMultiCallback.cpp
+++ b/testcases/callback/TestMultiCallback.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011 Daniel Jerolm
+    Copyright (C) 2011, 2025 Daniel Jerolm
 */
 
 #include <gpcc/callback/MultiCallback.hpp>
@@ -240,9 +240,7 @@ TEST_F(gpcc_callback_MultiCallback_TestsF, Unregister_All)
 
   uut.Notify();
 
-  uint8_t const expected[] = { };
-
-  ASSERT_TRUE(Trace_Check(0, expected));
+  ASSERT_TRUE(Trace_Check(0, nullptr));
 }
 TEST_F(gpcc_callback_MultiCallback_TestsF, DifferentThreads)
 {

--- a/testcases/callback/TestMultiCallbackSM.cpp
+++ b/testcases/callback/TestMultiCallbackSM.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011 Daniel Jerolm
+    Copyright (C) 2011, 2025 Daniel Jerolm
 */
 
 #include <gpcc/callback/MultiCallbackSM.hpp>
@@ -244,9 +244,7 @@ TEST_F(gpcc_callback_MultiCallbackSM_TestsF, Unregister_All)
 
   uut.Notify();
 
-  uint8_t const expected[] = { };
-
-  ASSERT_TRUE(Trace_Check(0, expected));
+  ASSERT_TRUE(Trace_Check(0, nullptr));
 }
 TEST_F(gpcc_callback_MultiCallbackSM_TestsF, DifferentThreads)
 {

--- a/testcases/callback/TestMultiCallbackSM_OneParam.cpp
+++ b/testcases/callback/TestMultiCallbackSM_OneParam.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011 Daniel Jerolm
+    Copyright (C) 2011, 2025 Daniel Jerolm
 */
 
 #include <gpcc/callback/MultiCallbackSM.hpp>
@@ -243,9 +243,7 @@ TEST_F(gpcc_callback_MultiCallbackSMOneParam_TestsF, Unregister_All)
 
   uut.Notify(65);
 
-  uint8_t const expected[] = { };
-
-  ASSERT_TRUE(Trace_Check(0, expected));
+  ASSERT_TRUE(Trace_Check(0, nullptr));
 }
 TEST_F(gpcc_callback_MultiCallbackSMOneParam_TestsF, DifferentThreads)
 {

--- a/testcases/callback/TestMultiCallback_OneParam.cpp
+++ b/testcases/callback/TestMultiCallback_OneParam.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011 Daniel Jerolm
+    Copyright (C) 2011, 2025 Daniel Jerolm
 */
 
 #include <gpcc/callback/MultiCallback.hpp>
@@ -239,9 +239,7 @@ TEST_F(gpcc_callback_MultiCallbackOneParam_TestsF, Unregister_All)
 
   uut.Notify(9);
 
-  uint8_t const expected[] = { };
-
-  ASSERT_TRUE(Trace_Check(0, expected));
+  ASSERT_TRUE(Trace_Check(0, nullptr));
 }
 TEST_F(gpcc_callback_MultiCallbackOneParam_TestsF, DifferentThreads)
 {

--- a/testcases/compiler/TestCompilerDefs.cpp
+++ b/testcases/compiler/TestCompilerDefs.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011 Daniel Jerolm
+    Copyright (C) 2011, 2025 Daniel Jerolm
 */
 
 #include <gpcc/compiler/definitions.hpp>
@@ -58,14 +58,14 @@ TEST(GPCC_Compiler_CompilerDefs_Tests, Endian)
 
 TEST(GPCC_Compiler_CompilerDefs_Tests, PacketTypedefStruct1)
 {
-  typedef PACKED1 struct packetStruct
+  PACKED1 struct PacketStruct
   {
     int8_t i8;
     int16_t i16;
     int32_t i32;
-  } PACKED2 packetStruct;
+  } PACKED2;
 
-  packetStruct uut;
+  PacketStruct uut;
 
   uint8_t const * const pBase = reinterpret_cast<uint8_t const *>(&uut);
 
@@ -81,9 +81,9 @@ TEST(GPCC_Compiler_CompilerDefs_Tests, PacketTypedefStruct2)
     int8_t i8;
     int16_t i16;
     int32_t i32;
-  } PACKED2 packetStruct;
+  } PACKED2 tPacketStruct;
 
-  packetStruct uut;
+  tPacketStruct uut;
 
   uint8_t const * const pBase = reinterpret_cast<uint8_t const *>(&uut);
 

--- a/testcases/cood/Test_data_types.cpp
+++ b/testcases/cood/Test_data_types.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2018 Daniel Jerolm
+    Copyright (C) 2018, 2025 Daniel Jerolm
 */
 
 #include <gpcc/cood/data_types.hpp>
@@ -823,13 +823,13 @@ TEST(gpcc_cood_data_types_Tests, StringToCANOpenEncodedData_REAL32)
   float f;
 
   f = msr.Read_float();
-  f = 0.55 - f;
+  f = 0.55f - f;
   if (f < 0)
     f = -f;
   EXPECT_LE(f, 0.01);
 
   f = msr.Read_float();
-  f = 3E15 - f;
+  f = 3E15f - f;
   if (f < 0)
     f = -f;
   EXPECT_LE(f, 3E8);

--- a/testcases/cood/remote_access/infrastructure/TestMultiplexer.cpp
+++ b/testcases/cood/remote_access/infrastructure/TestMultiplexer.cpp
@@ -698,9 +698,9 @@ TEST_F(gpcc_cood_Multiplexer_DeathTestsF, Mux_CallToRODANwhileServerOff)
 TEST_F(gpcc_cood_Multiplexer_TestsF, CreatePort_WhileNotConnected)
 {
   std::vector<std::shared_ptr<MultiplexerPort>> ports;
-  ports.reserve(Multiplexer::maxNbOfPorts_);
+  ports.reserve(Multiplexer::maxNbOfPorts);
 
-  for (size_t i = 0U; i < Multiplexer::maxNbOfPorts_; ++i)
+  for (size_t i = 0U; i < Multiplexer::maxNbOfPorts; ++i)
   {
     ASSERT_NO_THROW(ports.emplace_back(spUUT->CreatePort())) << "Could not create the expected number of ports!";
     ASSERT_TRUE(ports.back() != nullptr);
@@ -722,9 +722,9 @@ TEST_F(gpcc_cood_Multiplexer_TestsF, CreatePort_WhileConnected_ServerOff)
 
   // create ports
   std::vector<std::shared_ptr<MultiplexerPort>> ports;
-  ports.reserve(Multiplexer::maxNbOfPorts_);
+  ports.reserve(Multiplexer::maxNbOfPorts);
 
-  for (size_t i = 0U; i < Multiplexer::maxNbOfPorts_; ++i)
+  for (size_t i = 0U; i < Multiplexer::maxNbOfPorts; ++i)
   {
     ASSERT_NO_THROW(ports.emplace_back(spUUT->CreatePort())) << "Could not create the expected number of ports!";
     ASSERT_TRUE(ports.back() != nullptr);
@@ -750,9 +750,9 @@ TEST_F(gpcc_cood_Multiplexer_TestsF, CreatePort_WhileConnected_ServerOn)
 
   // create ports
   std::vector<std::shared_ptr<MultiplexerPort>> ports;
-  ports.reserve(Multiplexer::maxNbOfPorts_);
+  ports.reserve(Multiplexer::maxNbOfPorts);
 
-  for (size_t i = 0U; i < Multiplexer::maxNbOfPorts_; ++i)
+  for (size_t i = 0U; i < Multiplexer::maxNbOfPorts; ++i)
   {
     ASSERT_NO_THROW(ports.emplace_back(spUUT->CreatePort())) << "Could not create the expected number of ports!";
     ASSERT_TRUE(ports.back() != nullptr);

--- a/testcases/cood/remote_access/infrastructure/TestMultiplexer.cpp
+++ b/testcases/cood/remote_access/infrastructure/TestMultiplexer.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2021 Daniel Jerolm
+    Copyright (C) 2021, 2025 Daniel Jerolm
 */
 
 #include <gpcc/cood/remote_access/infrastructure/Multiplexer.hpp>
@@ -698,9 +698,9 @@ TEST_F(gpcc_cood_Multiplexer_DeathTestsF, Mux_CallToRODANwhileServerOff)
 TEST_F(gpcc_cood_Multiplexer_TestsF, CreatePort_WhileNotConnected)
 {
   std::vector<std::shared_ptr<MultiplexerPort>> ports;
-  ports.reserve(Multiplexer::maxNbOfPorts);
+  ports.reserve(Multiplexer::maxNbOfPorts_);
 
-  for (size_t i = 0U; i < Multiplexer::maxNbOfPorts; ++i)
+  for (size_t i = 0U; i < Multiplexer::maxNbOfPorts_; ++i)
   {
     ASSERT_NO_THROW(ports.emplace_back(spUUT->CreatePort())) << "Could not create the expected number of ports!";
     ASSERT_TRUE(ports.back() != nullptr);
@@ -722,9 +722,9 @@ TEST_F(gpcc_cood_Multiplexer_TestsF, CreatePort_WhileConnected_ServerOff)
 
   // create ports
   std::vector<std::shared_ptr<MultiplexerPort>> ports;
-  ports.reserve(Multiplexer::maxNbOfPorts);
+  ports.reserve(Multiplexer::maxNbOfPorts_);
 
-  for (size_t i = 0U; i < Multiplexer::maxNbOfPorts; ++i)
+  for (size_t i = 0U; i < Multiplexer::maxNbOfPorts_; ++i)
   {
     ASSERT_NO_THROW(ports.emplace_back(spUUT->CreatePort())) << "Could not create the expected number of ports!";
     ASSERT_TRUE(ports.back() != nullptr);
@@ -750,9 +750,9 @@ TEST_F(gpcc_cood_Multiplexer_TestsF, CreatePort_WhileConnected_ServerOn)
 
   // create ports
   std::vector<std::shared_ptr<MultiplexerPort>> ports;
-  ports.reserve(Multiplexer::maxNbOfPorts);
+  ports.reserve(Multiplexer::maxNbOfPorts_);
 
-  for (size_t i = 0U; i < Multiplexer::maxNbOfPorts; ++i)
+  for (size_t i = 0U; i < Multiplexer::maxNbOfPorts_; ++i)
   {
     ASSERT_NO_THROW(ports.emplace_back(spUUT->CreatePort())) << "Could not create the expected number of ports!";
     ASSERT_TRUE(ports.back() != nullptr);

--- a/testcases/execution/async/TestIWorkQueue.hpp
+++ b/testcases/execution/async/TestIWorkQueue.hpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011 Daniel Jerolm
+    Copyright (C) 2011, 2025 Daniel Jerolm
 */
 
 #ifndef TESTIWORKQUEUE_HPP_201701061557
@@ -1827,41 +1827,79 @@ REGISTER_TYPED_TEST_SUITE_P(IWorkQueue_Tests1F,
                             Remove1_stat_TheLastOne,
                             Remove1_stat_Empty); // 41
 
-REGISTER_TYPED_TEST_SUITE_P(IWorkQueue_Tests2F,
-                            Remove1_stat_NoHit,
-                            Remove2_dyn_first,
-                            Remove2_dyn_mid,
-                            Remove2_dyn_last,
-                            Remove2_dyn_nullptr,
-                            Remove2_dyn_fromWQcontext,
-                            Remove2_dyn_TheLastOne,
-                            Remove2_dyn_Empty,
-                            Remove2_dyn_NoHit,
-                            Remove2_stat_first,
-                            Remove2_stat_mid,
-                            Remove2_stat_last,
-                            Remove2_stat_nullptr,
-                            Remove2_stat_fromWQcontext,
-                            Remove2_stat_TheLastOne,
-                            Remove2_stat_Empty,
-                            Remove2_stat_NoHit,
-                            WaitUntilCurrentWorkPackageHasBeenExecuted_nullptr,
 #ifndef SKIP_TFC_BASED_TESTS
-                            WaitUntilCurrentWorkPackageHasBeenExecuted,
-                            WaitUntilCurrentWorkPackageHasBeenExecuted_otherwork,
-                            WaitUntilCurrentWorkPackageHasBeenExecuted_nowait,
+  REGISTER_TYPED_TEST_SUITE_P(IWorkQueue_Tests2F,
+                              Remove1_stat_NoHit,
+                              Remove2_dyn_first,
+                              Remove2_dyn_mid,
+                              Remove2_dyn_last,
+                              Remove2_dyn_nullptr,
+                              Remove2_dyn_fromWQcontext,
+                              Remove2_dyn_TheLastOne,
+                              Remove2_dyn_Empty,
+                              Remove2_dyn_NoHit,
+                              Remove2_stat_first,
+                              Remove2_stat_mid,
+                              Remove2_stat_last,
+                              Remove2_stat_nullptr,
+                              Remove2_stat_fromWQcontext,
+                              Remove2_stat_TheLastOne,
+                              Remove2_stat_Empty,
+                              Remove2_stat_NoHit,
+                              WaitUntilCurrentWorkPackageHasBeenExecuted_nullptr,
+  // #ifndef SKIP_TFC_BASED_TESTS
+                              WaitUntilCurrentWorkPackageHasBeenExecuted,
+                              WaitUntilCurrentWorkPackageHasBeenExecuted_otherwork,
+                              WaitUntilCurrentWorkPackageHasBeenExecuted_nowait,
+  // #endif
+                              WaitUntilCurrentWorkPackageHasBeenExecuted_WQcontext,
+                              IsAnyInQueue_dyn,
+                              IsAnyInQueue_stat,
+  // #ifndef SKIP_TFC_BASED_TESTS
+                              FlushNonDeferredWorkPackages,
+  // #endif
+                              Work_Restart,
+                              Work_Cancel_Restart,
+                              AbortBeforeStart,
+                              AbortTwiceBeforeStart,
+                              WorkPackageThrows); // 30
+#else
+  REGISTER_TYPED_TEST_SUITE_P(IWorkQueue_Tests2F,
+                              Remove1_stat_NoHit,
+                              Remove2_dyn_first,
+                              Remove2_dyn_mid,
+                              Remove2_dyn_last,
+                              Remove2_dyn_nullptr,
+                              Remove2_dyn_fromWQcontext,
+                              Remove2_dyn_TheLastOne,
+                              Remove2_dyn_Empty,
+                              Remove2_dyn_NoHit,
+                              Remove2_stat_first,
+                              Remove2_stat_mid,
+                              Remove2_stat_last,
+                              Remove2_stat_nullptr,
+                              Remove2_stat_fromWQcontext,
+                              Remove2_stat_TheLastOne,
+                              Remove2_stat_Empty,
+                              Remove2_stat_NoHit,
+                              WaitUntilCurrentWorkPackageHasBeenExecuted_nullptr,
+  // #ifndef SKIP_TFC_BASED_TESTS
+  //                          WaitUntilCurrentWorkPackageHasBeenExecuted,
+  //                          WaitUntilCurrentWorkPackageHasBeenExecuted_otherwork,
+  //                          WaitUntilCurrentWorkPackageHasBeenExecuted_nowait,
+  // #endif
+                              WaitUntilCurrentWorkPackageHasBeenExecuted_WQcontext,
+                              IsAnyInQueue_dyn,
+                              IsAnyInQueue_stat,
+  // #ifndef SKIP_TFC_BASED_TESTS
+  //                          FlushNonDeferredWorkPackages,
+  // #endif
+                              Work_Restart,
+                              Work_Cancel_Restart,
+                              AbortBeforeStart,
+                              AbortTwiceBeforeStart,
+                              WorkPackageThrows); // 30
 #endif
-                            WaitUntilCurrentWorkPackageHasBeenExecuted_WQcontext,
-                            IsAnyInQueue_dyn,
-                            IsAnyInQueue_stat,
-#ifndef SKIP_TFC_BASED_TESTS
-                            FlushNonDeferredWorkPackages,
-#endif
-                            Work_Restart,
-                            Work_Cancel_Restart,
-                            AbortBeforeStart,
-                            AbortTwiceBeforeStart,
-                            WorkPackageThrows); // 30
 
 REGISTER_TYPED_TEST_SUITE_P(IWorkQueue_DeathTests1F,
                             EnqueuedStaticWPDestroyed);

--- a/testcases/execution/cyclic/TriggerProvider.cpp
+++ b/testcases/execution/cyclic/TriggerProvider.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011 Daniel Jerolm
+    Copyright (C) 2011, 2025 Daniel Jerolm
 */
 
 #include "TriggerProvider.hpp"
@@ -20,18 +20,18 @@ namespace gpcc_tests {
 namespace execution {
 namespace cyclic {
 
-TriggerProvider::TriggerProvider(gpcc::time::TimeSpan const _expectedWaitWithTimeoutValue,
-                                 uint32_t const _permanentTriggerSleep_ms)
+TriggerProvider::TriggerProvider(gpcc::time::TimeSpan const expectedWaitWithTimeoutValue,
+                                 uint32_t const permanentTriggerSleep_ms)
 : gpcc::stdif::IIRQ2ThreadWakeup()
-, expectedWaitWithTimeoutValue(_expectedWaitWithTimeoutValue)
-, permanentTriggerSleep_ms(_permanentTriggerSleep_ms)
-, mutex()
-, threadInWaitWithTimeout(false)
-, threadInWaitWithTimeoutSetConvar()
-, continueFlag(false)
-, permanentContinue(false)
-, continueFlagSetConvar()
-, desiredReturnValue(gpcc::stdif::IIRQ2ThreadWakeup::Result::OK)
+, expectedWaitWithTimeoutValue_(expectedWaitWithTimeoutValue)
+, permanentTriggerSleep_ms_(permanentTriggerSleep_ms)
+, mutex_()
+, threadInWaitWithTimeout_(false)
+, threadInWaitWithTimeoutSetConvar_()
+, continueFlag_(false)
+, permanentContinue_(false)
+, continueFlagSetConvar_()
+, desiredReturnValue_(gpcc::stdif::IIRQ2ThreadWakeup::Result::OK)
 {
 }
 
@@ -43,35 +43,36 @@ bool TriggerProvider::WaitForThread(uint32_t const timeout_ms)
 
   using namespace gpcc::time;
 
-  gpcc::osal::MutexLocker mutexLocker(mutex);
+  gpcc::osal::MutexLocker mutexLocker(mutex_);
 
   TimePoint const absTimeout = TimePoint::FromSystemClock(gpcc::osal::ConditionVariable::clockID)
                              + TimeSpan::ms(timeout_ms);
-  while ((!threadInWaitWithTimeout) || (continueFlag))
+  while ((!threadInWaitWithTimeout_) || (continueFlag_))
   {
-    if (threadInWaitWithTimeoutSetConvar.TimeLimitedWait(mutex, absTimeout))
+    if (threadInWaitWithTimeoutSetConvar_.TimeLimitedWait(mutex_, absTimeout))
     {
       // timeout
       break;
     }
   }
 
-  return threadInWaitWithTimeout;
+  return threadInWaitWithTimeout_;
 }
-void TriggerProvider::Trigger(gpcc::stdif::IIRQ2ThreadWakeup::Result const _desiredReturnValue, bool const permanent)
-{
-  gpcc::osal::MutexLocker mutexLocker(mutex);
 
-  if (!threadInWaitWithTimeout)
+void TriggerProvider::Trigger(gpcc::stdif::IIRQ2ThreadWakeup::Result const desiredReturnValue, bool const permanent)
+{
+  gpcc::osal::MutexLocker mutexLocker(mutex_);
+
+  if (!threadInWaitWithTimeout_)
     throw std::runtime_error("TriggerProvider::Trigger: No thread inside WaitWithTimeout()");
 
-  if (continueFlag)
+  if (continueFlag_)
     throw std::runtime_error("TriggerProvider::Trigger: Trigger already pending!");
 
-  continueFlag = true;
-  permanentContinue = permanent;
-  desiredReturnValue = _desiredReturnValue;
-  continueFlagSetConvar.Signal();
+  continueFlag_ = true;
+  permanentContinue_ = permanent;
+  desiredReturnValue_ = desiredReturnValue;
+  continueFlagSetConvar_.Signal();
 }
 
 // --> gpcc::stdif::IIRQ2ThreadWakeup
@@ -80,6 +81,7 @@ bool TriggerProvider::SignalFromISR(void) noexcept
   gpcc::osal::Panic("Unexpected call to TriggerProvider::SignalFromISR");
   return false;
 }
+
 bool TriggerProvider::SignalFromThread(void)
 {
   gpcc::osal::Panic("Unexpected call to TriggerProvider::SignalFromThread");
@@ -93,33 +95,34 @@ gpcc::stdif::IIRQ2ThreadWakeup::Result TriggerProvider::Wait(void)
   // never reached, but makes compiler happy
   return gpcc::stdif::IIRQ2ThreadWakeup::Result::OK;
 }
+
 gpcc::stdif::IIRQ2ThreadWakeup::Result TriggerProvider::WaitWithTimeout(gpcc::time::TimeSpan const & timeout)
 {
-  if (timeout != expectedWaitWithTimeoutValue)
+  if (timeout != expectedWaitWithTimeoutValue_)
     gpcc::osal::Panic("TriggerProvider::WaitWithTimeout: UUT passed unexpected timeout value");
 
-  gpcc::osal::MutexLocker mutexLocker(mutex);
+  gpcc::osal::MutexLocker mutexLocker(mutex_);
 
-  if (threadInWaitWithTimeout)
-    gpcc::osal::Panic("TriggerProvider::WaitWithTimeout: threadInWaitWithTimeout already set");
+  if (threadInWaitWithTimeout_)
+    gpcc::osal::Panic("TriggerProvider::WaitWithTimeout: threadInWaitWithTimeout_ already set");
 
   // signal that a thread is within WaitWithTimeout()
-  threadInWaitWithTimeout = true;
-  threadInWaitWithTimeoutSetConvar.Signal();
+  threadInWaitWithTimeout_ = true;
+  threadInWaitWithTimeoutSetConvar_.Signal();
 
-  ON_SCOPE_EXIT() { threadInWaitWithTimeout = false; };
+  ON_SCOPE_EXIT() { threadInWaitWithTimeout_ = false; };
 
   // wait for go
-  while ((!continueFlag) && (!permanentContinue))
-    continueFlagSetConvar.Wait(mutex);
+  while ((!continueFlag_) && (!permanentContinue_))
+    continueFlagSetConvar_.Wait(mutex_);
 
-  continueFlag = false;
+  continueFlag_ = false;
 
-  if (permanentContinue)
-    gpcc::osal::Thread::Sleep_ms(permanentTriggerSleep_ms);
+  if (permanentContinue_)
+    gpcc::osal::Thread::Sleep_ms(permanentTriggerSleep_ms_);
 
   // leave WaitWithTimeout()
-  return desiredReturnValue;
+  return desiredReturnValue_;
 }
 // <-- gpcc::stdif::IIRQ2ThreadWakeup
 

--- a/testcases/execution/cyclic/TriggerProvider.hpp
+++ b/testcases/execution/cyclic/TriggerProvider.hpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011 Daniel Jerolm
+    Copyright (C) 2011, 2025 Daniel Jerolm
 */
 
 #ifndef TRIGGERPROVIDER_HPP_201612302045
@@ -27,8 +27,8 @@ namespace cyclic {
 class TriggerProvider final : public gpcc::stdif::IIRQ2ThreadWakeup
 {
   public:
-    TriggerProvider(gpcc::time::TimeSpan const _expectedWaitWithTimeoutValue,
-                    uint32_t const _permanentTriggerSleep_ms);
+    TriggerProvider(gpcc::time::TimeSpan const expectedWaitWithTimeoutValue,
+                    uint32_t const permanentTriggerSleep_ms);
     TriggerProvider(TriggerProvider const &) = delete;
     TriggerProvider(TriggerProvider &&) = delete;
     ~TriggerProvider(void) = default;
@@ -37,29 +37,29 @@ class TriggerProvider final : public gpcc::stdif::IIRQ2ThreadWakeup
     TriggerProvider& operator=(TriggerProvider &&) = delete;
 
     bool WaitForThread(uint32_t const timeout_ms);
-    void Trigger(gpcc::stdif::IIRQ2ThreadWakeup::Result const _desiredReturnValue, bool const permanent);
+    void Trigger(gpcc::stdif::IIRQ2ThreadWakeup::Result const desiredReturnValue, bool const permanent);
 
   private:
-    // Expected timeout when IIRQ2ThreadWakeup::WaitWithTimeout is invoked.
-    gpcc::time::TimeSpan const expectedWaitWithTimeoutValue;
+    // Expected timeout when IIRQ2ThreadWakeup::WaitWithTimeout() is invoked.
+    gpcc::time::TimeSpan const expectedWaitWithTimeoutValue_;
 
     // Time span slept in continous trigger mode before WaitWithTimeout() returns.
-    uint32_t const permanentTriggerSleep_ms;
+    uint32_t const permanentTriggerSleep_ms_;
 
     // Mutex to make stuff thread-safe.
-    gpcc::osal::Mutex mutex;
+    gpcc::osal::Mutex mutex_;
 
-    // Flag indicating that a thread is inside "WaitWithTimeout" and associated ConVar.
-    bool threadInWaitWithTimeout;
-    gpcc::osal::ConditionVariable threadInWaitWithTimeoutSetConvar;
+    // Flag indicating that a thread is inside "WaitWithTimeout()" and associated ConVar.
+    bool threadInWaitWithTimeout_;
+    gpcc::osal::ConditionVariable threadInWaitWithTimeoutSetConvar_;
 
-    // Flag signaling that the thread in "WaitWithTimeout" shall continue and associated ConVar.
-    bool continueFlag;
-    bool permanentContinue;
-    gpcc::osal::ConditionVariable continueFlagSetConvar;
+    // Flag signaling that the thread in "WaitWithTimeout()" shall continue and associated ConVar.
+    bool continueFlag_;
+    bool permanentContinue_;
+    gpcc::osal::ConditionVariable continueFlagSetConvar_;
 
-    // Desired return value for "WaitWithTimeout".
-    gpcc::stdif::IIRQ2ThreadWakeup::Result desiredReturnValue;
+    // Desired return value for "WaitWithTimeout()".
+    gpcc::stdif::IIRQ2ThreadWakeup::Result desiredReturnValue_;
 
 
     // --> gpcc::stdif::IIRQ2ThreadWakeup

--- a/testcases/execution/cyclic/UUT_TriggeredThreadedCyclicExec.cpp
+++ b/testcases/execution/cyclic/UUT_TriggeredThreadedCyclicExec.cpp
@@ -19,67 +19,67 @@ namespace gpcc_tests {
 namespace execution {
 namespace cyclic {
 
-UUT_TriggeredThreadedCyclicExec::UUT_TriggeredThreadedCyclicExec(Trace & _trace,
-                                                                 gpcc::stdif::IIRQ2ThreadWakeup & _trigger,
+UUT_TriggeredThreadedCyclicExec::UUT_TriggeredThreadedCyclicExec(Trace & trace,
+                                                                 gpcc::stdif::IIRQ2ThreadWakeup & trigger,
                                                                  gpcc::time::TimeSpan const & waitForTriggerTimeout)
-: TriggeredThreadedCyclicExec("UUT", _trigger, waitForTriggerTimeout, std::bind(&UUT_TriggeredThreadedCyclicExec::IsPllRunning, this))
-, trace(_trace)
-, pTTCEStartStopCtrl(nullptr)
-, mutex()
-, sampleRetVal(true)
-, isPllRunningRetVal(true)
+: TriggeredThreadedCyclicExec("UUT", trigger, waitForTriggerTimeout, std::bind(&UUT_TriggeredThreadedCyclicExec::IsPllRunning, this))
+, trace_(trace)
+, pTTCEStartStopCtrl_(nullptr)
+, mutex_()
+, sampleRetVal_(true)
+, isPllRunningRetVal_(true)
 {
 }
 
-void UUT_TriggeredThreadedCyclicExec::SetTTCEStartStopCtrl(TTCEStartStopCtrl* const _pTTCEStartStopCtrl)
+void UUT_TriggeredThreadedCyclicExec::SetTTCEStartStopCtrl(TTCEStartStopCtrl* const pTTCEStartStopCtrl)
 {
-  pTTCEStartStopCtrl = _pTTCEStartStopCtrl;
+  pTTCEStartStopCtrl_ = pTTCEStartStopCtrl;
 }
 
 
 void UUT_TriggeredThreadedCyclicExec::SetSampleRetVal(bool const value)
 {
-  gpcc::osal::MutexLocker mutexLocker(mutex);
-  sampleRetVal = value;
+  gpcc::osal::MutexLocker mutexLocker(mutex_);
+  sampleRetVal_ = value;
 }
 void UUT_TriggeredThreadedCyclicExec::SetIsPllRunningRetVal(bool const value)
 {
-  gpcc::osal::MutexLocker mutexLocker(mutex);
-  isPllRunningRetVal = value;
+  gpcc::osal::MutexLocker mutexLocker(mutex_);
+  isPllRunningRetVal_ = value;
 }
 
 void UUT_TriggeredThreadedCyclicExec::Cyclic(void)
 {
-  trace.Record(Trace::TRACE_CYCLIC);
+  trace_.Record(Trace::TRACE_CYCLIC);
 }
 void UUT_TriggeredThreadedCyclicExec::OnStart(void)
 {
-  trace.Record(Trace::TRACE_ONSTART);
+  trace_.Record(Trace::TRACE_ONSTART);
 }
 void UUT_TriggeredThreadedCyclicExec::OnStop(void)
 {
-  trace.Record(Trace::TRACE_ONSTOP);
+  trace_.Record(Trace::TRACE_ONSTOP);
 }
 bool UUT_TriggeredThreadedCyclicExec::Sample(bool const overrun)
 {
-  trace.Record(Trace::BuildTraceValue_Sample(overrun));
+  trace_.Record(Trace::BuildTraceValue_Sample(overrun));
 
-  gpcc::osal::MutexLocker mutexLocker(mutex);
-  return sampleRetVal;
+  gpcc::osal::MutexLocker mutexLocker(mutex_);
+  return sampleRetVal_;
 }
 void UUT_TriggeredThreadedCyclicExec::OnStateChange(States const newState, StopReasons const stopReason)
 {
-  trace.Record(Trace::BuildTraceValue_OnStateChange(newState, stopReason));
-  if (pTTCEStartStopCtrl)
-    pTTCEStartStopCtrl->OnTTCEStateChange(newState, stopReason);
+  trace_.Record(Trace::BuildTraceValue_OnStateChange(newState, stopReason));
+  if (pTTCEStartStopCtrl_)
+    pTTCEStartStopCtrl_->OnTTCEStateChange(newState, stopReason);
 }
 
 bool UUT_TriggeredThreadedCyclicExec::IsPllRunning(void)
 {
-  trace.Record(Trace::TRACE_ISPLLRUN);
+  trace_.Record(Trace::TRACE_ISPLLRUN);
 
-  gpcc::osal::MutexLocker mutexLocker(mutex);
-  return isPllRunningRetVal;
+  gpcc::osal::MutexLocker mutexLocker(mutex_);
+  return isPllRunningRetVal_;
 }
 
 } // namespace cyclic

--- a/testcases/execution/cyclic/UUT_TriggeredThreadedCyclicExec.cpp
+++ b/testcases/execution/cyclic/UUT_TriggeredThreadedCyclicExec.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011 Daniel Jerolm
+    Copyright (C) 2011, 2025 Daniel Jerolm
 */
 
 #include "UUT_TriggeredThreadedCyclicExec.hpp"
@@ -20,9 +20,9 @@ namespace execution {
 namespace cyclic {
 
 UUT_TriggeredThreadedCyclicExec::UUT_TriggeredThreadedCyclicExec(Trace & _trace,
-                                                                 gpcc::stdif::IIRQ2ThreadWakeup & trigger,
+                                                                 gpcc::stdif::IIRQ2ThreadWakeup & _trigger,
                                                                  gpcc::time::TimeSpan const & waitForTriggerTimeout)
-: TriggeredThreadedCyclicExec("UUT", trigger, waitForTriggerTimeout, std::bind(&UUT_TriggeredThreadedCyclicExec::IsPllRunning, this))
+: TriggeredThreadedCyclicExec("UUT", _trigger, waitForTriggerTimeout, std::bind(&UUT_TriggeredThreadedCyclicExec::IsPllRunning, this))
 , trace(_trace)
 , pTTCEStartStopCtrl(nullptr)
 , mutex()

--- a/testcases/execution/cyclic/UUT_TriggeredThreadedCyclicExec.cpp
+++ b/testcases/execution/cyclic/UUT_TriggeredThreadedCyclicExec.cpp
@@ -16,13 +16,16 @@
 #include <functional>
 
 namespace gpcc_tests {
-namespace execution {
-namespace cyclic {
+namespace execution  {
+namespace cyclic     {
 
 UUT_TriggeredThreadedCyclicExec::UUT_TriggeredThreadedCyclicExec(Trace & trace,
                                                                  gpcc::stdif::IIRQ2ThreadWakeup & trigger,
                                                                  gpcc::time::TimeSpan const & waitForTriggerTimeout)
-: TriggeredThreadedCyclicExec("UUT", trigger, waitForTriggerTimeout, std::bind(&UUT_TriggeredThreadedCyclicExec::IsPllRunning, this))
+: TriggeredThreadedCyclicExec("UUT",
+                              trigger,
+                              waitForTriggerTimeout,
+                              std::bind(&UUT_TriggeredThreadedCyclicExec::IsPllRunning, this))
 , trace_(trace)
 , pTTCEStartStopCtrl_(nullptr)
 , mutex_()
@@ -36,12 +39,12 @@ void UUT_TriggeredThreadedCyclicExec::SetTTCEStartStopCtrl(TTCEStartStopCtrl* co
   pTTCEStartStopCtrl_ = pTTCEStartStopCtrl;
 }
 
-
 void UUT_TriggeredThreadedCyclicExec::SetSampleRetVal(bool const value)
 {
   gpcc::osal::MutexLocker mutexLocker(mutex_);
   sampleRetVal_ = value;
 }
+
 void UUT_TriggeredThreadedCyclicExec::SetIsPllRunningRetVal(bool const value)
 {
   gpcc::osal::MutexLocker mutexLocker(mutex_);
@@ -52,14 +55,17 @@ void UUT_TriggeredThreadedCyclicExec::Cyclic(void)
 {
   trace_.Record(Trace::TRACE_CYCLIC);
 }
+
 void UUT_TriggeredThreadedCyclicExec::OnStart(void)
 {
   trace_.Record(Trace::TRACE_ONSTART);
 }
+
 void UUT_TriggeredThreadedCyclicExec::OnStop(void)
 {
   trace_.Record(Trace::TRACE_ONSTOP);
 }
+
 bool UUT_TriggeredThreadedCyclicExec::Sample(bool const overrun)
 {
   trace_.Record(Trace::BuildTraceValue_Sample(overrun));
@@ -67,6 +73,7 @@ bool UUT_TriggeredThreadedCyclicExec::Sample(bool const overrun)
   gpcc::osal::MutexLocker mutexLocker(mutex_);
   return sampleRetVal_;
 }
+
 void UUT_TriggeredThreadedCyclicExec::OnStateChange(States const newState, StopReasons const stopReason)
 {
   trace_.Record(Trace::BuildTraceValue_OnStateChange(newState, stopReason));

--- a/testcases/execution/cyclic/UUT_TriggeredThreadedCyclicExec.hpp
+++ b/testcases/execution/cyclic/UUT_TriggeredThreadedCyclicExec.hpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011 Daniel Jerolm
+    Copyright (C) 2011, 2025 Daniel Jerolm
 */
 
 #ifndef UUT_TRIGGEREDTHREADEDCYCLICEXEC_HPP_201612302049
@@ -51,7 +51,7 @@ class UUT_TriggeredThreadedCyclicExec final : public TriggeredThreadedCyclicExec
 {
   public:
     UUT_TriggeredThreadedCyclicExec(Trace & _trace,
-                                    gpcc::stdif::IIRQ2ThreadWakeup & trigger,
+                                    gpcc::stdif::IIRQ2ThreadWakeup & _trigger,
                                     gpcc::time::TimeSpan const & waitForTriggerTimeout);
     UUT_TriggeredThreadedCyclicExec(UUT_TriggeredThreadedCyclicExec const &) = delete;
     UUT_TriggeredThreadedCyclicExec(UUT_TriggeredThreadedCyclicExec &&) = delete;

--- a/testcases/execution/cyclic/UUT_TriggeredThreadedCyclicExec.hpp
+++ b/testcases/execution/cyclic/UUT_TriggeredThreadedCyclicExec.hpp
@@ -14,28 +14,25 @@
 #include <gpcc/execution/cyclic/TriggeredThreadedCyclicExec.hpp>
 #include <gpcc/osal/Mutex.hpp>
 
-namespace gpcc
-{
-  namespace execution
-  {
-    namespace cyclic
-    {
-      class TTCEStartStopCtrl;
-    }
-  }
-  namespace stdif
-  {
-    class IIRQ2ThreadWakeup;
-  }
-  namespace time
-  {
-    class TimeSpan;
-  }
-}
+namespace gpcc      {
+namespace execution {
+namespace cyclic    {
+  class TTCEStartStopCtrl;
+}}}
+
+namespace gpcc  {
+namespace stdif {
+  class IIRQ2ThreadWakeup;
+}}
+
+namespace gpcc {
+namespace time {
+  class TimeSpan;
+}}
 
 namespace gpcc_tests {
-namespace execution {
-namespace cyclic {
+namespace execution  {
+namespace cyclic     {
 
 class Trace;
 
@@ -71,8 +68,10 @@ class UUT_TriggeredThreadedCyclicExec final : public TriggeredThreadedCyclicExec
     TTCEStartStopCtrl* pTTCEStartStopCtrl_;
 
     gpcc::osal::Mutex mutex_;
+
     // Return value used when Sample() is called next time. "mutex_" is required.
     bool sampleRetVal_;
+
     // Return value used when IsPllRunning() is called next time. "mutex_" is required.
     bool isPllRunningRetVal_;
 

--- a/testcases/execution/cyclic/UUT_TriggeredThreadedCyclicExec.hpp
+++ b/testcases/execution/cyclic/UUT_TriggeredThreadedCyclicExec.hpp
@@ -50,8 +50,8 @@ using gpcc::execution::cyclic::TTCEStartStopCtrl;
 class UUT_TriggeredThreadedCyclicExec final : public TriggeredThreadedCyclicExec
 {
   public:
-    UUT_TriggeredThreadedCyclicExec(Trace & _trace,
-                                    gpcc::stdif::IIRQ2ThreadWakeup & _trigger,
+    UUT_TriggeredThreadedCyclicExec(Trace & trace,
+                                    gpcc::stdif::IIRQ2ThreadWakeup & trigger,
                                     gpcc::time::TimeSpan const & waitForTriggerTimeout);
     UUT_TriggeredThreadedCyclicExec(UUT_TriggeredThreadedCyclicExec const &) = delete;
     UUT_TriggeredThreadedCyclicExec(UUT_TriggeredThreadedCyclicExec &&) = delete;
@@ -60,21 +60,21 @@ class UUT_TriggeredThreadedCyclicExec final : public TriggeredThreadedCyclicExec
     UUT_TriggeredThreadedCyclicExec& operator=(UUT_TriggeredThreadedCyclicExec const &) = delete;
     UUT_TriggeredThreadedCyclicExec& operator=(UUT_TriggeredThreadedCyclicExec &&) = delete;
 
-    void SetTTCEStartStopCtrl(TTCEStartStopCtrl* const _pTTCEStartStopCtrl);
+    void SetTTCEStartStopCtrl(TTCEStartStopCtrl* const pTTCEStartStopCtrl);
 
 
     void SetSampleRetVal(bool const value);
     void SetIsPllRunningRetVal(bool const value);
 
   private:
-    Trace & trace;
-    TTCEStartStopCtrl* pTTCEStartStopCtrl;
+    Trace & trace_;
+    TTCEStartStopCtrl* pTTCEStartStopCtrl_;
 
-    gpcc::osal::Mutex mutex;
-    // Return value used when Sample() is called next time. "mutex" is required.
-    bool sampleRetVal;
-    // Return value used when IsPllRunning() is called next time. "mutex" is required.
-    bool isPllRunningRetVal;
+    gpcc::osal::Mutex mutex_;
+    // Return value used when Sample() is called next time. "mutex_" is required.
+    bool sampleRetVal_;
+    // Return value used when IsPllRunning() is called next time. "mutex_" is required.
+    bool isPllRunningRetVal_;
 
 
     void Cyclic(void) override;

--- a/testcases/file_systems/cli/TestIFSCLICommands.cpp
+++ b/testcases/file_systems/cli/TestIFSCLICommands.cpp
@@ -78,46 +78,46 @@ void GPCC_FileSystems_CLI_TestsF::SetUp(void)
                                             std::bind(&gpcc::file_systems::CLICMDDelete,
                                                       std::placeholders::_1,
                                                       std::placeholders::_2,
-                                                      static_cast<IFileStorage*>(&uut))));
+                                                      static_cast<IFileStorage*>(&uut_))));
   cli.AddCommand(gpcc::cli::Command::Create("Rename", "\nHelp text",
                                             std::bind(&gpcc::file_systems::CLICMDRename,
                                                       std::placeholders::_1,
                                                       std::placeholders::_2,
-                                                      static_cast<IFileStorage*>(&uut))));
+                                                      static_cast<IFileStorage*>(&uut_))));
   cli.AddCommand(gpcc::cli::Command::Create("Enumerate", "\nHelp text",
                                             std::bind(&gpcc::file_systems::CLICMDEnumerate,
                                                       std::placeholders::_1,
                                                       std::placeholders::_2,
-                                                      static_cast<IFileStorage*>(&uut))));
+                                                      static_cast<IFileStorage*>(&uut_))));
   cli.AddCommand(gpcc::cli::Command::Create("FreeSpace", "\nHelp text",
                                             std::bind(&gpcc::file_systems::CLICMDFreeSpace,
                                                       std::placeholders::_1,
                                                       std::placeholders::_2,
-                                                      static_cast<IFileStorage*>(&uut))));
+                                                      static_cast<IFileStorage*>(&uut_))));
   cli.AddCommand(gpcc::cli::Command::Create("Dump", "\nHelp text",
                                             std::bind(&gpcc::file_systems::CLICMDDump,
                                                       std::placeholders::_1,
                                                       std::placeholders::_2,
-                                                      static_cast<IFileStorage*>(&uut))));
+                                                      static_cast<IFileStorage*>(&uut_))));
   cli.AddCommand(gpcc::cli::Command::Create("Copy", "\nHelp text",
                                             std::bind(&gpcc::file_systems::CLICMDCopy,
                                                       std::placeholders::_1,
                                                       std::placeholders::_2,
-                                                      static_cast<IFileStorage*>(&uut))));
+                                                      static_cast<IFileStorage*>(&uut_))));
 
-  Format(fakeStorage.GetPageSize());
+  Format(fakeStorage_.GetPageSize());
 
-  rndData1.Write("rndData1", false, uut);
-  rndData2.Write("rndData2", false, uut);
+  rndData1.Write("rndData1", false, uut_);
+  rndData2.Write("rndData2", false, uut_);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 }
 void GPCC_FileSystems_CLI_TestsF::TearDown(void)
 {
   try
   {
-    if (uut.GetState() != gpcc::file_systems::eeprom_section_system::EEPROMSectionSystem::States::not_mounted)
-      uut.Unmount();
+    if (uut_.GetState() != gpcc::file_systems::eeprom_section_system::EEPROMSectionSystem::States::not_mounted)
+      uut_.Unmount();
 
     if (cliRunning)
       cli.Stop();
@@ -184,7 +184,7 @@ TEST_F(GPCC_FileSystems_CLI_TestsF, Delete_NoParameters)
   terminal.Input_ENTER();
   terminal.WaitForInputProcessed();
 
-  ASSERT_EQ(0U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(0U, fakeStorage_.writeAccessCnt);
   ASSERT_TRUE(terminal.Compare(expected));
 }
 TEST_F(GPCC_FileSystems_CLI_TestsF, Delete_NoSuchFile)
@@ -208,7 +208,7 @@ TEST_F(GPCC_FileSystems_CLI_TestsF, Delete_NoSuchFile)
   terminal.Input_ENTER();
   terminal.WaitForInputProcessed();
 
-  ASSERT_EQ(0U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(0U, fakeStorage_.writeAccessCnt);
   ASSERT_TRUE(terminal.Compare(expected));
 }
 TEST_F(GPCC_FileSystems_CLI_TestsF, Delete_NoSuchFiles)
@@ -232,7 +232,7 @@ TEST_F(GPCC_FileSystems_CLI_TestsF, Delete_NoSuchFiles)
   terminal.Input_ENTER();
   terminal.WaitForInputProcessed();
 
-  ASSERT_EQ(0U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(0U, fakeStorage_.writeAccessCnt);
   ASSERT_TRUE(terminal.Compare(expected));
 }
 TEST_F(GPCC_FileSystems_CLI_TestsF, Delete_OneFile)
@@ -256,10 +256,10 @@ TEST_F(GPCC_FileSystems_CLI_TestsF, Delete_OneFile)
   terminal.Input_ENTER();
   terminal.WaitForInputProcessed();
 
-  ASSERT_NE(0U, fakeStorage.writeAccessCnt);
+  ASSERT_NE(0U, fakeStorage_.writeAccessCnt);
   ASSERT_TRUE(terminal.Compare(expected));
 
-  auto sections = uut.Enumerate();
+  auto sections = uut_.Enumerate();
   ASSERT_EQ(1U, sections.size());
   ASSERT_TRUE(std::find(sections.begin(), sections.end(), "rndData2") != sections.end());
 }
@@ -284,10 +284,10 @@ TEST_F(GPCC_FileSystems_CLI_TestsF, Delete_TwoFiles)
   terminal.Input_ENTER();
   terminal.WaitForInputProcessed();
 
-  ASSERT_NE(0U, fakeStorage.writeAccessCnt);
+  ASSERT_NE(0U, fakeStorage_.writeAccessCnt);
   ASSERT_TRUE(terminal.Compare(expected));
 
-  auto sections = uut.Enumerate();
+  auto sections = uut_.Enumerate();
   ASSERT_EQ(0U, sections.size());
 }
 TEST_F(GPCC_FileSystems_CLI_TestsF, Delete_TwoFiles_OneNotExist)
@@ -311,10 +311,10 @@ TEST_F(GPCC_FileSystems_CLI_TestsF, Delete_TwoFiles_OneNotExist)
   terminal.Input_ENTER();
   terminal.WaitForInputProcessed();
 
-  ASSERT_NE(0U, fakeStorage.writeAccessCnt);
+  ASSERT_NE(0U, fakeStorage_.writeAccessCnt);
   ASSERT_TRUE(terminal.Compare(expected));
 
-  auto sections = uut.Enumerate();
+  auto sections = uut_.Enumerate();
   ASSERT_EQ(1U, sections.size());
   ASSERT_TRUE(std::find(sections.begin(), sections.end(), "rndData1") != sections.end());
 }
@@ -339,7 +339,7 @@ TEST_F(GPCC_FileSystems_CLI_TestsF, Rename_NoParameters)
   terminal.Input_ENTER();
   terminal.WaitForInputProcessed();
 
-  ASSERT_EQ(0U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(0U, fakeStorage_.writeAccessCnt);
   ASSERT_TRUE(terminal.Compare(expected));
 }
 TEST_F(GPCC_FileSystems_CLI_TestsF, Rename_OneParameters)
@@ -363,7 +363,7 @@ TEST_F(GPCC_FileSystems_CLI_TestsF, Rename_OneParameters)
   terminal.Input_ENTER();
   terminal.WaitForInputProcessed();
 
-  ASSERT_EQ(0U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(0U, fakeStorage_.writeAccessCnt);
   ASSERT_TRUE(terminal.Compare(expected));
 }
 TEST_F(GPCC_FileSystems_CLI_TestsF, Rename_OK)
@@ -387,10 +387,10 @@ TEST_F(GPCC_FileSystems_CLI_TestsF, Rename_OK)
   terminal.Input_ENTER();
   terminal.WaitForInputProcessed();
 
-  ASSERT_NE(0U, fakeStorage.writeAccessCnt);
+  ASSERT_NE(0U, fakeStorage_.writeAccessCnt);
   ASSERT_TRUE(terminal.Compare(expected));
 
-  auto sections = uut.Enumerate();
+  auto sections = uut_.Enumerate();
   ASSERT_EQ(2U, sections.size());
   ASSERT_TRUE(std::find(sections.begin(), sections.end(), "rndData2") != sections.end());
   ASSERT_TRUE(std::find(sections.begin(), sections.end(), "rndData3") != sections.end());
@@ -416,7 +416,7 @@ TEST_F(GPCC_FileSystems_CLI_TestsF, Enumerate_BadParameters)
   terminal.Input_ENTER();
   terminal.WaitForInputProcessed();
 
-  ASSERT_EQ(0U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(0U, fakeStorage_.writeAccessCnt);
   ASSERT_TRUE(terminal.Compare(expected));
 }
 TEST_F(GPCC_FileSystems_CLI_TestsF, Enumerate_NoParams)
@@ -440,7 +440,7 @@ TEST_F(GPCC_FileSystems_CLI_TestsF, Enumerate_NoParams)
   terminal.Input_ENTER();
   terminal.WaitForInputProcessed();
 
-  ASSERT_EQ(0U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(0U, fakeStorage_.writeAccessCnt);
   ASSERT_TRUE(terminal.Compare(expected));
 }
 TEST_F(GPCC_FileSystems_CLI_TestsF, Enumerate_Option_s)
@@ -464,7 +464,7 @@ TEST_F(GPCC_FileSystems_CLI_TestsF, Enumerate_Option_s)
   terminal.Input_ENTER();
   terminal.WaitForInputProcessed();
 
-  ASSERT_EQ(0U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(0U, fakeStorage_.writeAccessCnt);
   ASSERT_TRUE(terminal.Compare(expected));
 }
 TEST_F(GPCC_FileSystems_CLI_TestsF, FreeSpace_BadParameters)
@@ -488,7 +488,7 @@ TEST_F(GPCC_FileSystems_CLI_TestsF, FreeSpace_BadParameters)
   terminal.Input_ENTER();
   terminal.WaitForInputProcessed();
 
-  ASSERT_EQ(0U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(0U, fakeStorage_.writeAccessCnt);
   ASSERT_TRUE(terminal.Compare(expected));
 }
 TEST_F(GPCC_FileSystems_CLI_TestsF, FreeSpace_OK)
@@ -512,7 +512,7 @@ TEST_F(GPCC_FileSystems_CLI_TestsF, FreeSpace_OK)
   terminal.Input_ENTER();
   terminal.WaitForInputProcessed();
 
-  ASSERT_EQ(0U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(0U, fakeStorage_.writeAccessCnt);
   ASSERT_TRUE(terminal.Compare(expected));
 }
 TEST_F(GPCC_FileSystems_CLI_TestsF, Dump_NoParameters)
@@ -536,7 +536,7 @@ TEST_F(GPCC_FileSystems_CLI_TestsF, Dump_NoParameters)
   terminal.Input_ENTER();
   terminal.WaitForInputProcessed();
 
-  ASSERT_EQ(0U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(0U, fakeStorage_.writeAccessCnt);
   ASSERT_TRUE(terminal.Compare(expected));
 }
 TEST_F(GPCC_FileSystems_CLI_TestsF, Dump_NoSuchFile)
@@ -560,7 +560,7 @@ TEST_F(GPCC_FileSystems_CLI_TestsF, Dump_NoSuchFile)
   terminal.Input_ENTER();
   terminal.WaitForInputProcessed();
 
-  ASSERT_EQ(0U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(0U, fakeStorage_.writeAccessCnt);
   ASSERT_TRUE(terminal.Compare(expected));
 }
 TEST_F(GPCC_FileSystems_CLI_TestsF, Dump_OK)
@@ -577,13 +577,13 @@ TEST_F(GPCC_FileSystems_CLI_TestsF, Dump_OK)
    ">"
   };
 
-  auto fw = uut.Create("File1", false);
+  auto fw = uut_.Create("File1", false);
   ON_SCOPE_EXIT() { try { fw->Close(); } catch (std::exception const &) {}; };
   for (uint_fast8_t i = 0; i < 32; i++)
     fw->Write_uint8(i);
   ON_SCOPE_EXIT_DISMISS();
   fw->Close();
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   terminal.Input("login");
   terminal.Input_ENTER();
@@ -592,7 +592,7 @@ TEST_F(GPCC_FileSystems_CLI_TestsF, Dump_OK)
   terminal.Input_ENTER();
   terminal.WaitForInputProcessed();
 
-  ASSERT_EQ(0U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(0U, fakeStorage_.writeAccessCnt);
   ASSERT_TRUE(terminal.Compare(expected));
 }
 TEST_F(GPCC_FileSystems_CLI_TestsF, Dump_StopAfter1024)
@@ -609,13 +609,13 @@ TEST_F(GPCC_FileSystems_CLI_TestsF, Dump_StopAfter1024)
    ">"
   };
 
-  auto fw = uut.Create("File1", false);
+  auto fw = uut_.Create("File1", false);
   ON_SCOPE_EXIT() { try { fw->Close(); } catch (std::exception const &) {}; };
   for (uint_fast16_t i = 0; i < 1025; i++)
     fw->Write_uint8(i % 32U);
   ON_SCOPE_EXIT_DISMISS();
   fw->Close();
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   terminal.Input("login");
   terminal.Input_ENTER();
@@ -627,7 +627,7 @@ TEST_F(GPCC_FileSystems_CLI_TestsF, Dump_StopAfter1024)
   terminal.Input_ENTER();
   terminal.WaitForInputProcessed();
 
-  ASSERT_EQ(0U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(0U, fakeStorage_.writeAccessCnt);
   ASSERT_TRUE(terminal.Compare(expected));
 }
 TEST_F(GPCC_FileSystems_CLI_TestsF, Dump_ContinueAfter1024)
@@ -644,14 +644,14 @@ TEST_F(GPCC_FileSystems_CLI_TestsF, Dump_ContinueAfter1024)
    ">"
   };
 
-  auto fw = uut.Create("File1", false);
+  auto fw = uut_.Create("File1", false);
   ON_SCOPE_EXIT() { try { fw->Close(); } catch (std::exception const &) {}; };
   for (uint_fast16_t i = 0; i < 1024; i++)
     fw->Write_uint8(i % 32U);
   fw->Write_uint8(0xFFU);
   ON_SCOPE_EXIT_DISMISS();
   fw->Close();
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   terminal.Input("login");
   terminal.Input_ENTER();
@@ -663,7 +663,7 @@ TEST_F(GPCC_FileSystems_CLI_TestsF, Dump_ContinueAfter1024)
   terminal.Input_ENTER();
   terminal.WaitForInputProcessed();
 
-  ASSERT_EQ(0U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(0U, fakeStorage_.writeAccessCnt);
   ASSERT_TRUE(terminal.Compare(expected));
 }
 TEST_F(GPCC_FileSystems_CLI_TestsF, Copy_NoParameters)
@@ -687,7 +687,7 @@ TEST_F(GPCC_FileSystems_CLI_TestsF, Copy_NoParameters)
   terminal.Input_ENTER();
   terminal.WaitForInputProcessed();
 
-  ASSERT_EQ(0U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(0U, fakeStorage_.writeAccessCnt);
   ASSERT_TRUE(terminal.Compare(expected));
 }
 TEST_F(GPCC_FileSystems_CLI_TestsF, Copy_OneParameter)
@@ -711,7 +711,7 @@ TEST_F(GPCC_FileSystems_CLI_TestsF, Copy_OneParameter)
   terminal.Input_ENTER();
   terminal.WaitForInputProcessed();
 
-  ASSERT_EQ(0U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(0U, fakeStorage_.writeAccessCnt);
   ASSERT_TRUE(terminal.Compare(expected));
 }
 TEST_F(GPCC_FileSystems_CLI_TestsF, Copy_ThreeParameter)
@@ -735,7 +735,7 @@ TEST_F(GPCC_FileSystems_CLI_TestsF, Copy_ThreeParameter)
   terminal.Input_ENTER();
   terminal.WaitForInputProcessed();
 
-  ASSERT_EQ(0U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(0U, fakeStorage_.writeAccessCnt);
   ASSERT_TRUE(terminal.Compare(expected));
 }
 TEST_F(GPCC_FileSystems_CLI_TestsF, Copy_OK)
@@ -759,18 +759,18 @@ TEST_F(GPCC_FileSystems_CLI_TestsF, Copy_OK)
   terminal.Input_ENTER();
   terminal.WaitForInputProcessed();
 
-  ASSERT_NE(0U, fakeStorage.writeAccessCnt);
+  ASSERT_NE(0U, fakeStorage_.writeAccessCnt);
   ASSERT_TRUE(terminal.Compare(expected));
 
-  auto sections = uut.Enumerate();
+  auto sections = uut_.Enumerate();
   ASSERT_EQ(3U, sections.size());
   ASSERT_TRUE(std::find(sections.begin(), sections.end(), "rndData1") != sections.end());
   ASSERT_TRUE(std::find(sections.begin(), sections.end(), "rndData2") != sections.end());
   ASSERT_TRUE(std::find(sections.begin(), sections.end(), "Copy") != sections.end());
 
-  rndData1.Compare("Copy", uut);
-  rndData1.Compare("rndData1", uut);
-  rndData2.Compare("rndData2", uut);
+  rndData1.Compare("Copy", uut_);
+  rndData1.Compare("rndData1", uut_);
+  rndData2.Compare("rndData2", uut_);
 }
 TEST_F(GPCC_FileSystems_CLI_TestsF, Copy_FileAlreadyExisting)
 {
@@ -793,16 +793,16 @@ TEST_F(GPCC_FileSystems_CLI_TestsF, Copy_FileAlreadyExisting)
   terminal.Input_ENTER();
   terminal.WaitForInputProcessed();
 
-  ASSERT_EQ(0U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(0U, fakeStorage_.writeAccessCnt);
   ASSERT_TRUE(terminal.Compare(expected));
 
-  auto sections = uut.Enumerate();
+  auto sections = uut_.Enumerate();
   ASSERT_EQ(2U, sections.size());
   ASSERT_TRUE(std::find(sections.begin(), sections.end(), "rndData1") != sections.end());
   ASSERT_TRUE(std::find(sections.begin(), sections.end(), "rndData2") != sections.end());
 
-  rndData1.Compare("rndData1", uut);
-  rndData2.Compare("rndData2", uut);
+  rndData1.Compare("rndData1", uut_);
+  rndData2.Compare("rndData2", uut_);
 }
 TEST_F(GPCC_FileSystems_CLI_TestsF, Copy_SrcAndDestEqual)
 {
@@ -825,16 +825,16 @@ TEST_F(GPCC_FileSystems_CLI_TestsF, Copy_SrcAndDestEqual)
   terminal.Input_ENTER();
   terminal.WaitForInputProcessed();
 
-  ASSERT_EQ(0U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(0U, fakeStorage_.writeAccessCnt);
   ASSERT_TRUE(terminal.Compare(expected));
 
-  auto sections = uut.Enumerate();
+  auto sections = uut_.Enumerate();
   ASSERT_EQ(2U, sections.size());
   ASSERT_TRUE(std::find(sections.begin(), sections.end(), "rndData1") != sections.end());
   ASSERT_TRUE(std::find(sections.begin(), sections.end(), "rndData2") != sections.end());
 
-  rndData1.Compare("rndData1", uut);
-  rndData2.Compare("rndData2", uut);
+  rndData1.Compare("rndData1", uut_);
+  rndData2.Compare("rndData2", uut_);
 }
 TEST_F(GPCC_FileSystems_CLI_TestsF, Copy_SrcNotExisting)
 {
@@ -857,16 +857,16 @@ TEST_F(GPCC_FileSystems_CLI_TestsF, Copy_SrcNotExisting)
   terminal.Input_ENTER();
   terminal.WaitForInputProcessed();
 
-  ASSERT_EQ(0U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(0U, fakeStorage_.writeAccessCnt);
   ASSERT_TRUE(terminal.Compare(expected));
 
-  auto sections = uut.Enumerate();
+  auto sections = uut_.Enumerate();
   ASSERT_EQ(2U, sections.size());
   ASSERT_TRUE(std::find(sections.begin(), sections.end(), "rndData1") != sections.end());
   ASSERT_TRUE(std::find(sections.begin(), sections.end(), "rndData2") != sections.end());
 
-  rndData1.Compare("rndData1", uut);
-  rndData2.Compare("rndData2", uut);
+  rndData1.Compare("rndData1", uut_);
+  rndData2.Compare("rndData2", uut_);
 }
 
 } // namespace file_systems

--- a/testcases/file_systems/eeprom_section_system/EEPROMSectionSystemTestFixture.cpp
+++ b/testcases/file_systems/eeprom_section_system/EEPROMSectionSystemTestFixture.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011 Daniel Jerolm
+    Copyright (C) 2011, 2025 Daniel Jerolm
     Copyright (C) 2017 Falk Werner
 */
 
@@ -31,19 +31,19 @@ using namespace gpcc::file_systems::eeprom_section_system::internal;
 
 EEPROMSectionSystemTestFixture::EEPROMSectionSystemTestFixture(void)
 : Test()
-, blockSize(0)
-, bytesPerBlock(0)
-, fakeStorage(storageSize, storagePageSize)
-, uut(fakeStorage, 0, storageSize)
-, pBuffer(nullptr)
+, blockSize_(0)
+, bytesPerBlock_(0)
+, fakeStorage_(storageSize_, storagePageSize_)
+, uut_(fakeStorage_, 0, storageSize_)
+, pBuffer_(nullptr)
 {
 }
 EEPROMSectionSystemTestFixture::~EEPROMSectionSystemTestFixture(void)
 {
-  if (pBuffer != nullptr)
+  if (pBuffer_ != nullptr)
   {
-    delete [] pBuffer;
-    pBuffer = nullptr;
+    delete [] pBuffer_;
+    pBuffer_ = nullptr;
   }
 }
 
@@ -53,81 +53,81 @@ void EEPROMSectionSystemTestFixture::SetUp(void)
 void EEPROMSectionSystemTestFixture::TearDown(void)
 {
   // unmount, if uut's state is not not_mounted
-  eeprom_section_system::EEPROMSectionSystem::States const state = uut.GetState();
+  eeprom_section_system::EEPROMSectionSystem::States const state = uut_.GetState();
   EXPECT_EQ(eeprom_section_system::EEPROMSectionSystem::States::not_mounted, state);
   if (state != eeprom_section_system::EEPROMSectionSystem::States::not_mounted)
-    uut.Unmount();
+    uut_.Unmount();
 }
 
-void EEPROMSectionSystemTestFixture::Format(uint16_t const _blockSize)
+void EEPROMSectionSystemTestFixture::Format(uint16_t const blockSize)
 {
-  // Formats the UUT and allocated/reallocates pBuffer.
+  // Formats the UUT and allocates/reallocates pBuffer_.
 
-  std::unique_ptr<uint8_t[]> spNewBuffer(new uint8_t[_blockSize]);
+  std::unique_ptr<uint8_t[]> spNewBuffer(new uint8_t[blockSize]);
 
-  uut.Format(_blockSize);
-  blockSize = _blockSize;
-  bytesPerBlock = blockSize - (sizeof(DataBlock_t) + sizeof(uint16_t));
+  uut_.Format(blockSize);
+  blockSize_ = blockSize;
+  bytesPerBlock_ = blockSize_ - (sizeof(DataBlock_t) + sizeof(uint16_t));
 
-  if (pBuffer != nullptr)
+  if (pBuffer_ != nullptr)
   {
-    delete [] pBuffer;
-    pBuffer = nullptr;
+    delete [] pBuffer_;
+    pBuffer_ = nullptr;
   }
-  pBuffer = spNewBuffer.release();
+  pBuffer_ = spNewBuffer.release();
 }
 void EEPROMSectionSystemTestFixture::InvalidateCRC(uint16_t const blockIdx)
 {
-  // Invalidates the CRC of an storage block inside "fakeStorage".
+  // Invalidates the CRC of an storage block inside "fakeStorage_".
 
   // calculate block start address
-  size_t const bsa = blockIdx * blockSize;
+  size_t const bsa = blockIdx * blockSize_;
 
   // retrieve field "nBytes"
-  fakeStorage.Read(bsa + offsetof(CommonBlockHead_t, nBytes), 2U, pBuffer);
-  uint16_t const nBytes = pBuffer[0] + (static_cast<uint16_t>(pBuffer[1]) << 8U);
-  if ((nBytes < 2U) || (nBytes > blockSize - 2U))
+  fakeStorage_.Read(bsa + offsetof(CommonBlockHead_t, nBytes), 2U, pBuffer_);
+  uint16_t const nBytes = pBuffer_[0] + (static_cast<uint16_t>(pBuffer_[1]) << 8U);
+  if ((nBytes < 2U) || (nBytes > blockSize_ - 2U))
     throw std::runtime_error("EEPROMSectionSystemTestFixture::InvalidateCRC: Bad \"nBytes\"");
 
   // load CRC, negate it, and write it back
-  fakeStorage.Read(bsa + (nBytes - 2U), 2U, pBuffer);
-  pBuffer[0] = ~pBuffer[0];
-  pBuffer[1] = ~pBuffer[1];
-  fakeStorage.Write(bsa + (nBytes - 2U), 2U, pBuffer);
+  fakeStorage_.Read(bsa + (nBytes - 2U), 2U, pBuffer_);
+  pBuffer_[0] = ~pBuffer_[0];
+  pBuffer_[1] = ~pBuffer_[1];
+  fakeStorage_.Write(bsa + (nBytes - 2U), 2U, pBuffer_);
 }
 void EEPROMSectionSystemTestFixture::UpdateCRC(uint16_t const blockIdx)
 {
-  // Updates the CRC of an storage block inside "fakeStorage".
+  // Updates the CRC of an storage block inside "fakeStorage_".
 
   // calculate block start address
-  size_t const bsa = blockIdx * blockSize;
+  size_t const bsa = blockIdx * blockSize_;
 
   // retrieve field "nBytes"
-  fakeStorage.Read(bsa + offsetof(CommonBlockHead_t, nBytes), 2U, pBuffer);
-  uint16_t const nBytes = pBuffer[0] + (static_cast<uint16_t>(pBuffer[1]) << 8U);
-  if ((nBytes < 2U) || (nBytes > blockSize - 2U))
+  fakeStorage_.Read(bsa + offsetof(CommonBlockHead_t, nBytes), 2U, pBuffer_);
+  uint16_t const nBytes = pBuffer_[0] + (static_cast<uint16_t>(pBuffer_[1]) << 8U);
+  if ((nBytes < 2U) || (nBytes > blockSize_ - 2U))
     throw std::runtime_error("EEPROMSectionSystemTestFixture::UpdateCRC: Bad \"nBytes\"");
 
   // load block
-  fakeStorage.Read(bsa, nBytes - 2U, pBuffer);
+  fakeStorage_.Read(bsa, nBytes - 2U, pBuffer_);
 
   // calculate new CRC
   uint16_t crc = 0xFFFFU;
-  gpcc::crc::CalcCRC16_normal_noInputReverse(crc, pBuffer, nBytes - 2U, gpcc::crc::crc16_ccitt_table_normal);
+  gpcc::crc::CalcCRC16_normal_noInputReverse(crc, pBuffer_, nBytes - 2U, gpcc::crc::crc16_ccitt_table_normal);
 
   // update CRC
-  pBuffer[0] = crc & 0xFFU;
-  pBuffer[1] = crc >> 8U;
-  fakeStorage.Write(bsa + (nBytes - 2U), 2U, pBuffer);
+  pBuffer_[0] = crc & 0xFFU;
+  pBuffer_[1] = crc >> 8U;
+  fakeStorage_.Write(bsa + (nBytes - 2U), 2U, pBuffer_);
 }
 void EEPROMSectionSystemTestFixture::UpdateNextBlock(uint16_t const blockIdx, uint16_t const newNextBlock)
 {
   // Updates the nextBlock-attribute of an storage block and updates the block's CRC
 
-  fakeStorage.Read(blockSize * blockIdx + offsetof(CommonBlockHead_t, nextBlock), 2, pBuffer);
-  pBuffer[0] = newNextBlock & 0xFFU;
-  pBuffer[1] = newNextBlock >> 8U;
-  fakeStorage.Write(blockSize * blockIdx + offsetof(CommonBlockHead_t, nextBlock), 2, pBuffer);
+  fakeStorage_.Read(blockSize_ * blockIdx + offsetof(CommonBlockHead_t, nextBlock), 2, pBuffer_);
+  pBuffer_[0] = newNextBlock & 0xFFU;
+  pBuffer_[1] = newNextBlock >> 8U;
+  fakeStorage_.Write(blockSize_ * blockIdx + offsetof(CommonBlockHead_t, nextBlock), 2, pBuffer_);
   UpdateCRC(blockIdx);
 }
 

--- a/testcases/file_systems/eeprom_section_system/EEPROMSectionSystemTestFixture.hpp
+++ b/testcases/file_systems/eeprom_section_system/EEPROMSectionSystemTestFixture.hpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011 Daniel Jerolm
+    Copyright (C) 2011, 2025 Daniel Jerolm
 */
 
 #include <gpcc/file_systems/eeprom_section_system/EEPROMSectionSystem.hpp>
@@ -26,23 +26,23 @@ namespace eeprom_section_system
 class EEPROMSectionSystemTestFixture: public testing::Test
 {
   public:
-    static const size_t storageSize     = 16*1024;
-    static const size_t storagePageSize = 128;
-    uint16_t blockSize;
-    uint16_t bytesPerBlock;
+    static const size_t storageSize_     = 16*1024;
+    static const size_t storagePageSize_ = 128;
+    uint16_t blockSize_;
+    uint16_t bytesPerBlock_;
 
     EEPROMSectionSystemTestFixture(void);
     virtual ~EEPROMSectionSystemTestFixture(void);
 
   protected:
-    FakeEEPROM fakeStorage;
-    gpcc::file_systems::eeprom_section_system::EEPROMSectionSystem uut;
-    uint8_t* pBuffer;
+    FakeEEPROM fakeStorage_;
+    gpcc::file_systems::eeprom_section_system::EEPROMSectionSystem uut_;
+    uint8_t* pBuffer_;
 
     void SetUp(void) override;
     void TearDown(void) override;
 
-    void Format(uint16_t const _blockSize);
+    void Format(uint16_t const blockSize);
     void InvalidateCRC(uint16_t const blockIdx);
     void UpdateCRC(uint16_t const blockIdx);
     void UpdateNextBlock(uint16_t const blockIdx, uint16_t const newNextBlock);

--- a/testcases/file_systems/eeprom_section_system/TestEEPROMSectionSystem.cpp
+++ b/testcases/file_systems/eeprom_section_system/TestEEPROMSectionSystem.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011 Daniel Jerolm
+    Copyright (C) 2011, 2025 Daniel Jerolm
 */
 
 #include "EEPROMSectionSystemTestFixture.hpp"
@@ -202,16 +202,16 @@ TEST(GPCC_FileSystems_EEPROMSectionSystem_DeathTestsF, Destruction_BadState)
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, MountStep1_BadState)
 {
-  Format(storagePageSize);
+  Format(storagePageSize_);
 
-  ASSERT_THROW(uut.MountStep1(), InsufficientStateError);
+  ASSERT_THROW(uut_.MountStep1(), InsufficientStateError);
 
-  uut.Unmount();
+  uut_.Unmount();
 
-  ASSERT_NO_THROW(uut.MountStep1());
-  ASSERT_THROW(uut.MountStep1(), InsufficientStateError);
+  ASSERT_NO_THROW(uut_.MountStep1());
+  ASSERT_THROW(uut_.MountStep1(), InsufficientStateError);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST(GPCC_FileSystems_EEPROMSectionSystem_Tests, MountStep1_StoragePageSizeTooSmall)
 {
@@ -222,178 +222,178 @@ TEST(GPCC_FileSystems_EEPROMSectionSystem_Tests, MountStep1_StoragePageSizeTooSm
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, MountStep1_BlankStorage)
 {
-  // note: fakeStorage is initialized with zeros by FakeEEPROM::FakeEEPROM()
-  ASSERT_THROW(uut.MountStep1(), eeprom_section_system::BadSectionSystemInfoBlockError);
+  // note: fakeStorage_ is initialized with zeros by FakeEEPROM::FakeEEPROM()
+  ASSERT_THROW(uut_.MountStep1(), eeprom_section_system::BadSectionSystemInfoBlockError);
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, MountStep1_SSIB_BadCRC)
 {
   Format(128);
-  uut.Unmount();
+  uut_.Unmount();
 
   InvalidateCRC(0);
 
-  ASSERT_THROW(uut.MountStep1(), eeprom_section_system::BadSectionSystemInfoBlockError);
+  ASSERT_THROW(uut_.MountStep1(), eeprom_section_system::BadSectionSystemInfoBlockError);
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, MountStep1_SSIB_WrongType_freeBlock)
 {
   Format(128);
-  uut.Unmount();
+  uut_.Unmount();
 
-  pBuffer[0] = static_cast<uint8_t>(BlockTypes::freeBlock); // type
-  pBuffer[1] = 0; // sectionNameHash
-  pBuffer[2] = 12; // nBytes (LB)
-  pBuffer[3] = 0; // nBytes (HB)
-  pBuffer[4] = 0; // totalNbOfWrites LB
-  pBuffer[5] = 0; // ...
-  pBuffer[6] = 0; // ...
-  pBuffer[7] = 0; // totalNbOfWrites
-  pBuffer[8] = NOBLOCK & 0xFFU; // nextBlock LB
-  pBuffer[9] = NOBLOCK >> 8U; // nextBlock HB
+  pBuffer_[0] = static_cast<uint8_t>(BlockTypes::freeBlock); // type
+  pBuffer_[1] = 0; // sectionNameHash
+  pBuffer_[2] = 12; // nBytes (LB)
+  pBuffer_[3] = 0; // nBytes (HB)
+  pBuffer_[4] = 0; // totalNbOfWrites LB
+  pBuffer_[5] = 0; // ...
+  pBuffer_[6] = 0; // ...
+  pBuffer_[7] = 0; // totalNbOfWrites
+  pBuffer_[8] = NOBLOCK & 0xFFU; // nextBlock LB
+  pBuffer_[9] = NOBLOCK >> 8U; // nextBlock HB
 
-  fakeStorage.Write(0, 10, pBuffer);
+  fakeStorage_.Write(0, 10, pBuffer_);
   UpdateCRC(0);
 
-  ASSERT_THROW(uut.MountStep1(), eeprom_section_system::BadSectionSystemInfoBlockError);
+  ASSERT_THROW(uut_.MountStep1(), eeprom_section_system::BadSectionSystemInfoBlockError);
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, MountStep1_SSIB_WrongType_sectionHead)
 {
   Format(128);
-  uut.Unmount();
+  uut_.Unmount();
 
-  pBuffer[0] = static_cast<uint8_t>(BlockTypes::sectionHead); // type
-  pBuffer[1] = 'A'; // sectionNameHash
-  pBuffer[2] = 16; // nBytes (LB)
-  pBuffer[3] = 0; // nBytes (HB)
-  pBuffer[4] = 0; // totalNbOfWrites LB
-  pBuffer[5] = 0; // ...
-  pBuffer[6] = 0; // ...
-  pBuffer[7] = 0; // totalNbOfWrites
-  pBuffer[8] = 2; // nextBlock LB
-  pBuffer[9] = 0; // nextBlock HB
-  pBuffer[10] = 1; // version LB
-  pBuffer[11] = 0; // version HB
-  pBuffer[12] = 'A';
-  pBuffer[13] = 0;
+  pBuffer_[0] = static_cast<uint8_t>(BlockTypes::sectionHead); // type
+  pBuffer_[1] = 'A'; // sectionNameHash
+  pBuffer_[2] = 16; // nBytes (LB)
+  pBuffer_[3] = 0; // nBytes (HB)
+  pBuffer_[4] = 0; // totalNbOfWrites LB
+  pBuffer_[5] = 0; // ...
+  pBuffer_[6] = 0; // ...
+  pBuffer_[7] = 0; // totalNbOfWrites
+  pBuffer_[8] = 2; // nextBlock LB
+  pBuffer_[9] = 0; // nextBlock HB
+  pBuffer_[10] = 1; // version LB
+  pBuffer_[11] = 0; // version HB
+  pBuffer_[12] = 'A';
+  pBuffer_[13] = 0;
 
-  fakeStorage.Write(0, 14, pBuffer);
+  fakeStorage_.Write(0, 14, pBuffer_);
   UpdateCRC(0);
 
-  ASSERT_THROW(uut.MountStep1(), eeprom_section_system::BadSectionSystemInfoBlockError);
+  ASSERT_THROW(uut_.MountStep1(), eeprom_section_system::BadSectionSystemInfoBlockError);
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, MountStep1_SSIB_WrongType_sectionData)
 {
   Format(128);
-  uut.Unmount();
+  uut_.Unmount();
 
-  pBuffer[0] = static_cast<uint8_t>(BlockTypes::sectionData); // type
-  pBuffer[1] = 0; // sectionNameHash
-  pBuffer[2] = 16; // nBytes (LB)
-  pBuffer[3] = 0; // nBytes (HB)
-  pBuffer[4] = 0; // totalNbOfWrites LB
-  pBuffer[5] = 0; // ...
-  pBuffer[6] = 0; // ...
-  pBuffer[7] = 0; // totalNbOfWrites
-  pBuffer[8] = 2; // nextBlock LB
-  pBuffer[9] = 0; // nextBlock HB
-  pBuffer[10] = 1; // seqNb LB
-  pBuffer[11] = 0; // seqNb HB
-  pBuffer[12] = 0x01;
-  pBuffer[13] = 0x02;
+  pBuffer_[0] = static_cast<uint8_t>(BlockTypes::sectionData); // type
+  pBuffer_[1] = 0; // sectionNameHash
+  pBuffer_[2] = 16; // nBytes (LB)
+  pBuffer_[3] = 0; // nBytes (HB)
+  pBuffer_[4] = 0; // totalNbOfWrites LB
+  pBuffer_[5] = 0; // ...
+  pBuffer_[6] = 0; // ...
+  pBuffer_[7] = 0; // totalNbOfWrites
+  pBuffer_[8] = 2; // nextBlock LB
+  pBuffer_[9] = 0; // nextBlock HB
+  pBuffer_[10] = 1; // seqNb LB
+  pBuffer_[11] = 0; // seqNb HB
+  pBuffer_[12] = 0x01;
+  pBuffer_[13] = 0x02;
 
-  fakeStorage.Write(0, 14, pBuffer);
+  fakeStorage_.Write(0, 14, pBuffer_);
   UpdateCRC(0);
 
-  ASSERT_THROW(uut.MountStep1(), eeprom_section_system::BadSectionSystemInfoBlockError);
+  ASSERT_THROW(uut_.MountStep1(), eeprom_section_system::BadSectionSystemInfoBlockError);
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, MountStep1_SSIB_BadVersion)
 {
   Format(128);
-  uut.Unmount();
+  uut_.Unmount();
 
-  fakeStorage.Read(offsetof(SectionSystemInfoBlock_t, sectionSystemVersion), 2, pBuffer);
-  uint16_t version = pBuffer[0] | (static_cast<uint16_t>(pBuffer[1]) << 8U);
+  fakeStorage_.Read(offsetof(SectionSystemInfoBlock_t, sectionSystemVersion), 2, pBuffer_);
+  uint16_t version = pBuffer_[0] | (static_cast<uint16_t>(pBuffer_[1]) << 8U);
   version++;
-  pBuffer[0] = version & 0xFF;
-  pBuffer[1] = version >> 8U;
-  fakeStorage.Write(offsetof(SectionSystemInfoBlock_t, sectionSystemVersion), 2, pBuffer);
+  pBuffer_[0] = version & 0xFF;
+  pBuffer_[1] = version >> 8U;
+  fakeStorage_.Write(offsetof(SectionSystemInfoBlock_t, sectionSystemVersion), 2, pBuffer_);
 
   UpdateCRC(0);
 
-  ASSERT_THROW(uut.MountStep1(), eeprom_section_system::InvalidVersionError);
+  ASSERT_THROW(uut_.MountStep1(), eeprom_section_system::InvalidVersionError);
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, MountStep1_SSIB_BadBlockSize)
 {
   Format(128);
-  uut.Unmount();
+  uut_.Unmount();
 
-  pBuffer[0] = 16;
-  pBuffer[1] = 0;
-  fakeStorage.Write(offsetof(SectionSystemInfoBlock_t, blockSize), 2, pBuffer);
+  pBuffer_[0] = 16;
+  pBuffer_[1] = 0;
+  fakeStorage_.Write(offsetof(SectionSystemInfoBlock_t, blockSize), 2, pBuffer_);
   UpdateCRC(0);
-  ASSERT_THROW(uut.MountStep1(), eeprom_section_system::InvalidHeaderError);
+  ASSERT_THROW(uut_.MountStep1(), eeprom_section_system::InvalidHeaderError);
 
-  pBuffer[0] = (blockSize + 1U) & 0xFFU;
-  pBuffer[1] = (blockSize + 1U) >> 8U;
-  fakeStorage.Write(offsetof(SectionSystemInfoBlock_t, blockSize), 2, pBuffer);
+  pBuffer_[0] = (blockSize_ + 1U) & 0xFFU;
+  pBuffer_[1] = (blockSize_ + 1U) >> 8U;
+  fakeStorage_.Write(offsetof(SectionSystemInfoBlock_t, blockSize), 2, pBuffer_);
   UpdateCRC(0);
-  ASSERT_THROW(uut.MountStep1(), std::invalid_argument);
+  ASSERT_THROW(uut_.MountStep1(), std::invalid_argument);
 
-  pBuffer[0] = (blockSize - 1U) & 0xFFU;
-  pBuffer[1] = (blockSize - 1U) >> 8U;
-  fakeStorage.Write(offsetof(SectionSystemInfoBlock_t, blockSize), 2, pBuffer);
+  pBuffer_[0] = (blockSize_ - 1U) & 0xFFU;
+  pBuffer_[1] = (blockSize_ - 1U) >> 8U;
+  fakeStorage_.Write(offsetof(SectionSystemInfoBlock_t, blockSize), 2, pBuffer_);
   UpdateCRC(0);
-  ASSERT_THROW(uut.MountStep1(), std::invalid_argument);
+  ASSERT_THROW(uut_.MountStep1(), std::invalid_argument);
 
-  pBuffer[0] = gpcc::file_systems::eeprom_section_system::EEPROMSectionSystem::MinimumBlockSize;
-  pBuffer[1] = 0;
-  fakeStorage.Write(offsetof(SectionSystemInfoBlock_t, blockSize), 2, pBuffer);
+  pBuffer_[0] = gpcc::file_systems::eeprom_section_system::EEPROMSectionSystem::MinimumBlockSize;
+  pBuffer_[1] = 0;
+  fakeStorage_.Write(offsetof(SectionSystemInfoBlock_t, blockSize), 2, pBuffer_);
   UpdateCRC(0);
-  ASSERT_THROW(uut.MountStep1(), eeprom_section_system::StorageSizeMismatchError);
+  ASSERT_THROW(uut_.MountStep1(), eeprom_section_system::StorageSizeMismatchError);
 
-  pBuffer[0] = (2 * gpcc::file_systems::eeprom_section_system::EEPROMSectionSystem::MaximumBlockSize) & 0xFFU;
-  pBuffer[1] = (2 * gpcc::file_systems::eeprom_section_system::EEPROMSectionSystem::MaximumBlockSize) >> 8U;
-  fakeStorage.Write(offsetof(SectionSystemInfoBlock_t, blockSize), 2, pBuffer);
+  pBuffer_[0] = (2 * gpcc::file_systems::eeprom_section_system::EEPROMSectionSystem::MaximumBlockSize) & 0xFFU;
+  pBuffer_[1] = (2 * gpcc::file_systems::eeprom_section_system::EEPROMSectionSystem::MaximumBlockSize) >> 8U;
+  fakeStorage_.Write(offsetof(SectionSystemInfoBlock_t, blockSize), 2, pBuffer_);
   UpdateCRC(0);
-  ASSERT_THROW(uut.MountStep1(), eeprom_section_system::InvalidHeaderError);
+  ASSERT_THROW(uut_.MountStep1(), eeprom_section_system::InvalidHeaderError);
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, MountStep1_SSIB_BadNumberOfBlocks)
 {
   Format(128);
-  uut.Unmount();
+  uut_.Unmount();
 
-  pBuffer[0] = ((storageSize / blockSize) + 1U) & 0xFFU;
-  pBuffer[1] = ((storageSize / blockSize) + 1U) >> 8U;
-  fakeStorage.Write(offsetof(SectionSystemInfoBlock_t, nBlocks), 2, pBuffer);
+  pBuffer_[0] = ((storageSize_ / blockSize_) + 1U) & 0xFFU;
+  pBuffer_[1] = ((storageSize_ / blockSize_) + 1U) >> 8U;
+  fakeStorage_.Write(offsetof(SectionSystemInfoBlock_t, nBlocks), 2, pBuffer_);
   UpdateCRC(0);
-  ASSERT_THROW(uut.MountStep1(), eeprom_section_system::StorageSizeMismatchError);
+  ASSERT_THROW(uut_.MountStep1(), eeprom_section_system::StorageSizeMismatchError);
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Format_WrongState)
 {
   // state is not_mounted
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::not_mounted, uut.GetState());
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::not_mounted, uut_.GetState());
   Format(128);
 
   // state is mounted
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::mounted, uut.GetState());
-  ASSERT_THROW(uut.Format(128), eeprom_section_system::InsufficientStateError);
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::mounted, uut_.GetState());
+  ASSERT_THROW(uut_.Format(128), eeprom_section_system::InsufficientStateError);
 
-  uut.Unmount();
+  uut_.Unmount();
 
   // bring uut into state "ro_mount"
-  uut.MountStep1();
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::ro_mount, uut.GetState());
-  ASSERT_THROW(uut.Format(128), eeprom_section_system::InsufficientStateError);
+  uut_.MountStep1();
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::ro_mount, uut_.GetState());
+  ASSERT_THROW(uut_.Format(128), eeprom_section_system::InsufficientStateError);
 
   // bring uut into state "defect"
-  uut.MountStep2();
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::mounted, uut.GetState());
-  fakeStorage.Invalidate(blockSize, blockSize);
+  uut_.MountStep2();
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::mounted, uut_.GetState());
+  fakeStorage_.Invalidate(blockSize_, blockSize_);
   RandomData data1(8,8);
-  ASSERT_THROW(data1.Write("Section1", false, uut), DataIntegrityError);
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::defect, uut.GetState());
-  ASSERT_THROW(uut.Format(128), eeprom_section_system::InsufficientStateError);
+  ASSERT_THROW(data1.Write("Section1", false, uut_), DataIntegrityError);
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::defect, uut_.GetState());
+  ASSERT_THROW(uut_.Format(128), eeprom_section_system::InsufficientStateError);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST(GPCC_FileSystems_EEPROMSectionSystem_Tests, Format_BlockSizeTooSmall)
 {
@@ -665,41 +665,41 @@ TEST(GPCC_FileSystems_EEPROMSectionSystem_Tests, FormatUnmountMount_WithoutPageS
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, GetState)
 {
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::not_mounted, uut.GetState());
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::not_mounted, uut_.GetState());
   Format(128);
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::mounted, uut.GetState());
-  uut.Unmount();
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::not_mounted, uut.GetState());
-  uut.MountStep1();
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::ro_mount, uut.GetState());
-  uut.Unmount();
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::mounted, uut_.GetState());
+  uut_.Unmount();
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::not_mounted, uut_.GetState());
+  uut_.MountStep1();
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::ro_mount, uut_.GetState());
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, MountStep2_CircleOfFreeBlocks)
 {
   Format(128);
-  uut.Unmount();
+  uut_.Unmount();
 
-  uint16_t const lastBlockIdx = ((storageSize / blockSize) - 1);
+  uint16_t const lastBlockIdx = ((storageSize_ / blockSize_) - 1);
 
   // make nextBlock of last free block refer to first free block
   UpdateNextBlock(lastBlockIdx, 1);
 
   // mount
-  ASSERT_NO_THROW(uut.MountStep1());
-  ASSERT_NO_THROW(uut.MountStep2());
+  ASSERT_NO_THROW(uut_.MountStep1());
+  ASSERT_NO_THROW(uut_.MountStep2());
 
   // check that nextBlock of last free block has been fixed
-  fakeStorage.Read(blockSize * lastBlockIdx + offsetof(CommonBlockHead_t, nextBlock), 2, pBuffer);
-  ASSERT_EQ(NOBLOCK & 0xFFU, pBuffer[0]);
-  ASSERT_EQ(NOBLOCK >> 8U, pBuffer[1]);
+  fakeStorage_.Read(blockSize_ * lastBlockIdx + offsetof(CommonBlockHead_t, nextBlock), 2, pBuffer_);
+  ASSERT_EQ(NOBLOCK & 0xFFU, pBuffer_[0]);
+  ASSERT_EQ(NOBLOCK >> 8U, pBuffer_[1]);
 
   // check that expected free storage is available
-  ASSERT_EQ(((storageSize / blockSize) - 2U) * (blockSize - (sizeof(DataBlock_t) + sizeof(uint16_t))), uut.GetFreeSpace());
+  ASSERT_EQ(((storageSize_ / blockSize_) - 2U) * (blockSize_ - (sizeof(DataBlock_t) + sizeof(uint16_t))), uut_.GetFreeSpace());
 
   // use it
-  BasicTest_WriteRead(&uut, blockSize, 1);
+  BasicTest_WriteRead(&uut_, blockSize_, 1);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, MountStep2_FreeBlocks1)
 {
@@ -708,9 +708,9 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, MountStep2_FreeBlocks1)
   // then one block + a few next blocks added to head of initial list
 
   Format(128);
-  uut.Unmount();
+  uut_.Unmount();
 
-  uint16_t const nBlocks = storageSize / blockSize;
+  uint16_t const nBlocks = storageSize_ / blockSize_;
   ASSERT_TRUE(nBlocks > 10);
 
   for (uint16_t idx = 1; idx < 10; idx++)
@@ -729,16 +729,16 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, MountStep2_FreeBlocks1)
   }
 
   // mount it
-  ASSERT_NO_THROW(uut.MountStep1());
-  ASSERT_NO_THROW(uut.MountStep2());
+  ASSERT_NO_THROW(uut_.MountStep1());
+  ASSERT_NO_THROW(uut_.MountStep2());
 
   // check that expected free storage is available
-  ASSERT_EQ(((storageSize / blockSize) - 2U) * (blockSize - (sizeof(DataBlock_t) + sizeof(uint16_t))), uut.GetFreeSpace());
+  ASSERT_EQ(((storageSize_ / blockSize_) - 2U) * (blockSize_ - (sizeof(DataBlock_t) + sizeof(uint16_t))), uut_.GetFreeSpace());
 
   // use it
-  BasicTest_WriteRead(&uut, blockSize, 1);
+  BasicTest_WriteRead(&uut_, blockSize_, 1);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, MountStep2_FreeBlocks2)
 {
@@ -747,9 +747,9 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, MountStep2_FreeBlocks2)
   // then one block added to head of initial list
 
   Format(128);
-  uut.Unmount();
+  uut_.Unmount();
 
-  uint16_t const nBlocks = storageSize / blockSize;
+  uint16_t const nBlocks = storageSize_ / blockSize_;
   ASSERT_TRUE(nBlocks > 3);
 
   for (uint16_t idx = 1; idx < nBlocks-1; idx++)
@@ -762,16 +762,16 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, MountStep2_FreeBlocks2)
   UpdateNextBlock(nBlocks-1, 1);
 
   // mount it
-  ASSERT_NO_THROW(uut.MountStep1());
-  ASSERT_NO_THROW(uut.MountStep2());
+  ASSERT_NO_THROW(uut_.MountStep1());
+  ASSERT_NO_THROW(uut_.MountStep2());
 
   // check that expected free storage is available
-  ASSERT_EQ(((storageSize / blockSize) - 2U) * (blockSize - (sizeof(DataBlock_t) + sizeof(uint16_t))), uut.GetFreeSpace());
+  ASSERT_EQ(((storageSize_ / blockSize_) - 2U) * (blockSize_ - (sizeof(DataBlock_t) + sizeof(uint16_t))), uut_.GetFreeSpace());
 
   // use it
-  BasicTest_WriteRead(&uut, blockSize, 1);
+  BasicTest_WriteRead(&uut_, blockSize_, 1);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, MountStep2_FreeBlocks3)
 {
@@ -780,9 +780,9 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, MountStep2_FreeBlocks3)
   // then one block + a few next blocks that are stand alone and marked as garbage
 
   Format(128);
-  uut.Unmount();
+  uut_.Unmount();
 
-  uint16_t const nBlocks = storageSize / blockSize;
+  uint16_t const nBlocks = storageSize_ / blockSize_;
   ASSERT_TRUE(nBlocks > 10);
 
   // blocks 5..7 shall be stand-alone free blocks
@@ -798,16 +798,16 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, MountStep2_FreeBlocks3)
   }
 
   // mount it
-  ASSERT_NO_THROW(uut.MountStep1());
-  ASSERT_NO_THROW(uut.MountStep2());
+  ASSERT_NO_THROW(uut_.MountStep1());
+  ASSERT_NO_THROW(uut_.MountStep2());
 
   // check that expected free storage is available
-  ASSERT_EQ(((storageSize / blockSize) - 2U) * (blockSize - (sizeof(DataBlock_t) + sizeof(uint16_t))), uut.GetFreeSpace());
+  ASSERT_EQ(((storageSize_ / blockSize_) - 2U) * (blockSize_ - (sizeof(DataBlock_t) + sizeof(uint16_t))), uut_.GetFreeSpace());
 
   // use it
-  BasicTest_WriteRead(&uut, blockSize, 1);
+  BasicTest_WriteRead(&uut_, blockSize_, 1);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, MountStep2_FreeBlocks4)
 {
@@ -816,9 +816,9 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, MountStep2_FreeBlocks4)
   // then one block stand alone and marked ad garbage
 
   Format(128);
-  uut.Unmount();
+  uut_.Unmount();
 
-  uint16_t const nBlocks = storageSize / blockSize;
+  uint16_t const nBlocks = storageSize_ / blockSize_;
   ASSERT_TRUE(nBlocks > 10);
 
   // block 5 shall be stand-alone free block
@@ -834,16 +834,16 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, MountStep2_FreeBlocks4)
   }
 
   // mount it
-  ASSERT_NO_THROW(uut.MountStep1());
-  ASSERT_NO_THROW(uut.MountStep2());
+  ASSERT_NO_THROW(uut_.MountStep1());
+  ASSERT_NO_THROW(uut_.MountStep2());
 
   // check that expected free storage is available
-  ASSERT_EQ(((storageSize / blockSize) - 2U) * (blockSize - (sizeof(DataBlock_t) + sizeof(uint16_t))), uut.GetFreeSpace());
+  ASSERT_EQ(((storageSize_ / blockSize_) - 2U) * (blockSize_ - (sizeof(DataBlock_t) + sizeof(uint16_t))), uut_.GetFreeSpace());
 
   // use it
-  BasicTest_WriteRead(&uut, blockSize, 1);
+  BasicTest_WriteRead(&uut_, blockSize_, 1);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, MountStep2_LastFreeBlockRefersToSection)
 {
@@ -851,27 +851,27 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, MountStep2_LastFreeBlockRefe
   // Last free block refers to a section. Mount_CheckLastFreeBlock must fix the block.
 
   Format(128);
-  uint16_t const nBlocks = storageSize / blockSize;
+  uint16_t const nBlocks = storageSize_ / blockSize_;
   RandomData dataBlock(8,8);
-  dataBlock.Write("Section", false, uut);
-  uut.Unmount();
+  dataBlock.Write("Section", false, uut_);
+  uut_.Unmount();
 
   // ensure that the section's data is located in block 2
-  fakeStorage.Read(blockSize * 2 + offsetof(CommonBlockHead_t, type), 1, pBuffer);
-  ASSERT_EQ(static_cast<uint8_t>(BlockTypes::sectionData), pBuffer[0]);
+  fakeStorage_.Read(blockSize_ * 2 + offsetof(CommonBlockHead_t, type), 1, pBuffer_);
+  ASSERT_EQ(static_cast<uint8_t>(BlockTypes::sectionData), pBuffer_[0]);
 
   UpdateNextBlock(nBlocks - 1, 2);
 
   // mount
-  ASSERT_NO_THROW(uut.MountStep1());
-  ASSERT_NO_THROW(uut.MountStep2());
+  ASSERT_NO_THROW(uut_.MountStep1());
+  ASSERT_NO_THROW(uut_.MountStep2());
 
-  dataBlock.Compare("Section", uut);
+  dataBlock.Compare("Section", uut_);
 
   // use it
-  BasicTest_WriteRead(&uut, blockSize, 1);
+  BasicTest_WriteRead(&uut_, blockSize_, 1);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, MountStep2_SectionWith2Heads_diffName_sameVersion)
 {
@@ -881,30 +881,30 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, MountStep2_SectionWith2Heads
   // Version of the section heads is the same.
 
   Format(128);
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
   RandomData data(8,8);
-  data.Write("Section1", false, uut);
-  ASSERT_EQ(2U, fakeStorage.writeAccessCnt);
-  uut.Unmount();
+  data.Write("Section1", false, uut_);
+  ASSERT_EQ(2U, fakeStorage_.writeAccessCnt);
+  uut_.Unmount();
 
   // create 2nd section head, uses head of 1st section as template
-  fakeStorage.Read(1U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Read(1U * blockSize_, blockSize_, pBuffer_);
 
-  pBuffer[sizeof(SectionHeadBlock_t) + 7U] = '2';           // Section1 -> Section2
-  pBuffer[offsetof(CommonBlockHead_t, sectionNameHash)]++;  // Update name hash
+  pBuffer_[sizeof(SectionHeadBlock_t) + 7U] = '2';           // Section1 -> Section2
+  pBuffer_[offsetof(CommonBlockHead_t, sectionNameHash)]++;  // Update name hash
 
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 0] = 1;   // set version LB
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 1] = 0;   // set version HB
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 0] = 1;   // set version LB
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 1] = 0;   // set version HB
 
-  fakeStorage.Write(3U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Write(3U * blockSize_, blockSize_, pBuffer_);
   UpdateCRC(3);
 
   // test
-  uut.MountStep1();
-  ASSERT_THROW(uut.MountStep2(), BlockLinkageError);
+  uut_.MountStep1();
+  ASSERT_THROW(uut_.MountStep2(), BlockLinkageError);
 
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::defect, uut.GetState());
-  uut.Unmount();
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::defect, uut_.GetState());
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, MountStep2_SectionWith2Heads_diffName_2ndOlder)
 {
@@ -914,35 +914,35 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, MountStep2_SectionWith2Heads
   // The second section head has an lower version. No version wrap-around.
 
   Format(128);
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
   RandomData data(8,8);
-  data.Write("Section1", false, uut);
-  ASSERT_EQ(2U, fakeStorage.writeAccessCnt);
-  size_t const freeSpace = uut.GetFreeSpace();
-  uut.Unmount();
+  data.Write("Section1", false, uut_);
+  ASSERT_EQ(2U, fakeStorage_.writeAccessCnt);
+  size_t const freeSpace = uut_.GetFreeSpace();
+  uut_.Unmount();
 
   // create 2nd section head, uses head of 1st section as template
-  fakeStorage.Read(1U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Read(1U * blockSize_, blockSize_, pBuffer_);
 
-  pBuffer[sizeof(SectionHeadBlock_t) + 7U] = '2';           // Section1 -> Section2
-  pBuffer[offsetof(CommonBlockHead_t, sectionNameHash)]++;  // Update name hash
+  pBuffer_[sizeof(SectionHeadBlock_t) + 7U] = '2';           // Section1 -> Section2
+  pBuffer_[offsetof(CommonBlockHead_t, sectionNameHash)]++;  // Update name hash
 
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 0] = 0;   // set version LB
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 1] = 0;   // set version HB
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 0] = 0;   // set version LB
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 1] = 0;   // set version HB
 
-  fakeStorage.Write(3U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Write(3U * blockSize_, blockSize_, pBuffer_);
   UpdateCRC(3);
 
   // test
-  uut.MountStep1();
-  uut.MountStep2();
+  uut_.MountStep1();
+  uut_.MountStep2();
 
-  data.Compare("Section1", uut);
-  ASSERT_THROW(data.Compare("Section2", uut), gpcc::file_systems::NoSuchFileError);
-  ASSERT_EQ(freeSpace, uut.GetFreeSpace());
+  data.Compare("Section1", uut_);
+  ASSERT_THROW(data.Compare("Section2", uut_), gpcc::file_systems::NoSuchFileError);
+  ASSERT_EQ(freeSpace, uut_.GetFreeSpace());
 
-  BasicTest_WriteRead(&uut, blockSize, 1);
-  uut.Unmount();
+  BasicTest_WriteRead(&uut_, blockSize_, 1);
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, MountStep2_SectionWith2Heads_diffName_2ndNewer)
 {
@@ -952,35 +952,35 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, MountStep2_SectionWith2Heads
   // The second section head has an higher version. No version wrap-around.
 
   Format(128);
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
   RandomData data(8,8);
-  data.Write("Section1", false, uut);
-  ASSERT_EQ(2U, fakeStorage.writeAccessCnt);
-  size_t const freeSpace = uut.GetFreeSpace();
-  uut.Unmount();
+  data.Write("Section1", false, uut_);
+  ASSERT_EQ(2U, fakeStorage_.writeAccessCnt);
+  size_t const freeSpace = uut_.GetFreeSpace();
+  uut_.Unmount();
 
   // create 2nd section head, uses head of 1st section as template
-  fakeStorage.Read(1U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Read(1U * blockSize_, blockSize_, pBuffer_);
 
-  pBuffer[sizeof(SectionHeadBlock_t) + 7U] = '2';           // Section1 -> Section2
-  pBuffer[offsetof(CommonBlockHead_t, sectionNameHash)]++;  // Update name hash
+  pBuffer_[sizeof(SectionHeadBlock_t) + 7U] = '2';           // Section1 -> Section2
+  pBuffer_[offsetof(CommonBlockHead_t, sectionNameHash)]++;  // Update name hash
 
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 0] = 2;   // set version LB
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 1] = 0;   // set version HB
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 0] = 2;   // set version LB
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 1] = 0;   // set version HB
 
-  fakeStorage.Write(3U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Write(3U * blockSize_, blockSize_, pBuffer_);
   UpdateCRC(3);
 
   // test
-  uut.MountStep1();
-  uut.MountStep2();
+  uut_.MountStep1();
+  uut_.MountStep2();
 
-  ASSERT_THROW(data.Compare("Section1", uut), gpcc::file_systems::NoSuchFileError);
-  data.Compare("Section2", uut);
-  ASSERT_EQ(freeSpace, uut.GetFreeSpace());
+  ASSERT_THROW(data.Compare("Section1", uut_), gpcc::file_systems::NoSuchFileError);
+  data.Compare("Section2", uut_);
+  ASSERT_EQ(freeSpace, uut_.GetFreeSpace());
 
-  BasicTest_WriteRead(&uut, blockSize, 1);
-  uut.Unmount();
+  BasicTest_WriteRead(&uut_, blockSize_, 1);
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, MountStep2_SectionWith2Heads_diffName_2ndOlder_WithWrapAround)
 {
@@ -990,42 +990,42 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, MountStep2_SectionWith2Heads
   // The second section head has an lower version. There is a version wrap-around.
 
   Format(128);
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
   RandomData data(8,8);
-  data.Write("Section1", false, uut);
-  ASSERT_EQ(2U, fakeStorage.writeAccessCnt);
-  size_t const freeSpace = uut.GetFreeSpace();
-  uut.Unmount();
+  data.Write("Section1", false, uut_);
+  ASSERT_EQ(2U, fakeStorage_.writeAccessCnt);
+  size_t const freeSpace = uut_.GetFreeSpace();
+  uut_.Unmount();
 
   // set version of first section head
-  fakeStorage.Read(1U * blockSize, blockSize, pBuffer);
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 0] = 0;
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 1] = 0;
-  fakeStorage.Write(1U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Read(1U * blockSize_, blockSize_, pBuffer_);
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 0] = 0;
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 1] = 0;
+  fakeStorage_.Write(1U * blockSize_, blockSize_, pBuffer_);
   UpdateCRC(1);
 
   // create 2nd section head, uses head of 1st section as template
-  fakeStorage.Read(1U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Read(1U * blockSize_, blockSize_, pBuffer_);
 
-  pBuffer[sizeof(SectionHeadBlock_t) + 7U] = '2';           // Section1 -> Section2
-  pBuffer[offsetof(CommonBlockHead_t, sectionNameHash)]++;  // Update name hash
+  pBuffer_[sizeof(SectionHeadBlock_t) + 7U] = '2';           // Section1 -> Section2
+  pBuffer_[offsetof(CommonBlockHead_t, sectionNameHash)]++;  // Update name hash
 
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 0] = 0xFF; // set version LB
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 1] = 0xFF; // set version HB
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 0] = 0xFF; // set version LB
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 1] = 0xFF; // set version HB
 
-  fakeStorage.Write(3U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Write(3U * blockSize_, blockSize_, pBuffer_);
   UpdateCRC(3);
 
   // test
-  uut.MountStep1();
-  uut.MountStep2();
+  uut_.MountStep1();
+  uut_.MountStep2();
 
-  data.Compare("Section1", uut);
-  ASSERT_THROW(data.Compare("Section2", uut), gpcc::file_systems::NoSuchFileError);
-  ASSERT_EQ(freeSpace, uut.GetFreeSpace());
+  data.Compare("Section1", uut_);
+  ASSERT_THROW(data.Compare("Section2", uut_), gpcc::file_systems::NoSuchFileError);
+  ASSERT_EQ(freeSpace, uut_.GetFreeSpace());
 
-  BasicTest_WriteRead(&uut, blockSize, 1);
-  uut.Unmount();
+  BasicTest_WriteRead(&uut_, blockSize_, 1);
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, MountStep2_SectionWith2Heads_diffName_2ndNewer_WithWrapAround)
 {
@@ -1035,42 +1035,42 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, MountStep2_SectionWith2Heads
   // The second section head has an higher version. There is a version wrap-around.
 
   Format(128);
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
   RandomData data(8,8);
-  data.Write("Section1", false, uut);
-  ASSERT_EQ(2U, fakeStorage.writeAccessCnt);
-  size_t const freeSpace = uut.GetFreeSpace();
-  uut.Unmount();
+  data.Write("Section1", false, uut_);
+  ASSERT_EQ(2U, fakeStorage_.writeAccessCnt);
+  size_t const freeSpace = uut_.GetFreeSpace();
+  uut_.Unmount();
 
   // set version of first section head
-  fakeStorage.Read(1U * blockSize, blockSize, pBuffer);
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 0] = 0xFF;
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 1] = 0xFF;
-  fakeStorage.Write(1U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Read(1U * blockSize_, blockSize_, pBuffer_);
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 0] = 0xFF;
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 1] = 0xFF;
+  fakeStorage_.Write(1U * blockSize_, blockSize_, pBuffer_);
   UpdateCRC(1);
 
   // create 2nd section head, uses head of 1st section as template
-  fakeStorage.Read(1U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Read(1U * blockSize_, blockSize_, pBuffer_);
 
-  pBuffer[sizeof(SectionHeadBlock_t) + 7U] = '2';           // Section1 -> Section2
-  pBuffer[offsetof(CommonBlockHead_t, sectionNameHash)]++;  // Update name hash
+  pBuffer_[sizeof(SectionHeadBlock_t) + 7U] = '2';           // Section1 -> Section2
+  pBuffer_[offsetof(CommonBlockHead_t, sectionNameHash)]++;  // Update name hash
 
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 0] = 0;   // set version LB
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 1] = 0;   // set version HB
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 0] = 0;   // set version LB
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 1] = 0;   // set version HB
 
-  fakeStorage.Write(3U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Write(3U * blockSize_, blockSize_, pBuffer_);
   UpdateCRC(3);
 
   // test
-  uut.MountStep1();
-  uut.MountStep2();
+  uut_.MountStep1();
+  uut_.MountStep2();
 
-  ASSERT_THROW(data.Compare("Section1", uut), gpcc::file_systems::NoSuchFileError);
-  data.Compare("Section2", uut);
-  ASSERT_EQ(freeSpace, uut.GetFreeSpace());
+  ASSERT_THROW(data.Compare("Section1", uut_), gpcc::file_systems::NoSuchFileError);
+  data.Compare("Section2", uut_);
+  ASSERT_EQ(freeSpace, uut_.GetFreeSpace());
 
-  BasicTest_WriteRead(&uut, blockSize, 1);
-  uut.Unmount();
+  BasicTest_WriteRead(&uut_, blockSize_, 1);
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, MountStep2_SectionWith2Heads_sameName_sameVersion)
 {
@@ -1080,32 +1080,32 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, MountStep2_SectionWith2Heads
   // Name and version of the section heads are the same.
 
   Format(128);
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
   RandomData data1(8,8);
-  data1.Write("Section1", false, uut);
+  data1.Write("Section1", false, uut_);
   RandomData data2(8,8);
-  data2.Write("Section2", false, uut);
-  ASSERT_EQ(4U, fakeStorage.writeAccessCnt);
-  uut.Unmount();
+  data2.Write("Section2", false, uut_);
+  ASSERT_EQ(4U, fakeStorage_.writeAccessCnt);
+  uut_.Unmount();
 
   // update head of 2nd section
-  fakeStorage.Read(3U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Read(3U * blockSize_, blockSize_, pBuffer_);
 
-  pBuffer[sizeof(SectionHeadBlock_t) + 7] = '1';            // Section2 -> Section1
-  pBuffer[offsetof(CommonBlockHead_t, sectionNameHash)]--;  // Update name hash
+  pBuffer_[sizeof(SectionHeadBlock_t) + 7] = '1';            // Section2 -> Section1
+  pBuffer_[offsetof(CommonBlockHead_t, sectionNameHash)]--;  // Update name hash
 
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 0] = 1;   // set version LB
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 1] = 0;   // set version HB
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 0] = 1;   // set version LB
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 1] = 0;   // set version HB
 
-  fakeStorage.Write(3U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Write(3U * blockSize_, blockSize_, pBuffer_);
   UpdateCRC(3);
 
   // test
-  uut.MountStep1();
-  ASSERT_THROW(uut.MountStep2(), BlockLinkageError);
+  uut_.MountStep1();
+  ASSERT_THROW(uut_.MountStep2(), BlockLinkageError);
 
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::defect, uut.GetState());
-  uut.Unmount();
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::defect, uut_.GetState());
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, MountStep2_SectionWith2Heads_sameName_2ndOlder)
 {
@@ -1115,36 +1115,36 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, MountStep2_SectionWith2Heads
   // Names are the same, version of the second section is lower. No version wrap-around.
 
   Format(128);
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
   RandomData data1(8,8);
-  data1.Write("Section1", false, uut);
-  size_t const freeSpace = uut.GetFreeSpace();
+  data1.Write("Section1", false, uut_);
+  size_t const freeSpace = uut_.GetFreeSpace();
   RandomData data2(8,8);
-  data2.Write("Section2", false, uut);
-  ASSERT_EQ(4U, fakeStorage.writeAccessCnt);
-  uut.Unmount();
+  data2.Write("Section2", false, uut_);
+  ASSERT_EQ(4U, fakeStorage_.writeAccessCnt);
+  uut_.Unmount();
 
   // update head of 2nd section
-  fakeStorage.Read(3U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Read(3U * blockSize_, blockSize_, pBuffer_);
 
-  pBuffer[sizeof(SectionHeadBlock_t) + 7] = '1';            // Section2 -> Section1
-  pBuffer[offsetof(CommonBlockHead_t, sectionNameHash)]--;  // Update name hash
+  pBuffer_[sizeof(SectionHeadBlock_t) + 7] = '1';            // Section2 -> Section1
+  pBuffer_[offsetof(CommonBlockHead_t, sectionNameHash)]--;  // Update name hash
 
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 0] = 0;   // set version LB
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 1] = 0;   // set version HB
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 0] = 0;   // set version LB
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 1] = 0;   // set version HB
 
-  fakeStorage.Write(3U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Write(3U * blockSize_, blockSize_, pBuffer_);
   UpdateCRC(3);
 
   // test
-  uut.MountStep1();
-  uut.MountStep2();
+  uut_.MountStep1();
+  uut_.MountStep2();
 
-  data1.Compare("Section1", uut);
-  ASSERT_EQ(freeSpace, uut.GetFreeSpace());
+  data1.Compare("Section1", uut_);
+  ASSERT_EQ(freeSpace, uut_.GetFreeSpace());
 
-  BasicTest_WriteRead(&uut, blockSize, 1);
-  uut.Unmount();
+  BasicTest_WriteRead(&uut_, blockSize_, 1);
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, MountStep2_SectionWith2Heads_sameName_2ndNewer)
 {
@@ -1154,36 +1154,36 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, MountStep2_SectionWith2Heads
   // Names are the same, version of the second section is higher. No version wrap-around.
 
   Format(128);
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
   RandomData data1(8,8);
-  data1.Write("Section1", false, uut);
-  size_t const freeSpace = uut.GetFreeSpace();
+  data1.Write("Section1", false, uut_);
+  size_t const freeSpace = uut_.GetFreeSpace();
   RandomData data2(8,8);
-  data2.Write("Section2", false, uut);
-  ASSERT_EQ(4U, fakeStorage.writeAccessCnt);
-  uut.Unmount();
+  data2.Write("Section2", false, uut_);
+  ASSERT_EQ(4U, fakeStorage_.writeAccessCnt);
+  uut_.Unmount();
 
   // update head of 2nd section
-  fakeStorage.Read(3U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Read(3U * blockSize_, blockSize_, pBuffer_);
 
-  pBuffer[sizeof(SectionHeadBlock_t) + 7] = '1';            // Section2 -> Section1
-  pBuffer[offsetof(CommonBlockHead_t, sectionNameHash)]--;  // Update name hash
+  pBuffer_[sizeof(SectionHeadBlock_t) + 7] = '1';            // Section2 -> Section1
+  pBuffer_[offsetof(CommonBlockHead_t, sectionNameHash)]--;  // Update name hash
 
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 0] = 2;   // set version LB
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 1] = 0;   // set version HB
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 0] = 2;   // set version LB
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 1] = 0;   // set version HB
 
-  fakeStorage.Write(3U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Write(3U * blockSize_, blockSize_, pBuffer_);
   UpdateCRC(3);
 
   // test
-  uut.MountStep1();
-  uut.MountStep2();
+  uut_.MountStep1();
+  uut_.MountStep2();
 
-  data2.Compare("Section1", uut);
-  ASSERT_EQ(freeSpace, uut.GetFreeSpace());
+  data2.Compare("Section1", uut_);
+  ASSERT_EQ(freeSpace, uut_.GetFreeSpace());
 
-  BasicTest_WriteRead(&uut, blockSize, 1);
-  uut.Unmount();
+  BasicTest_WriteRead(&uut_, blockSize_, 1);
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, MountStep2_SectionWith2Heads_sameName_2ndOlder_WithWrapAround)
 {
@@ -1193,43 +1193,43 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, MountStep2_SectionWith2Heads
   // Names are the same, version of the second section is lower. With version wrap-around.
 
   Format(128);
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
   RandomData data1(8,8);
-  data1.Write("Section1", false, uut);
-  size_t const freeSpace = uut.GetFreeSpace();
+  data1.Write("Section1", false, uut_);
+  size_t const freeSpace = uut_.GetFreeSpace();
   RandomData data2(8,8);
-  data2.Write("Section2", false, uut);
-  ASSERT_EQ(4U, fakeStorage.writeAccessCnt);
-  uut.Unmount();
+  data2.Write("Section2", false, uut_);
+  ASSERT_EQ(4U, fakeStorage_.writeAccessCnt);
+  uut_.Unmount();
 
   // set version of first section
-  fakeStorage.Read(1U * blockSize, blockSize, pBuffer);
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 0] = 0x00;
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 1] = 0x00;
-  fakeStorage.Write(1U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Read(1U * blockSize_, blockSize_, pBuffer_);
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 0] = 0x00;
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 1] = 0x00;
+  fakeStorage_.Write(1U * blockSize_, blockSize_, pBuffer_);
   UpdateCRC(1);
 
   // update head of 2nd section
-  fakeStorage.Read(3U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Read(3U * blockSize_, blockSize_, pBuffer_);
 
-  pBuffer[sizeof(SectionHeadBlock_t) + 7] = '1';            // Section2 -> Section1
-  pBuffer[offsetof(CommonBlockHead_t, sectionNameHash)]--;  // Update name hash
+  pBuffer_[sizeof(SectionHeadBlock_t) + 7] = '1';            // Section2 -> Section1
+  pBuffer_[offsetof(CommonBlockHead_t, sectionNameHash)]--;  // Update name hash
 
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 0] = 0xFF; // set version LB
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 1] = 0xFF; // set version HB
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 0] = 0xFF; // set version LB
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 1] = 0xFF; // set version HB
 
-  fakeStorage.Write(3U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Write(3U * blockSize_, blockSize_, pBuffer_);
   UpdateCRC(3);
 
   // test
-  uut.MountStep1();
-  uut.MountStep2();
+  uut_.MountStep1();
+  uut_.MountStep2();
 
-  data1.Compare("Section1", uut);
-  ASSERT_EQ(freeSpace, uut.GetFreeSpace());
+  data1.Compare("Section1", uut_);
+  ASSERT_EQ(freeSpace, uut_.GetFreeSpace());
 
-  BasicTest_WriteRead(&uut, blockSize, 1);
-  uut.Unmount();
+  BasicTest_WriteRead(&uut_, blockSize_, 1);
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, MountStep2_SectionWith2Heads_sameName_2ndNewer_WithWrapAround)
 {
@@ -1239,43 +1239,43 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, MountStep2_SectionWith2Heads
   // Names are the same, version of the second section is higher. With version wrap-around.
 
   Format(128);
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
   RandomData data1(8,8);
-  data1.Write("Section1", false, uut);
-  size_t const freeSpace = uut.GetFreeSpace();
+  data1.Write("Section1", false, uut_);
+  size_t const freeSpace = uut_.GetFreeSpace();
   RandomData data2(8,8);
-  data2.Write("Section2", false, uut);
-  ASSERT_EQ(4U, fakeStorage.writeAccessCnt);
-  uut.Unmount();
+  data2.Write("Section2", false, uut_);
+  ASSERT_EQ(4U, fakeStorage_.writeAccessCnt);
+  uut_.Unmount();
 
   // set version of first section
-  fakeStorage.Read(1U * blockSize, blockSize, pBuffer);
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 0] = 0xFF;
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 1] = 0xFF;
-  fakeStorage.Write(1U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Read(1U * blockSize_, blockSize_, pBuffer_);
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 0] = 0xFF;
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 1] = 0xFF;
+  fakeStorage_.Write(1U * blockSize_, blockSize_, pBuffer_);
   UpdateCRC(1);
 
   // update head of 2nd section
-  fakeStorage.Read(3U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Read(3U * blockSize_, blockSize_, pBuffer_);
 
-  pBuffer[sizeof(SectionHeadBlock_t) + 7] = '1';            // Section2 -> Section1
-  pBuffer[offsetof(CommonBlockHead_t, sectionNameHash)]--;  // Update name hash
+  pBuffer_[sizeof(SectionHeadBlock_t) + 7] = '1';            // Section2 -> Section1
+  pBuffer_[offsetof(CommonBlockHead_t, sectionNameHash)]--;  // Update name hash
 
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 0] = 0x00; // set version LB
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 1] = 0x00; // set version HB
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 0] = 0x00; // set version LB
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 1] = 0x00; // set version HB
 
-  fakeStorage.Write(3U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Write(3U * blockSize_, blockSize_, pBuffer_);
   UpdateCRC(3);
 
   // test
-  uut.MountStep1();
-  uut.MountStep2();
+  uut_.MountStep1();
+  uut_.MountStep2();
 
-  data2.Compare("Section1", uut);
-  ASSERT_EQ(freeSpace, uut.GetFreeSpace());
+  data2.Compare("Section1", uut_);
+  ASSERT_EQ(freeSpace, uut_.GetFreeSpace());
 
-  BasicTest_WriteRead(&uut, blockSize, 1);
-  uut.Unmount();
+  BasicTest_WriteRead(&uut_, blockSize_, 1);
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Create_BadNames)
 {
@@ -1283,46 +1283,46 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Create_BadNames)
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
 
-  ASSERT_THROW(spISW = uut.Create("", false), std::invalid_argument);
-  ASSERT_THROW(spISW = uut.Create(" Sec1", false), std::invalid_argument);
-  ASSERT_THROW(spISW = uut.Create("Sec2 ", false), std::invalid_argument);
-  ASSERT_THROW(spISW = uut.Create(" Sec3 ", false), std::invalid_argument);
-  ASSERT_THROW(spISW = uut.Create(" ", false), std::invalid_argument);
+  ASSERT_THROW(spISW = uut_.Create("", false), std::invalid_argument);
+  ASSERT_THROW(spISW = uut_.Create(" Sec1", false), std::invalid_argument);
+  ASSERT_THROW(spISW = uut_.Create("Sec2 ", false), std::invalid_argument);
+  ASSERT_THROW(spISW = uut_.Create(" Sec3 ", false), std::invalid_argument);
+  ASSERT_THROW(spISW = uut_.Create(" ", false), std::invalid_argument);
 
-  ASSERT_NO_THROW(spISW = uut.Create("A", false));
-  ASSERT_NO_THROW(spISW = uut.Create("A B", false));
+  ASSERT_NO_THROW(spISW = uut_.Create("A", false));
+  ASSERT_NO_THROW(spISW = uut_.Create("A B", false));
   spISW.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Create_WrongState)
 {
   Format(128);
-  uut.Unmount();
+  uut_.Unmount();
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
 
   // not_mounted
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::not_mounted, uut.GetState());
-  ASSERT_THROW(spISW = uut.Create("Sec1", false), InsufficientStateError);
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::not_mounted, uut_.GetState());
+  ASSERT_THROW(spISW = uut_.Create("Sec1", false), InsufficientStateError);
 
   // ro_mount
-  uut.MountStep1();
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::ro_mount, uut.GetState());
-  ASSERT_THROW(spISW = uut.Create("Sec1", false), InsufficientStateError);
+  uut_.MountStep1();
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::ro_mount, uut_.GetState());
+  ASSERT_THROW(spISW = uut_.Create("Sec1", false), InsufficientStateError);
 
   // mounted
-  uut.MountStep2();
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::mounted, uut.GetState());
+  uut_.MountStep2();
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::mounted, uut_.GetState());
 
   // defect
-  fakeStorage.Invalidate(blockSize * 1U, blockSize);
-  ASSERT_THROW(spISW = uut.Create("Sec1", false), InvalidHeaderError);
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::defect, uut.GetState());
+  fakeStorage_.Invalidate(blockSize_ * 1U, blockSize_);
+  ASSERT_THROW(spISW = uut_.Create("Sec1", false), InvalidHeaderError);
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::defect, uut_.GetState());
 
-  ASSERT_THROW(spISW = uut.Create("Sec1", false), InsufficientStateError);
+  ASSERT_THROW(spISW = uut_.Create("Sec1", false), InsufficientStateError);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Create_SectionLocked)
 {
@@ -1332,16 +1332,16 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Create_SectionLocked)
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW2;
 
   // locked by writer
-  spISW1 = uut.Create("Sec1", false);
-  ASSERT_THROW(spISW2 = uut.Create("Sec1", false), gpcc::file_systems::FileAlreadyAccessedError);
+  spISW1 = uut_.Create("Sec1", false);
+  ASSERT_THROW(spISW2 = uut_.Create("Sec1", false), gpcc::file_systems::FileAlreadyAccessedError);
   spISW1->Close();
 
   // locked by reader
-  auto spISR1 = uut.Open("Sec1");
-  ASSERT_THROW(spISW2 = uut.Create("Sec1", false), gpcc::file_systems::FileAlreadyAccessedError);
+  auto spISR1 = uut_.Open("Sec1");
+  ASSERT_THROW(spISW2 = uut_.Create("Sec1", false), gpcc::file_systems::FileAlreadyAccessedError);
   spISR1->Close();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Create_SectionAlreadyExistingAndNoOverwrite)
 {
@@ -1350,77 +1350,77 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Create_SectionAlreadyExistin
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW1;
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW2;
 
-  spISW1 = uut.Create("Sec1", false);
+  spISW1 = uut_.Create("Sec1", false);
   spISW1->Close();
 
-  ASSERT_THROW(spISW2 = uut.Create("Sec1", false), gpcc::file_systems::FileAlreadyExistingError);
+  ASSERT_THROW(spISW2 = uut_.Create("Sec1", false), gpcc::file_systems::FileAlreadyExistingError);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Create_NoFreeBlocks)
 {
   Format(128);
 
-  size_t const n = uut.GetFreeSpace();
+  size_t const n = uut_.GetFreeSpace();
   ASSERT_TRUE(n > 8U);
   RandomData data(n - 8U, n - 8U);
-  data.Write("Section1", false, uut);
+  data.Write("Section1", false, uut_);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW1;
-  ASSERT_THROW(spISW1 = uut.Create("Section2", false), gpcc::file_systems::InsufficientSpaceError);
+  ASSERT_THROW(spISW1 = uut_.Create("Section2", false), gpcc::file_systems::InsufficientSpaceError);
 
-  data.Compare("Section1", uut);
+  data.Compare("Section1", uut_);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Create_OneFreeBlock)
 {
   Format(128);
 
-  size_t const bytesPerBlock = blockSize - (sizeof(DataBlock_t) + sizeof(uint16_t));
-  size_t const n = uut.GetFreeSpace();
+  size_t const bytesPerBlock = blockSize_ - (sizeof(DataBlock_t) + sizeof(uint16_t));
+  size_t const n = uut_.GetFreeSpace();
   ASSERT_TRUE(n > 8U + bytesPerBlock);
   RandomData data(n - (8U + bytesPerBlock), n - (8U + bytesPerBlock));
-  data.Write("Section1", false, uut);
+  data.Write("Section1", false, uut_);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW1;
-  ASSERT_THROW(spISW1 = uut.Create("Section2", false), gpcc::file_systems::InsufficientSpaceError);
+  ASSERT_THROW(spISW1 = uut_.Create("Section2", false), gpcc::file_systems::InsufficientSpaceError);
 
-  data.Compare("Section1", uut);
+  data.Compare("Section1", uut_);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Create_TwoFreeBlocks)
 {
   Format(128);
 
-  size_t const bytesPerBlock = blockSize - (sizeof(DataBlock_t) + sizeof(uint16_t));
+  size_t const bytesPerBlock = blockSize_ - (sizeof(DataBlock_t) + sizeof(uint16_t));
   ASSERT_TRUE(bytesPerBlock > 8U);
-  size_t const n = uut.GetFreeSpace();
+  size_t const n = uut_.GetFreeSpace();
   ASSERT_TRUE(n > 8U + 2U * bytesPerBlock);
   RandomData data(n - (8U + 2U * bytesPerBlock), n - (8U + 2U * bytesPerBlock));
-  data.Write("Section1", false, uut);
+  data.Write("Section1", false, uut_);
 
   RandomData data2(bytesPerBlock - 8, bytesPerBlock - 8);
-  data2.Write("Section2", false, uut);
+  data2.Write("Section2", false, uut_);
 
-  data.Compare("Section1", uut);
-  data2.Compare("Section2", uut);
+  data.Compare("Section1", uut_);
+  data2.Compare("Section2", uut_);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Create_OverwriteExistingSection)
 {
   Format(128);
 
-  auto spISW = uut.Create("Section1", false);
+  auto spISW = uut_.Create("Section1", false);
   *spISW << static_cast<uint8_t>(0xDE);
   *spISW << static_cast<uint8_t>(0xAD);
   *spISW << static_cast<uint8_t>(0xBE);
   *spISW << static_cast<uint8_t>(0xEF);
   spISW->Close();
 
-  spISW = uut.Create("Section1", true);
+  spISW = uut_.Create("Section1", true);
   *spISW << static_cast<uint8_t>(0x12);
   *spISW << static_cast<uint8_t>(0x34);
   *spISW << static_cast<uint8_t>(0x56);
@@ -1429,7 +1429,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Create_OverwriteExistingSect
 
   spISW.reset();
 
-  auto spISR = uut.Open("Section1");
+  auto spISR = uut_.Open("Section1");
   uint8_t data[4];
   *spISR >> data[0];
   *spISR >> data[1];
@@ -1443,11 +1443,11 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Create_OverwriteExistingSect
 
   spISR->Close();
 
-  ASSERT_EQ(((storageSize / blockSize) - 4) * (blockSize - (sizeof(DataBlock_t) + sizeof(uint16_t))), uut.GetFreeSpace());
+  ASSERT_EQ(((storageSize_ / blockSize_) - 4) * (blockSize_ - (sizeof(DataBlock_t) + sizeof(uint16_t))), uut_.GetFreeSpace());
 
-  BasicTest_WriteRead(&uut, blockSize, 1);
+  BasicTest_WriteRead(&uut_, blockSize_, 1);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Create_VersionWrapAroundDuringOverwrite)
 {
@@ -1457,40 +1457,40 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Create_VersionWrapAroundDuri
   Format(128);
 
   // create first section
-  fakeStorage.writeAccessCnt = 0;
-  auto spISW = uut.Create("Section1", false);
+  fakeStorage_.writeAccessCnt = 0;
+  auto spISW = uut_.Create("Section1", false);
   *spISW << static_cast<uint8_t>(0xDE);
   *spISW << static_cast<uint8_t>(0xAD);
   *spISW << static_cast<uint8_t>(0xBE);
   *spISW << static_cast<uint8_t>(0xEF);
   spISW->Close();
-  ASSERT_EQ(2U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(2U, fakeStorage_.writeAccessCnt);
 
   // set version of first section
-  fakeStorage.Read(1U * blockSize, blockSize, pBuffer);
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 0] = 0xFF;
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 1] = 0xFF;
-  fakeStorage.Write(1U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Read(1U * blockSize_, blockSize_, pBuffer_);
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 0] = 0xFF;
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 1] = 0xFF;
+  fakeStorage_.Write(1U * blockSize_, blockSize_, pBuffer_);
   UpdateCRC(1);
 
   // create second section, overwrites first section
-  fakeStorage.writeAccessCnt = 0;
-  spISW = uut.Create("Section1", true);
+  fakeStorage_.writeAccessCnt = 0;
+  spISW = uut_.Create("Section1", true);
   *spISW << static_cast<uint8_t>(0x12);
   *spISW << static_cast<uint8_t>(0x34);
   *spISW << static_cast<uint8_t>(0x56);
   *spISW << static_cast<uint8_t>(0x78);
   spISW->Close();
-  ASSERT_EQ(5U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(5U, fakeStorage_.writeAccessCnt);
 
   spISW.reset();
 
   // check version of 2nd section
-  fakeStorage.Read(3U * blockSize, blockSize, pBuffer);
-  ASSERT_EQ(0x00, pBuffer[offsetof(SectionHeadBlock_t, version) + 0]);
-  ASSERT_EQ(0x00, pBuffer[offsetof(SectionHeadBlock_t, version) + 1]);
+  fakeStorage_.Read(3U * blockSize_, blockSize_, pBuffer_);
+  ASSERT_EQ(0x00, pBuffer_[offsetof(SectionHeadBlock_t, version) + 0]);
+  ASSERT_EQ(0x00, pBuffer_[offsetof(SectionHeadBlock_t, version) + 1]);
 
-  auto spISR = uut.Open("Section1");
+  auto spISR = uut_.Open("Section1");
   uint8_t data[4];
   *spISR >> data[0];
   *spISR >> data[1];
@@ -1504,32 +1504,32 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Create_VersionWrapAroundDuri
 
   spISR->Close();
 
-  ASSERT_EQ(((storageSize / blockSize) - 4) * (blockSize - (sizeof(DataBlock_t) + sizeof(uint16_t))), uut.GetFreeSpace());
+  ASSERT_EQ(((storageSize_ / blockSize_) - 4) * (blockSize_ - (sizeof(DataBlock_t) + sizeof(uint16_t))), uut_.GetFreeSpace());
 
-  BasicTest_WriteRead(&uut, blockSize, 1);
+  BasicTest_WriteRead(&uut_, blockSize_, 1);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionWriter_RemainingCapacitySupported)
 {
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Test.dat", false);
+  spISW = uut_.Create("Test.dat", false);
 
   ASSERT_FALSE(spISW->IsRemainingCapacitySupported());
 
   spISW->Close();
   spISW.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionWriter_RemainingCapacity)
 {
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Test.dat", false);
+  spISW = uut_.Create("Test.dat", false);
 
   EXPECT_THROW((void)spISW->RemainingCapacity(), std::logic_error);
 
@@ -1538,20 +1538,20 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionWriter_RemainingCapac
 
   spISW.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionWriter_DestroyWithoutClose)
 {
   Format(128);
 
-  auto spISW = uut.Create("Section1", false);
+  auto spISW = uut_.Create("Section1", false);
   *spISW << static_cast<uint8_t>(0xDE);
   *spISW << static_cast<uint8_t>(0xAD);
   *spISW << static_cast<uint8_t>(0xBE);
   *spISW << static_cast<uint8_t>(0xEF);
   spISW.reset(); // note: no Close()
 
-  auto spISR = uut.Open("Section1");
+  auto spISR = uut_.Open("Section1");
   uint8_t data[4];
   *spISR >> data[0];
   *spISR >> data[1];
@@ -1565,13 +1565,13 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionWriter_DestroyWithout
 
   spISR->Close();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionWriter_WriteStrings)
 {
   Format(128);
 
-  auto spISW = uut.Create("Section1", false);
+  auto spISW = uut_.Create("Section1", false);
   spISW->Write_string("Text");
   spISW->Write_string("");
   spISW->Write_line("Line");
@@ -1580,14 +1580,14 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionWriter_WriteStrings)
   spISW->Close();
   spISW.reset();
 
-  auto spISR = uut.Open("Section1");
+  auto spISR = uut_.Open("Section1");
   uint8_t readData[13];
   spISR->Read_uint8(readData, sizeof(readData));
   EXPECT_EQ(gpcc::stream::IStreamReader::States::empty, spISR->GetState());
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 
   uint8_t expected[] = {'T', 'e', 'x', 't', 0x00,
                         0x00,
@@ -1602,7 +1602,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionWriter_WriteBitsOneBy
 
   uint8_t const someBits[3] = { 0x24, 0xB6, 0xF2 };
 
-  auto spISW = uut.Create("Section1", false);
+  auto spISW = uut_.Create("Section1", false);
   spISW->Write_Bit(true);
   spISW->Write_Bit(false);
   spISW->Write_Bits(0x0E, 4U);
@@ -1614,7 +1614,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionWriter_WriteBitsOneBy
   spISW->Close();
   spISW.reset();
 
-  auto spISR = uut.Open("Section1");
+  auto spISR = uut_.Open("Section1");
   uint8_t readData[4];
   spISR->Read_uint8(readData, 4);
   spISR->Close();
@@ -1625,13 +1625,13 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionWriter_WriteBitsOneBy
   ASSERT_EQ(0xD8, readData[2]);
   ASSERT_EQ(0x0A, readData[3]);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionWriter_WriteBits4Plus1Byte)
 {
   Format(128);
 
-  auto spISW = uut.Create("Section1", false);
+  auto spISW = uut_.Create("Section1", false);
   spISW->Write_Bit(true);
   spISW->Write_Bit(false);
   spISW->Write_Bit(false);
@@ -1640,7 +1640,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionWriter_WriteBits4Plus
   spISW->Close();
   spISW.reset();
 
-  auto spISR = uut.Open("Section1");
+  auto spISR = uut_.Open("Section1");
   uint8_t readData[2];
   spISR->Read_uint8(readData, 2);
   spISR->Close();
@@ -1649,14 +1649,14 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionWriter_WriteBits4Plus
   ASSERT_EQ(0x09, readData[0]);
   ASSERT_EQ(0xAB, readData[1]);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionWriter_WriteBits4Plus2Bytes)
 {
   Format(128);
 
   uint8_t const someData[2] = { 0xAC, 0x6F };
-  auto spISW = uut.Create("Section1", false);
+  auto spISW = uut_.Create("Section1", false);
   spISW->Write_Bit(true);
   spISW->Write_Bit(false);
   spISW->Write_Bit(false);
@@ -1665,7 +1665,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionWriter_WriteBits4Plus
   spISW->Close();
   spISW.reset();
 
-  auto spISR = uut.Open("Section1");
+  auto spISR = uut_.Open("Section1");
   uint8_t readData[3];
   spISR->Read_uint8(readData, 3);
   spISR->Close();
@@ -1675,13 +1675,13 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionWriter_WriteBits4Plus
   ASSERT_EQ(0xAC, readData[1]);
   ASSERT_EQ(0x6F, readData[2]);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionWriter_WriteBits4ThenClose)
 {
   Format(128);
 
-  auto spISW = uut.Create("Section1", false);
+  auto spISW = uut_.Create("Section1", false);
   spISW->Write_Bit(true);
   spISW->Write_Bit(false);
   spISW->Write_Bit(false);
@@ -1689,7 +1689,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionWriter_WriteBits4Then
   spISW->Close();
   spISW.reset();
 
-  auto spISR = uut.Open("Section1");
+  auto spISR = uut_.Open("Section1");
   uint8_t readData;
   *spISR >> readData;
   spISR->Close();
@@ -1697,33 +1697,33 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionWriter_WriteBits4Then
 
   ASSERT_EQ(0x09, readData);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionWriter_WriteBitsAllocationRequired)
 {
   Format(128);
 
-  auto spISW = uut.Create("Section1", false);
+  auto spISW = uut_.Create("Section1", false);
 
-  fakeStorage.writeAccessCnt = 0;
-  fakeStorage.readAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
+  fakeStorage_.readAccessCnt = 0;
 
-  for (size_t i = 0; i < bytesPerBlock; i++)
+  for (size_t i = 0; i < bytesPerBlock_; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
 
-  ASSERT_EQ(0U, fakeStorage.writeAccessCnt);
-  ASSERT_EQ(0U, fakeStorage.readAccessCnt);
+  ASSERT_EQ(0U, fakeStorage_.writeAccessCnt);
+  ASSERT_EQ(0U, fakeStorage_.readAccessCnt);
 
   spISW->Write_Bit(true);
 
-  ASSERT_EQ(1U, fakeStorage.writeAccessCnt);
-  ASSERT_EQ(2U, fakeStorage.readAccessCnt); // read-back of written block + read free block
+  ASSERT_EQ(1U, fakeStorage_.writeAccessCnt);
+  ASSERT_EQ(2U, fakeStorage_.readAccessCnt); // read-back of written block + read free block
 
   spISW->Close();
   spISW.reset();
 
-  auto spISR = uut.Open("Section1");
-  for (size_t i = 0; i < bytesPerBlock; i++)
+  auto spISR = uut_.Open("Section1");
+  for (size_t i = 0; i < bytesPerBlock_; i++)
   {
     uint8_t readData;
     *spISR >> readData;
@@ -1735,18 +1735,18 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionWriter_WriteBitsAlloc
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionWriter_WriteBitsNextWriteWouldTriggerAllocation)
 {
   Format(128);
 
-  auto spISW = uut.Create("Section1", false);
+  auto spISW = uut_.Create("Section1", false);
 
-  fakeStorage.writeAccessCnt = 0;
-  fakeStorage.readAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
+  fakeStorage_.readAccessCnt = 0;
 
-  for (size_t i = 0; i < bytesPerBlock-1U; i++)
+  for (size_t i = 0; i < bytesPerBlock_-1U; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
 
   spISW->Write_Bit(true);
@@ -1758,19 +1758,19 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionWriter_WriteBitsNextW
   spISW->Write_Bit(false);
   spISW->Write_Bit(false);
 
-  ASSERT_EQ(0U, fakeStorage.writeAccessCnt);
-  ASSERT_EQ(0U, fakeStorage.readAccessCnt);
+  ASSERT_EQ(0U, fakeStorage_.writeAccessCnt);
+  ASSERT_EQ(0U, fakeStorage_.readAccessCnt);
 
   spISW->Close();
 
-  ASSERT_EQ(2U, fakeStorage.writeAccessCnt);
-  ASSERT_EQ(2U, fakeStorage.readAccessCnt);
+  ASSERT_EQ(2U, fakeStorage_.writeAccessCnt);
+  ASSERT_EQ(2U, fakeStorage_.readAccessCnt);
 
   spISW.reset();
 
-  auto spISR = uut.Open("Section1");
+  auto spISR = uut_.Open("Section1");
   uint8_t readData;
-  for (size_t i = 0; i < bytesPerBlock-1U; i++)
+  for (size_t i = 0; i < bytesPerBlock_-1U; i++)
   {
     *spISR >> readData;
     ASSERT_EQ(static_cast<uint8_t>(i & 0xFFU), readData);
@@ -1782,42 +1782,42 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionWriter_WriteBitsNextW
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionWriter_Write2x6StoreAndAllocAfterWriting)
 {
   Format(128);
 
-  auto spISW = uut.Create("Section1", false);
+  auto spISW = uut_.Create("Section1", false);
 
-  fakeStorage.writeAccessCnt = 0;
-  fakeStorage.readAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
+  fakeStorage_.readAccessCnt = 0;
 
-  for (size_t i = 0; i < bytesPerBlock-1U; i++)
+  for (size_t i = 0; i < bytesPerBlock_-1U; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
 
   spISW->Write_Bits(0x3B, 6);
 
-  ASSERT_EQ(0U, fakeStorage.writeAccessCnt);
-  ASSERT_EQ(0U, fakeStorage.readAccessCnt);
+  ASSERT_EQ(0U, fakeStorage_.writeAccessCnt);
+  ASSERT_EQ(0U, fakeStorage_.readAccessCnt);
 
   spISW->Write_Bits(0x26, 6);
 
-  ASSERT_EQ(1U, fakeStorage.writeAccessCnt);
-  ASSERT_EQ(2U, fakeStorage.readAccessCnt);
-  fakeStorage.writeAccessCnt = 0;
-  fakeStorage.readAccessCnt = 0;
+  ASSERT_EQ(1U, fakeStorage_.writeAccessCnt);
+  ASSERT_EQ(2U, fakeStorage_.readAccessCnt);
+  fakeStorage_.writeAccessCnt = 0;
+  fakeStorage_.readAccessCnt = 0;
 
   spISW->Close();
 
-  ASSERT_EQ(2U, fakeStorage.writeAccessCnt);
-  ASSERT_EQ(2U, fakeStorage.readAccessCnt);
+  ASSERT_EQ(2U, fakeStorage_.writeAccessCnt);
+  ASSERT_EQ(2U, fakeStorage_.readAccessCnt);
 
   spISW.reset();
 
-  auto spISR = uut.Open("Section1");
+  auto spISR = uut_.Open("Section1");
   uint8_t readData;
-  for (size_t i = 0; i < bytesPerBlock-1U; i++)
+  for (size_t i = 0; i < bytesPerBlock_-1U; i++)
   {
     *spISR >> readData;
     ASSERT_EQ(static_cast<uint8_t>(i & 0xFFU), readData);
@@ -1831,35 +1831,35 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionWriter_Write2x6StoreA
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionWriter_WriteMultipleBytesAllocRequired)
 {
   Format(128);
 
-  auto spISW = uut.Create("Section1", false);
+  auto spISW = uut_.Create("Section1", false);
 
-  fakeStorage.writeAccessCnt = 0;
-  fakeStorage.readAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
+  fakeStorage_.readAccessCnt = 0;
 
-  RandomData data(bytesPerBlock + 1U, bytesPerBlock + 1U);
-  spISW->Write_uint8(data.GetData(), bytesPerBlock + 1U);
+  RandomData data(bytesPerBlock_ + 1U, bytesPerBlock_ + 1U);
+  spISW->Write_uint8(data.GetData(), bytesPerBlock_ + 1U);
 
-  ASSERT_EQ(1U, fakeStorage.writeAccessCnt);
-  ASSERT_EQ(2U, fakeStorage.readAccessCnt);
-  fakeStorage.writeAccessCnt = 0;
-  fakeStorage.readAccessCnt = 0;
+  ASSERT_EQ(1U, fakeStorage_.writeAccessCnt);
+  ASSERT_EQ(2U, fakeStorage_.readAccessCnt);
+  fakeStorage_.writeAccessCnt = 0;
+  fakeStorage_.readAccessCnt = 0;
 
   spISW->Close();
 
-  ASSERT_EQ(2U, fakeStorage.writeAccessCnt);
-  ASSERT_EQ(2U, fakeStorage.readAccessCnt);
+  ASSERT_EQ(2U, fakeStorage_.writeAccessCnt);
+  ASSERT_EQ(2U, fakeStorage_.readAccessCnt);
 
   spISW.reset();
 
-  auto spISR = uut.Open("Section1");
+  auto spISR = uut_.Open("Section1");
 
-  for (size_t i = 0; i < bytesPerBlock+1U; i++)
+  for (size_t i = 0; i < bytesPerBlock_+1U; i++)
   {
     uint8_t readData;
     *spISR >> readData;
@@ -1869,443 +1869,443 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionWriter_WriteMultipleB
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionWriter_WriteMultipleBytesFullErrorOnAllocation)
 {
   Format(128);
 
-  RandomData fillUp(uut.GetFreeSpace() - 2U * bytesPerBlock - 8U, uut.GetFreeSpace() - 2U * bytesPerBlock - 8U);
-  fillUp.Write("FillUp", false, uut);
+  RandomData fillUp(uut_.GetFreeSpace() - 2U * bytesPerBlock_ - 8U, uut_.GetFreeSpace() - 2U * bytesPerBlock_ - 8U);
+  fillUp.Write("FillUp", false, uut_);
 
-  auto spISW = uut.Create("Section1", false);
+  auto spISW = uut_.Create("Section1", false);
 
-  RandomData data(bytesPerBlock + 1U, bytesPerBlock + 1U);
-  EXPECT_THROW(spISW->Write_uint8(data.GetData(), bytesPerBlock + 1U), gpcc::stream::FullError);
+  RandomData data(bytesPerBlock_ + 1U, bytesPerBlock_ + 1U);
+  EXPECT_THROW(spISW->Write_uint8(data.GetData(), bytesPerBlock_ + 1U), gpcc::stream::FullError);
 
   ASSERT_EQ(gpcc::stream::IStreamWriter::States::error, spISW->GetState());
 
   spISW->Close();
   spISW.reset();
 
-  ASSERT_EQ(bytesPerBlock, uut.GetFreeSpace());
+  ASSERT_EQ(bytesPerBlock_, uut_.GetFreeSpace());
 
-  fillUp.Compare("FillUp", uut);
+  fillUp.Compare("FillUp", uut_);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  ASSERT_THROW(spISR = uut.Open("Section1"), gpcc::file_systems::NoSuchFileError);
+  ASSERT_THROW(spISR = uut_.Open("Section1"), gpcc::file_systems::NoSuchFileError);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionWriter_WriteBitsFullErrorOnAllocation)
 {
   Format(128);
 
-  RandomData fillUp(uut.GetFreeSpace() - 2U * bytesPerBlock - 8U, uut.GetFreeSpace() - 2U * bytesPerBlock - 8U);
-  fillUp.Write("FillUp", false, uut);
+  RandomData fillUp(uut_.GetFreeSpace() - 2U * bytesPerBlock_ - 8U, uut_.GetFreeSpace() - 2U * bytesPerBlock_ - 8U);
+  fillUp.Write("FillUp", false, uut_);
 
-  auto spISW = uut.Create("Section1", false);
+  auto spISW = uut_.Create("Section1", false);
 
-  fakeStorage.writeAccessCnt = 0;
-  fakeStorage.readAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
+  fakeStorage_.readAccessCnt = 0;
 
-  RandomData data(bytesPerBlock, bytesPerBlock);
-  spISW->Write_uint8(data.GetData(), bytesPerBlock);
+  RandomData data(bytesPerBlock_, bytesPerBlock_);
+  spISW->Write_uint8(data.GetData(), bytesPerBlock_);
 
-  ASSERT_EQ(0U, fakeStorage.writeAccessCnt);
-  ASSERT_EQ(0U, fakeStorage.readAccessCnt);
+  ASSERT_EQ(0U, fakeStorage_.writeAccessCnt);
+  ASSERT_EQ(0U, fakeStorage_.readAccessCnt);
 
   ASSERT_THROW(spISW->Write_Bits(0x1B, 6), gpcc::stream::FullError);
 
   spISW->Close();
   spISW.reset();
 
-  ASSERT_EQ(bytesPerBlock, uut.GetFreeSpace());
+  ASSERT_EQ(bytesPerBlock_, uut_.GetFreeSpace());
 
-  fillUp.Compare("FillUp", uut);
+  fillUp.Compare("FillUp", uut_);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  ASSERT_THROW(spISR = uut.Open("Section1"), gpcc::file_systems::NoSuchFileError);
+  ASSERT_THROW(spISR = uut_.Open("Section1"), gpcc::file_systems::NoSuchFileError);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionWriter_Write2x6StoreAndAllocAfterWritingWithFullError)
 {
   Format(128);
 
-  RandomData fillUp(uut.GetFreeSpace() - 2U * bytesPerBlock - 8U, uut.GetFreeSpace() - 2U * bytesPerBlock - 8U);
-  fillUp.Write("FillUp", false, uut);
+  RandomData fillUp(uut_.GetFreeSpace() - 2U * bytesPerBlock_ - 8U, uut_.GetFreeSpace() - 2U * bytesPerBlock_ - 8U);
+  fillUp.Write("FillUp", false, uut_);
 
-  auto spISW = uut.Create("Section1", false);
+  auto spISW = uut_.Create("Section1", false);
 
-  fakeStorage.writeAccessCnt = 0;
-  fakeStorage.readAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
+  fakeStorage_.readAccessCnt = 0;
 
-  for (size_t i = 0; i < bytesPerBlock - 1U; i++)
+  for (size_t i = 0; i < bytesPerBlock_ - 1U; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
 
   spISW->Write_Bits(0x3B, 6);
 
-  ASSERT_EQ(0U, fakeStorage.writeAccessCnt);
-  ASSERT_EQ(0U, fakeStorage.readAccessCnt);
+  ASSERT_EQ(0U, fakeStorage_.writeAccessCnt);
+  ASSERT_EQ(0U, fakeStorage_.readAccessCnt);
 
   ASSERT_THROW(spISW->Write_Bits(0x26, 6), gpcc::stream::FullError);
 
   spISW->Close();
   spISW.reset();
 
-  ASSERT_EQ(bytesPerBlock, uut.GetFreeSpace());
+  ASSERT_EQ(bytesPerBlock_, uut_.GetFreeSpace());
 
-  fillUp.Compare("FillUp", uut);
+  fillUp.Compare("FillUp", uut_);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  ASSERT_THROW(spISR = uut.Open("Section1"), gpcc::file_systems::NoSuchFileError);
+  ASSERT_THROW(spISR = uut_.Open("Section1"), gpcc::file_systems::NoSuchFileError);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionWriter_ProperCleanupUponCloseInErrorState)
 {
   Format(128);
 
-  RandomData fillUp(uut.GetFreeSpace() - 2U * bytesPerBlock - 8U, uut.GetFreeSpace() - 2U * bytesPerBlock - 8U);
-  fillUp.Write("FillUp", false, uut);
+  RandomData fillUp(uut_.GetFreeSpace() - 2U * bytesPerBlock_ - 8U, uut_.GetFreeSpace() - 2U * bytesPerBlock_ - 8U);
+  fillUp.Write("FillUp", false, uut_);
 
-  RandomData dataSec1(bytesPerBlock - 8U + 1U, bytesPerBlock - 8U + 1U);
-  ASSERT_THROW(dataSec1.Write("Section1", false, uut), gpcc::stream::FullError);
+  RandomData dataSec1(bytesPerBlock_ - 8U + 1U, bytesPerBlock_ - 8U + 1U);
+  ASSERT_THROW(dataSec1.Write("Section1", false, uut_), gpcc::stream::FullError);
 
   // check free space
-  ASSERT_EQ(bytesPerBlock, uut.GetFreeSpace());
+  ASSERT_EQ(bytesPerBlock_, uut_.GetFreeSpace());
 
   // check section fillUp
-  fillUp.Compare("FillUp", uut);
+  fillUp.Compare("FillUp", uut_);
 
   // check: Section1 must not be existing
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  ASSERT_THROW(spISR = uut.Open("Section1"), gpcc::file_systems::NoSuchFileError);
+  ASSERT_THROW(spISR = uut_.Open("Section1"), gpcc::file_systems::NoSuchFileError);
 
   // unmount/remount. Check: There must be no write access to storage
-  fakeStorage.writeAccessCnt = 0;
-  fakeStorage.readAccessCnt = 0;
-  uut.Unmount();
-  uut.MountStep1();
-  uut.MountStep2();
-  ASSERT_EQ(0U, fakeStorage.writeAccessCnt);
+  fakeStorage_.writeAccessCnt = 0;
+  fakeStorage_.readAccessCnt = 0;
+  uut_.Unmount();
+  uut_.MountStep1();
+  uut_.MountStep2();
+  ASSERT_EQ(0U, fakeStorage_.writeAccessCnt);
 
   // check free space
-  ASSERT_EQ(bytesPerBlock, uut.GetFreeSpace());
+  ASSERT_EQ(bytesPerBlock_, uut_.GetFreeSpace());
 
   // check section fillUp
-  fillUp.Compare("FillUp", uut);
+  fillUp.Compare("FillUp", uut_);
 
   // check: Section1 must not be existing
-  ASSERT_THROW(spISR = uut.Open("Section1"), gpcc::file_systems::NoSuchFileError);
+  ASSERT_THROW(spISR = uut_.Open("Section1"), gpcc::file_systems::NoSuchFileError);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionWriter_StorageErrorUponWrite)
 {
   Format(128);
 
   RandomData fillUp(512, 512);
-  fillUp.Write("FillUp", false, uut);
+  fillUp.Write("FillUp", false, uut_);
 
-  RandomData data(3U * bytesPerBlock, 3U * bytesPerBlock);
+  RandomData data(3U * bytesPerBlock_, 3U * bytesPerBlock_);
 
-  auto spISW = uut.Create("Section1", false);
+  auto spISW = uut_.Create("Section1", false);
 
-  fakeStorage.writeAndCheckAccessTillFailure = 2;
+  fakeStorage_.writeAndCheckAccessTillFailure = 2;
 
-  ASSERT_THROW( for (size_t i = 0; i < 3U * bytesPerBlock; i++) { *spISW << static_cast<uint8_t>(i & 0xFFU); }, gpcc::stream::IOError);
+  ASSERT_THROW( for (size_t i = 0; i < 3U * bytesPerBlock_; i++) { *spISW << static_cast<uint8_t>(i & 0xFFU); }, gpcc::stream::IOError);
 
   ASSERT_EQ(gpcc::stream::IStreamWriter::States::error, spISW->GetState());
 
   EXPECT_ANY_THROW(spISW->Close());
   spISW.reset();
 
-  ASSERT_EQ(gpcc::file_systems::eeprom_section_system::EEPROMSectionSystem::States::defect, uut.GetState());
+  ASSERT_EQ(gpcc::file_systems::eeprom_section_system::EEPROMSectionSystem::States::defect, uut_.GetState());
 
-  uut.Unmount();
+  uut_.Unmount();
 
-  fakeStorage.writeAccessCnt = 0;
-  fakeStorage.readAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
+  fakeStorage_.readAccessCnt = 0;
 
-  uut.MountStep1();
+  uut_.MountStep1();
 
-  fillUp.Compare("FillUp", uut);
+  fillUp.Compare("FillUp", uut_);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  ASSERT_THROW(spISR = uut.Open("Section1"), gpcc::file_systems::NoSuchFileError);
+  ASSERT_THROW(spISR = uut_.Open("Section1"), gpcc::file_systems::NoSuchFileError);
 
-  ASSERT_EQ(0U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(0U, fakeStorage_.writeAccessCnt);
 
-  uut.MountStep2();
+  uut_.MountStep2();
 
-  ASSERT_NE(0U, fakeStorage.writeAccessCnt);
+  ASSERT_NE(0U, fakeStorage_.writeAccessCnt);
 
-  fillUp.Compare("FillUp", uut);
-  ASSERT_THROW(spISR = uut.Open("Section1"), gpcc::file_systems::NoSuchFileError);
+  fillUp.Compare("FillUp", uut_);
+  ASSERT_THROW(spISR = uut_.Open("Section1"), gpcc::file_systems::NoSuchFileError);
 
-  BasicTest_WriteRead(&uut, blockSize, 1);
+  BasicTest_WriteRead(&uut_, blockSize_, 1);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionWriter_StorageErrorUponClose1)
 {
   Format(128);
 
   RandomData fillUp(512, 512);
-  fillUp.Write("FillUp", false, uut);
+  fillUp.Write("FillUp", false, uut_);
 
-  RandomData data(3U * bytesPerBlock, 3U * bytesPerBlock);
+  RandomData data(3U * bytesPerBlock_, 3U * bytesPerBlock_);
 
-  auto spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < 3U * bytesPerBlock; i++)
+  auto spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < 3U * bytesPerBlock_; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
 
-  fakeStorage.writeAndCheckAccessTillFailure = 1;
+  fakeStorage_.writeAndCheckAccessTillFailure = 1;
   EXPECT_THROW(spISW->Close(), gpcc::stream::IOError);
   spISW.reset();
 
-  ASSERT_EQ(gpcc::file_systems::eeprom_section_system::EEPROMSectionSystem::States::defect, uut.GetState());
+  ASSERT_EQ(gpcc::file_systems::eeprom_section_system::EEPROMSectionSystem::States::defect, uut_.GetState());
 
-  uut.Unmount();
+  uut_.Unmount();
 
-  fakeStorage.writeAccessCnt = 0;
-  fakeStorage.readAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
+  fakeStorage_.readAccessCnt = 0;
 
-  uut.MountStep1();
+  uut_.MountStep1();
 
-  fillUp.Compare("FillUp", uut);
+  fillUp.Compare("FillUp", uut_);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  ASSERT_THROW(spISR = uut.Open("Section1"), gpcc::file_systems::NoSuchFileError);
+  ASSERT_THROW(spISR = uut_.Open("Section1"), gpcc::file_systems::NoSuchFileError);
 
-  ASSERT_EQ(0U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(0U, fakeStorage_.writeAccessCnt);
 
-  uut.MountStep2();
+  uut_.MountStep2();
 
-  ASSERT_NE(0U, fakeStorage.writeAccessCnt);
+  ASSERT_NE(0U, fakeStorage_.writeAccessCnt);
 
-  fillUp.Compare("FillUp", uut);
-  ASSERT_THROW(spISR = uut.Open("Section1"), gpcc::file_systems::NoSuchFileError);
+  fillUp.Compare("FillUp", uut_);
+  ASSERT_THROW(spISR = uut_.Open("Section1"), gpcc::file_systems::NoSuchFileError);
 
-  BasicTest_WriteRead(&uut, blockSize, 1);
+  BasicTest_WriteRead(&uut_, blockSize_, 1);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionWriter_StorageErrorUponClose2)
 {
   Format(128);
 
   RandomData fillUp(512, 512);
-  fillUp.Write("FillUp", false, uut);
+  fillUp.Write("FillUp", false, uut_);
 
-  RandomData data(3U * bytesPerBlock, 3U * bytesPerBlock);
+  RandomData data(3U * bytesPerBlock_, 3U * bytesPerBlock_);
 
-  auto spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < 3U * bytesPerBlock; i++)
+  auto spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < 3U * bytesPerBlock_; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
 
-  fakeStorage.writeAndCheckAccessTillFailure = 2;
+  fakeStorage_.writeAndCheckAccessTillFailure = 2;
   EXPECT_THROW(spISW->Close(), gpcc::stream::IOError);
   spISW.reset();
 
-  ASSERT_EQ(gpcc::file_systems::eeprom_section_system::EEPROMSectionSystem::States::defect, uut.GetState());
+  ASSERT_EQ(gpcc::file_systems::eeprom_section_system::EEPROMSectionSystem::States::defect, uut_.GetState());
 
-  uut.Unmount();
+  uut_.Unmount();
 
-  fakeStorage.writeAccessCnt = 0;
-  fakeStorage.readAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
+  fakeStorage_.readAccessCnt = 0;
 
-  uut.MountStep1();
+  uut_.MountStep1();
 
-  fillUp.Compare("FillUp", uut);
+  fillUp.Compare("FillUp", uut_);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  ASSERT_THROW(spISR = uut.Open("Section1"), gpcc::file_systems::NoSuchFileError);
+  ASSERT_THROW(spISR = uut_.Open("Section1"), gpcc::file_systems::NoSuchFileError);
 
-  ASSERT_EQ(0U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(0U, fakeStorage_.writeAccessCnt);
 
-  uut.MountStep2();
+  uut_.MountStep2();
 
-  ASSERT_NE(0U, fakeStorage.writeAccessCnt);
+  ASSERT_NE(0U, fakeStorage_.writeAccessCnt);
 
-  fillUp.Compare("FillUp", uut);
-  ASSERT_THROW(spISR = uut.Open("Section1"), gpcc::file_systems::NoSuchFileError);
+  fillUp.Compare("FillUp", uut_);
+  ASSERT_THROW(spISR = uut_.Open("Section1"), gpcc::file_systems::NoSuchFileError);
 
-  BasicTest_WriteRead(&uut, blockSize, 1);
+  BasicTest_WriteRead(&uut_, blockSize_, 1);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionWriter_StorageThrowsUponWrite)
 {
   Format(128);
 
   RandomData fillUp(512, 512);
-  fillUp.Write("FillUp", false, uut);
+  fillUp.Write("FillUp", false, uut_);
 
-  RandomData data(3U * bytesPerBlock, 3U * bytesPerBlock);
+  RandomData data(3U * bytesPerBlock_, 3U * bytesPerBlock_);
 
-  auto spISW = uut.Create("Section1", false);
+  auto spISW = uut_.Create("Section1", false);
 
-  fakeStorage.writeAccessesTillThrow = 2;
+  fakeStorage_.writeAccessesTillThrow = 2;
 
-  ASSERT_THROW( for (size_t i = 0; i < 3U * bytesPerBlock; i++) { *spISW << static_cast<uint8_t>(i & 0xFFU); }, gpcc::stream::IOError);
+  ASSERT_THROW( for (size_t i = 0; i < 3U * bytesPerBlock_; i++) { *spISW << static_cast<uint8_t>(i & 0xFFU); }, gpcc::stream::IOError);
 
   ASSERT_EQ(gpcc::stream::IStreamWriter::States::error, spISW->GetState());
 
   EXPECT_ANY_THROW(spISW->Close());
   spISW.reset();
 
-  ASSERT_EQ(gpcc::file_systems::eeprom_section_system::EEPROMSectionSystem::States::defect, uut.GetState());
+  ASSERT_EQ(gpcc::file_systems::eeprom_section_system::EEPROMSectionSystem::States::defect, uut_.GetState());
 
-  uut.Unmount();
+  uut_.Unmount();
 
-  fakeStorage.writeAccessCnt = 0;
-  fakeStorage.readAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
+  fakeStorage_.readAccessCnt = 0;
 
-  uut.MountStep1();
+  uut_.MountStep1();
 
-  fillUp.Compare("FillUp", uut);
+  fillUp.Compare("FillUp", uut_);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  ASSERT_THROW(spISR = uut.Open("Section1"), gpcc::file_systems::NoSuchFileError);
+  ASSERT_THROW(spISR = uut_.Open("Section1"), gpcc::file_systems::NoSuchFileError);
 
-  ASSERT_EQ(0U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(0U, fakeStorage_.writeAccessCnt);
 
-  uut.MountStep2();
+  uut_.MountStep2();
 
-  ASSERT_NE(0U, fakeStorage.writeAccessCnt);
+  ASSERT_NE(0U, fakeStorage_.writeAccessCnt);
 
-  fillUp.Compare("FillUp", uut);
-  ASSERT_THROW(spISR = uut.Open("Section1"), gpcc::file_systems::NoSuchFileError);
+  fillUp.Compare("FillUp", uut_);
+  ASSERT_THROW(spISR = uut_.Open("Section1"), gpcc::file_systems::NoSuchFileError);
 
-  BasicTest_WriteRead(&uut, blockSize, 1);
+  BasicTest_WriteRead(&uut_, blockSize_, 1);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionWriter_StorageThrowsUponClose1)
 {
   Format(128);
 
   RandomData fillUp(512, 512);
-  fillUp.Write("FillUp", false, uut);
+  fillUp.Write("FillUp", false, uut_);
 
-  RandomData data(3U * bytesPerBlock, 3U * bytesPerBlock);
+  RandomData data(3U * bytesPerBlock_, 3U * bytesPerBlock_);
 
-  auto spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < 3U * bytesPerBlock; i++)
+  auto spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < 3U * bytesPerBlock_; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
 
-  fakeStorage.writeAccessesTillThrow = 1;
+  fakeStorage_.writeAccessesTillThrow = 1;
   EXPECT_THROW(spISW->Close(), gpcc::stream::IOError);
   spISW.reset();
 
-  ASSERT_EQ(gpcc::file_systems::eeprom_section_system::EEPROMSectionSystem::States::defect, uut.GetState());
+  ASSERT_EQ(gpcc::file_systems::eeprom_section_system::EEPROMSectionSystem::States::defect, uut_.GetState());
 
-  uut.Unmount();
+  uut_.Unmount();
 
-  fakeStorage.writeAccessCnt = 0;
-  fakeStorage.readAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
+  fakeStorage_.readAccessCnt = 0;
 
-  uut.MountStep1();
+  uut_.MountStep1();
 
-  fillUp.Compare("FillUp", uut);
+  fillUp.Compare("FillUp", uut_);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  ASSERT_THROW(spISR = uut.Open("Section1"), gpcc::file_systems::NoSuchFileError);
+  ASSERT_THROW(spISR = uut_.Open("Section1"), gpcc::file_systems::NoSuchFileError);
 
-  ASSERT_EQ(0U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(0U, fakeStorage_.writeAccessCnt);
 
-  uut.MountStep2();
+  uut_.MountStep2();
 
-  ASSERT_NE(0U, fakeStorage.writeAccessCnt);
+  ASSERT_NE(0U, fakeStorage_.writeAccessCnt);
 
-  fillUp.Compare("FillUp", uut);
-  ASSERT_THROW(spISR = uut.Open("Section1"), gpcc::file_systems::NoSuchFileError);
+  fillUp.Compare("FillUp", uut_);
+  ASSERT_THROW(spISR = uut_.Open("Section1"), gpcc::file_systems::NoSuchFileError);
 
-  BasicTest_WriteRead(&uut, blockSize, 1);
+  BasicTest_WriteRead(&uut_, blockSize_, 1);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionWriter_StorageThrowsUponClose2)
 {
   Format(128);
 
   RandomData fillUp(512, 512);
-  fillUp.Write("FillUp", false, uut);
+  fillUp.Write("FillUp", false, uut_);
 
-  RandomData data(3U * bytesPerBlock, 3U * bytesPerBlock);
+  RandomData data(3U * bytesPerBlock_, 3U * bytesPerBlock_);
 
-  auto spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < 3U * bytesPerBlock; i++)
+  auto spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < 3U * bytesPerBlock_; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
 
-  fakeStorage.writeAccessesTillThrow = 2;
+  fakeStorage_.writeAccessesTillThrow = 2;
   EXPECT_THROW(spISW->Close(), gpcc::stream::IOError);
   spISW.reset();
 
-  ASSERT_EQ(gpcc::file_systems::eeprom_section_system::EEPROMSectionSystem::States::defect, uut.GetState());
+  ASSERT_EQ(gpcc::file_systems::eeprom_section_system::EEPROMSectionSystem::States::defect, uut_.GetState());
 
-  uut.Unmount();
+  uut_.Unmount();
 
-  fakeStorage.writeAccessCnt = 0;
-  fakeStorage.readAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
+  fakeStorage_.readAccessCnt = 0;
 
-  uut.MountStep1();
+  uut_.MountStep1();
 
-  fillUp.Compare("FillUp", uut);
+  fillUp.Compare("FillUp", uut_);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  ASSERT_THROW(spISR = uut.Open("Section1"), gpcc::file_systems::NoSuchFileError);
+  ASSERT_THROW(spISR = uut_.Open("Section1"), gpcc::file_systems::NoSuchFileError);
 
-  ASSERT_EQ(0U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(0U, fakeStorage_.writeAccessCnt);
 
-  uut.MountStep2();
+  uut_.MountStep2();
 
-  ASSERT_NE(0U, fakeStorage.writeAccessCnt);
+  ASSERT_NE(0U, fakeStorage_.writeAccessCnt);
 
-  fillUp.Compare("FillUp", uut);
-  ASSERT_THROW(spISR = uut.Open("Section1"), gpcc::file_systems::NoSuchFileError);
+  fillUp.Compare("FillUp", uut_);
+  ASSERT_THROW(spISR = uut_.Open("Section1"), gpcc::file_systems::NoSuchFileError);
 
-  BasicTest_WriteRead(&uut, blockSize, 1);
+  BasicTest_WriteRead(&uut_, blockSize_, 1);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionWriter_PowerFailUponWriteOrClose)
 {
   Format(128);
 
-  fakeStorage.SetEnableUndo(true);
-  fakeStorage.writeAccessCnt = 0;
-  fakeStorage.readAccessCnt  = 0;
+  fakeStorage_.SetEnableUndo(true);
+  fakeStorage_.writeAccessCnt = 0;
+  fakeStorage_.readAccessCnt  = 0;
 
-  RandomData data(2U * bytesPerBlock, 2U * bytesPerBlock);
-  data.Write("Section1", false, uut);
+  RandomData data(2U * bytesPerBlock_, 2U * bytesPerBlock_);
+  data.Write("Section1", false, uut_);
 
-  ASSERT_EQ(4U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(4U, fakeStorage_.writeAccessCnt);
 
-  FakeEEPROM copyOfStorage(fakeStorage);
+  FakeEEPROM copyOfStorage(fakeStorage_);
 
-  uut.Unmount();
+  uut_.Unmount();
 
   for (uint_fast8_t i = 1U; i < 4U; i++)
   {
-    fakeStorage = copyOfStorage;
-    fakeStorage.Undo(i);
+    fakeStorage_ = copyOfStorage;
+    fakeStorage_.Undo(i);
 
-    uut.MountStep1();
+    uut_.MountStep1();
 
     std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-    ASSERT_THROW(spISR = uut.Open("Section1"), gpcc::file_systems::NoSuchFileError);
+    ASSERT_THROW(spISR = uut_.Open("Section1"), gpcc::file_systems::NoSuchFileError);
 
-    uut.MountStep2();
+    uut_.MountStep2();
 
-    ASSERT_THROW(spISR = uut.Open("Section1"), gpcc::file_systems::NoSuchFileError);
+    ASSERT_THROW(spISR = uut_.Open("Section1"), gpcc::file_systems::NoSuchFileError);
 
-    BasicTest_WriteRead(&uut, blockSize, 1);
+    BasicTest_WriteRead(&uut_, blockSize_, 1);
 
-    uut.Unmount();
+    uut_.Unmount();
   }
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionWriter_GetNbOfCachedBits)
@@ -2313,7 +2313,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionWriter_GetNbOfCachedB
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Test.dat", false);
+  spISW = uut_.Create("Test.dat", false);
 
   ASSERT_EQ(gpcc::stream::IStreamWriter::States::open, spISW->GetState());
 
@@ -2341,7 +2341,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionWriter_GetNbOfCachedB
   ASSERT_EQ(gpcc::stream::IStreamWriter::States::closed, spISW->GetState());
   EXPECT_THROW(spISW->GetNbOfCachedBits(), gpcc::stream::ClosedError);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Open_BadNames)
 {
@@ -2349,128 +2349,128 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Open_BadNames)
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  ASSERT_THROW(spISR = uut.Open(""), std::invalid_argument);
-  ASSERT_THROW(spISR = uut.Open(" Sec1"), std::invalid_argument);
-  ASSERT_THROW(spISR = uut.Open("Sec2 "), std::invalid_argument);
-  ASSERT_THROW(spISR = uut.Open(" Sec3 "), std::invalid_argument);
-  ASSERT_THROW(spISR = uut.Open(" "), std::invalid_argument);
+  ASSERT_THROW(spISR = uut_.Open(""), std::invalid_argument);
+  ASSERT_THROW(spISR = uut_.Open(" Sec1"), std::invalid_argument);
+  ASSERT_THROW(spISR = uut_.Open("Sec2 "), std::invalid_argument);
+  ASSERT_THROW(spISR = uut_.Open(" Sec3 "), std::invalid_argument);
+  ASSERT_THROW(spISR = uut_.Open(" "), std::invalid_argument);
 
-  ASSERT_NO_THROW(spISW = uut.Create("A", false));
-  ASSERT_NO_THROW(spISW = uut.Create("A B", false));
+  ASSERT_NO_THROW(spISW = uut_.Create("A", false));
+  ASSERT_NO_THROW(spISW = uut_.Create("A B", false));
   spISW.reset();
 
-  ASSERT_NO_THROW(spISR = uut.Open("A"));
-  ASSERT_NO_THROW(spISR = uut.Open("A B"));
+  ASSERT_NO_THROW(spISR = uut_.Open("A"));
+  ASSERT_NO_THROW(spISR = uut_.Open("A B"));
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Open_SectionNotExisting)
 {
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  ASSERT_THROW(spISR = uut.Open("Sec1"), gpcc::file_systems::NoSuchFileError);
+  ASSERT_THROW(spISR = uut_.Open("Sec1"), gpcc::file_systems::NoSuchFileError);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Open_WrongState)
 {
   Format(128);
   RandomData data(8,8);
-  data.Write("Section1", false, uut);
-  uut.Unmount();
+  data.Write("Section1", false, uut_);
+  uut_.Unmount();
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
 
   // state is not_mounted
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::not_mounted, uut.GetState());
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::not_mounted, uut_.GetState());
 
-  ASSERT_THROW(spISR = uut.Open("Section1"), InsufficientStateError);
+  ASSERT_THROW(spISR = uut_.Open("Section1"), InsufficientStateError);
 
   // bring uut into state "ro_mount"
-  uut.MountStep1();
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::ro_mount, uut.GetState());
+  uut_.MountStep1();
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::ro_mount, uut_.GetState());
 
-  ASSERT_NO_THROW(spISR = uut.Open("Section1"));
+  ASSERT_NO_THROW(spISR = uut_.Open("Section1"));
   spISR.reset();
 
   // bring uut into state "mounted"
-  uut.MountStep2();
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::mounted, uut.GetState());
+  uut_.MountStep2();
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::mounted, uut_.GetState());
 
-  ASSERT_NO_THROW(spISR = uut.Open("Section1"));
+  ASSERT_NO_THROW(spISR = uut_.Open("Section1"));
   spISR.reset();
 
   // bring uut into state "defect"
-  fakeStorage.Invalidate(blockSize * 3U, blockSize);
-  ASSERT_THROW(data.Write("Section2", false, uut), DataIntegrityError);
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::defect, uut.GetState());
+  fakeStorage_.Invalidate(blockSize_ * 3U, blockSize_);
+  ASSERT_THROW(data.Write("Section2", false, uut_), DataIntegrityError);
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::defect, uut_.GetState());
 
-  ASSERT_THROW(spISR = uut.Open("Section1"), InsufficientStateError);
+  ASSERT_THROW(spISR = uut_.Open("Section1"), InsufficientStateError);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Open_SectionLockedByReader)
 {
   Format(128);
 
   RandomData data(8,8);
-  data.Write("Section1", false, uut);
+  data.Write("Section1", false, uut_);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR1;
   std::unique_ptr<gpcc::stream::IStreamReader> spISR2;
-  ASSERT_NO_THROW(spISR1 = uut.Open("Section1"));
-  ASSERT_NO_THROW(spISR2 = uut.Open("Section1"));
+  ASSERT_NO_THROW(spISR1 = uut_.Open("Section1"));
+  ASSERT_NO_THROW(spISR2 = uut_.Open("Section1"));
   spISR1.reset();
   spISR2.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Open_SectionLockedByWriter)
 {
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
+  spISW = uut_.Create("Section1", false);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  ASSERT_THROW(spISR = uut.Open("Section1"), gpcc::file_systems::FileAlreadyAccessedError);
+  ASSERT_THROW(spISR = uut_.Open("Section1"), gpcc::file_systems::FileAlreadyAccessedError);
 
   spISW.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Open_EmptySection)
 {
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
+  spISW = uut_.Create("Section1", false);
   spISW.reset();
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
   ASSERT_EQ(gpcc::stream::IStreamReader::States::empty, spISR->GetState());
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Open_DestroyReaderWithoutClose)
 {
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
+  spISW = uut_.Create("Section1", false);
   spISW->Write_uint32(0x12345678U);
   spISW->Close();
   spISW.reset();
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
   spISR.reset();
 
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
   uint8_t data[4];
   spISR->Read_uint8(data, 4);
   ASSERT_EQ(0x78U, data[0]);
@@ -2479,8 +2479,8 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Open_DestroyReaderWithoutClo
   ASSERT_EQ(0x12U, data[3]);
   spISR.reset();
 
-  ASSERT_NO_THROW(uut.Delete("Section1"));
-  uut.Unmount();
+  ASSERT_NO_THROW(uut_.Delete("Section1"));
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Open_SectionWith2Heads_diffName_sameVersion)
 {
@@ -2490,31 +2490,31 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Open_SectionWith2Heads_diffN
   // Version of the section heads is the same.
 
   Format(128);
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
   RandomData data(8,8);
-  data.Write("Section1", false, uut);
-  ASSERT_EQ(2U, fakeStorage.writeAccessCnt);
-  uut.Unmount();
+  data.Write("Section1", false, uut_);
+  ASSERT_EQ(2U, fakeStorage_.writeAccessCnt);
+  uut_.Unmount();
 
   // create 2nd section head, uses head of 1st section as template
-  fakeStorage.Read(1U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Read(1U * blockSize_, blockSize_, pBuffer_);
 
-  pBuffer[sizeof(SectionHeadBlock_t) + 7U] = '2';           // Section1 -> Section2
-  pBuffer[offsetof(CommonBlockHead_t, sectionNameHash)]++;  // Update name hash
+  pBuffer_[sizeof(SectionHeadBlock_t) + 7U] = '2';           // Section1 -> Section2
+  pBuffer_[offsetof(CommonBlockHead_t, sectionNameHash)]++;  // Update name hash
 
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 0] = 1;   // set version LB
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 1] = 0;   // set version HB
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 0] = 1;   // set version LB
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 1] = 0;   // set version HB
 
-  fakeStorage.Write(3U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Write(3U * blockSize_, blockSize_, pBuffer_);
   UpdateCRC(3);
 
   // test
-  uut.MountStep1();
+  uut_.MountStep1();
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  ASSERT_THROW(spISR = uut.Open("Section1"), BlockLinkageError);
+  ASSERT_THROW(spISR = uut_.Open("Section1"), BlockLinkageError);
 
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::defect, uut.GetState());
-  uut.Unmount();
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::defect, uut_.GetState());
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Open_SectionWith2Heads_diffName_2ndOlder)
 {
@@ -2524,30 +2524,30 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Open_SectionWith2Heads_diffN
   // The second section head has an lower version. No version wrap-around.
 
   Format(128);
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
   RandomData data(8,8);
-  data.Write("Section1", false, uut);
-  ASSERT_EQ(2U, fakeStorage.writeAccessCnt);
-  uut.Unmount();
+  data.Write("Section1", false, uut_);
+  ASSERT_EQ(2U, fakeStorage_.writeAccessCnt);
+  uut_.Unmount();
 
   // create 2nd section head, uses head of 1st section as template
-  fakeStorage.Read(1U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Read(1U * blockSize_, blockSize_, pBuffer_);
 
-  pBuffer[sizeof(SectionHeadBlock_t) + 7U] = '2';           // Section1 -> Section2
-  pBuffer[offsetof(CommonBlockHead_t, sectionNameHash)]++;  // Update name hash
+  pBuffer_[sizeof(SectionHeadBlock_t) + 7U] = '2';           // Section1 -> Section2
+  pBuffer_[offsetof(CommonBlockHead_t, sectionNameHash)]++;  // Update name hash
 
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 0] = 0;   // set version LB
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 1] = 0;   // set version HB
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 0] = 0;   // set version LB
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 1] = 0;   // set version HB
 
-  fakeStorage.Write(3U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Write(3U * blockSize_, blockSize_, pBuffer_);
   UpdateCRC(3);
 
   // test
-  uut.MountStep1();
-  data.Compare("Section1", uut);
-  ASSERT_THROW(data.Compare("Section2", uut), gpcc::file_systems::NoSuchFileError);
+  uut_.MountStep1();
+  data.Compare("Section1", uut_);
+  ASSERT_THROW(data.Compare("Section2", uut_), gpcc::file_systems::NoSuchFileError);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Open_SectionWith2Heads_diffName_2ndNewer)
 {
@@ -2557,30 +2557,30 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Open_SectionWith2Heads_diffN
   // The second section head has an higher version. No version wrap-around.
 
   Format(128);
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
   RandomData data(8,8);
-  data.Write("Section1", false, uut);
-  ASSERT_EQ(2U, fakeStorage.writeAccessCnt);
-  uut.Unmount();
+  data.Write("Section1", false, uut_);
+  ASSERT_EQ(2U, fakeStorage_.writeAccessCnt);
+  uut_.Unmount();
 
   // create 2nd section head, uses head of 1st section as template
-  fakeStorage.Read(1U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Read(1U * blockSize_, blockSize_, pBuffer_);
 
-  pBuffer[sizeof(SectionHeadBlock_t) + 7U] = '2';           // Section1 -> Section2
-  pBuffer[offsetof(CommonBlockHead_t, sectionNameHash)]++;  // Update name hash
+  pBuffer_[sizeof(SectionHeadBlock_t) + 7U] = '2';           // Section1 -> Section2
+  pBuffer_[offsetof(CommonBlockHead_t, sectionNameHash)]++;  // Update name hash
 
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 0] = 2;   // set version LB
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 1] = 0;   // set version HB
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 0] = 2;   // set version LB
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 1] = 0;   // set version HB
 
-  fakeStorage.Write(3U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Write(3U * blockSize_, blockSize_, pBuffer_);
   UpdateCRC(3);
 
   // test
-  uut.MountStep1();
-  ASSERT_THROW(data.Compare("Section1", uut), gpcc::file_systems::NoSuchFileError);
-  data.Compare("Section2", uut);
+  uut_.MountStep1();
+  ASSERT_THROW(data.Compare("Section1", uut_), gpcc::file_systems::NoSuchFileError);
+  data.Compare("Section2", uut_);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Open_SectionWith2Heads_diffName_2ndOlder_WithWrapAround)
 {
@@ -2590,37 +2590,37 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Open_SectionWith2Heads_diffN
   // The second section head has an lower version. With version wrap-around.
 
   Format(128);
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
   RandomData data(8,8);
-  data.Write("Section1", false, uut);
-  ASSERT_EQ(2U, fakeStorage.writeAccessCnt);
-  uut.Unmount();
+  data.Write("Section1", false, uut_);
+  ASSERT_EQ(2U, fakeStorage_.writeAccessCnt);
+  uut_.Unmount();
 
   // set version of first section
-  fakeStorage.Read(1U * blockSize, blockSize, pBuffer);
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 0] = 0;
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 1] = 0;
-  fakeStorage.Write(1U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Read(1U * blockSize_, blockSize_, pBuffer_);
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 0] = 0;
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 1] = 0;
+  fakeStorage_.Write(1U * blockSize_, blockSize_, pBuffer_);
   UpdateCRC(1);
 
   // create 2nd section head, uses head of 1st section as template
-  fakeStorage.Read(1U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Read(1U * blockSize_, blockSize_, pBuffer_);
 
-  pBuffer[sizeof(SectionHeadBlock_t) + 7U] = '2';           // Section1 -> Section2
-  pBuffer[offsetof(CommonBlockHead_t, sectionNameHash)]++;  // Update name hash
+  pBuffer_[sizeof(SectionHeadBlock_t) + 7U] = '2';           // Section1 -> Section2
+  pBuffer_[offsetof(CommonBlockHead_t, sectionNameHash)]++;  // Update name hash
 
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 0] = 0xFF; // set version LB
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 1] = 0xFF; // set version HB
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 0] = 0xFF; // set version LB
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 1] = 0xFF; // set version HB
 
-  fakeStorage.Write(3U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Write(3U * blockSize_, blockSize_, pBuffer_);
   UpdateCRC(3);
 
   // test
-  uut.MountStep1();
-  data.Compare("Section1", uut);
-  ASSERT_THROW(data.Compare("Section2", uut), gpcc::file_systems::NoSuchFileError);
+  uut_.MountStep1();
+  data.Compare("Section1", uut_);
+  ASSERT_THROW(data.Compare("Section2", uut_), gpcc::file_systems::NoSuchFileError);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Open_SectionWith2Heads_diffName_2ndNewer_WithWrapAround)
 {
@@ -2630,37 +2630,37 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Open_SectionWith2Heads_diffN
   // The second section head has an higher version. With version wrap-around.
 
   Format(128);
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
   RandomData data(8,8);
-  data.Write("Section1", false, uut);
-  ASSERT_EQ(2U, fakeStorage.writeAccessCnt);
-  uut.Unmount();
+  data.Write("Section1", false, uut_);
+  ASSERT_EQ(2U, fakeStorage_.writeAccessCnt);
+  uut_.Unmount();
 
   // set version of first section
-  fakeStorage.Read(1U * blockSize, blockSize, pBuffer);
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 0] = 0xFF;
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 1] = 0xFF;
-  fakeStorage.Write(1U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Read(1U * blockSize_, blockSize_, pBuffer_);
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 0] = 0xFF;
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 1] = 0xFF;
+  fakeStorage_.Write(1U * blockSize_, blockSize_, pBuffer_);
   UpdateCRC(1);
 
   // create 2nd section head, uses head of 1st section as template
-  fakeStorage.Read(1U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Read(1U * blockSize_, blockSize_, pBuffer_);
 
-  pBuffer[sizeof(SectionHeadBlock_t) + 7U] = '2';           // Section1 -> Section2
-  pBuffer[offsetof(CommonBlockHead_t, sectionNameHash)]++;  // Update name hash
+  pBuffer_[sizeof(SectionHeadBlock_t) + 7U] = '2';           // Section1 -> Section2
+  pBuffer_[offsetof(CommonBlockHead_t, sectionNameHash)]++;  // Update name hash
 
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 0] = 0x00; // set version LB
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 1] = 0x00; // set version HB
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 0] = 0x00; // set version LB
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 1] = 0x00; // set version HB
 
-  fakeStorage.Write(3U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Write(3U * blockSize_, blockSize_, pBuffer_);
   UpdateCRC(3);
 
   // test
-  uut.MountStep1();
-  ASSERT_THROW(data.Compare("Section1", uut), gpcc::file_systems::NoSuchFileError);
-  data.Compare("Section2", uut);
+  uut_.MountStep1();
+  ASSERT_THROW(data.Compare("Section1", uut_), gpcc::file_systems::NoSuchFileError);
+  data.Compare("Section2", uut_);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Open_SectionWith2Heads_sameName_sameVersion)
 {
@@ -2670,33 +2670,33 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Open_SectionWith2Heads_sameN
   // Name and version of the section heads are the same.
 
   Format(128);
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
   RandomData data1(8,8);
-  data1.Write("Section1", false, uut);
+  data1.Write("Section1", false, uut_);
   RandomData data2(8,8);
-  data2.Write("Section2", false, uut);
-  ASSERT_EQ(4U, fakeStorage.writeAccessCnt);
-  uut.Unmount();
+  data2.Write("Section2", false, uut_);
+  ASSERT_EQ(4U, fakeStorage_.writeAccessCnt);
+  uut_.Unmount();
 
   // update head of 2nd section
-  fakeStorage.Read(3U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Read(3U * blockSize_, blockSize_, pBuffer_);
 
-  pBuffer[sizeof(SectionHeadBlock_t) + 7U] = '1';           // Section2 -> Section1
-  pBuffer[offsetof(CommonBlockHead_t, sectionNameHash)]--;  // Update name hash
+  pBuffer_[sizeof(SectionHeadBlock_t) + 7U] = '1';           // Section2 -> Section1
+  pBuffer_[offsetof(CommonBlockHead_t, sectionNameHash)]--;  // Update name hash
 
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 0] = 1;   // set version LB
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 1] = 0;   // set version HB
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 0] = 1;   // set version LB
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 1] = 0;   // set version HB
 
-  fakeStorage.Write(3U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Write(3U * blockSize_, blockSize_, pBuffer_);
   UpdateCRC(3);
 
   // test
-  uut.MountStep1();
+  uut_.MountStep1();
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  ASSERT_THROW(spISR = uut.Open("Section1"), BlockLinkageError);
+  ASSERT_THROW(spISR = uut_.Open("Section1"), BlockLinkageError);
 
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::defect, uut.GetState());
-  uut.Unmount();
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::defect, uut_.GetState());
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Open_SectionWith2Heads_sameName_2ndOlder)
 {
@@ -2706,31 +2706,31 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Open_SectionWith2Heads_sameN
   // Names are the same, version of the second section is lower. No version wrap-around.
 
   Format(128);
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
   RandomData data1(8,8);
-  data1.Write("Section1", false, uut);
+  data1.Write("Section1", false, uut_);
   RandomData data2(8,8);
-  data2.Write("Section2", false, uut);
-  ASSERT_EQ(4U, fakeStorage.writeAccessCnt);
-  uut.Unmount();
+  data2.Write("Section2", false, uut_);
+  ASSERT_EQ(4U, fakeStorage_.writeAccessCnt);
+  uut_.Unmount();
 
   // update head of 2nd section
-  fakeStorage.Read(3U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Read(3U * blockSize_, blockSize_, pBuffer_);
 
-  pBuffer[sizeof(SectionHeadBlock_t) + 7U] = '1';           // Section2 -> Section1
-  pBuffer[offsetof(CommonBlockHead_t, sectionNameHash)]--;  // Update name hash
+  pBuffer_[sizeof(SectionHeadBlock_t) + 7U] = '1';           // Section2 -> Section1
+  pBuffer_[offsetof(CommonBlockHead_t, sectionNameHash)]--;  // Update name hash
 
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 0] = 0;   // set version LB
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 1] = 0;   // set version HB
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 0] = 0;   // set version LB
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 1] = 0;   // set version HB
 
-  fakeStorage.Write(3U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Write(3U * blockSize_, blockSize_, pBuffer_);
   UpdateCRC(3);
 
   // test
-  uut.MountStep1();
-  data1.Compare("Section1", uut);
+  uut_.MountStep1();
+  data1.Compare("Section1", uut_);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Open_SectionWith2Heads_sameName_2ndNewer)
 {
@@ -2740,31 +2740,31 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Open_SectionWith2Heads_sameN
   // Names are the same, version of the second section is higher. No version wrap-around.
 
   Format(128);
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
   RandomData data1(8,8);
-  data1.Write("Section1", false, uut);
+  data1.Write("Section1", false, uut_);
   RandomData data2(8,8);
-  data2.Write("Section2", false, uut);
-  ASSERT_EQ(4U, fakeStorage.writeAccessCnt);
-  uut.Unmount();
+  data2.Write("Section2", false, uut_);
+  ASSERT_EQ(4U, fakeStorage_.writeAccessCnt);
+  uut_.Unmount();
 
   // update head of 2nd section
-  fakeStorage.Read(3U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Read(3U * blockSize_, blockSize_, pBuffer_);
 
-  pBuffer[sizeof(SectionHeadBlock_t) + 7U] = '1';           // Section2 -> Section1
-  pBuffer[offsetof(CommonBlockHead_t, sectionNameHash)]--;  // Update name hash
+  pBuffer_[sizeof(SectionHeadBlock_t) + 7U] = '1';           // Section2 -> Section1
+  pBuffer_[offsetof(CommonBlockHead_t, sectionNameHash)]--;  // Update name hash
 
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 0] = 2;   // set version LB
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 1] = 0;   // set version HB
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 0] = 2;   // set version LB
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 1] = 0;   // set version HB
 
-  fakeStorage.Write(3U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Write(3U * blockSize_, blockSize_, pBuffer_);
   UpdateCRC(3);
 
   // test
-  uut.MountStep1();
-  data2.Compare("Section1", uut);
+  uut_.MountStep1();
+  data2.Compare("Section1", uut_);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Open_SectionWith2Heads_sameName_2ndOlder_WithWrapAround)
 {
@@ -2774,38 +2774,38 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Open_SectionWith2Heads_sameN
   // Names are the same, version of the second section is lower. With version wrap-around.
 
   Format(128);
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
   RandomData data1(8,8);
-  data1.Write("Section1", false, uut);
+  data1.Write("Section1", false, uut_);
   RandomData data2(8,8);
-  data2.Write("Section2", false, uut);
-  ASSERT_EQ(4U, fakeStorage.writeAccessCnt);
-  uut.Unmount();
+  data2.Write("Section2", false, uut_);
+  ASSERT_EQ(4U, fakeStorage_.writeAccessCnt);
+  uut_.Unmount();
 
   // set version of first section
-  fakeStorage.Read(1U * blockSize, blockSize, pBuffer);
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 0] = 0x00;
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 1] = 0x00;
-  fakeStorage.Write(1U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Read(1U * blockSize_, blockSize_, pBuffer_);
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 0] = 0x00;
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 1] = 0x00;
+  fakeStorage_.Write(1U * blockSize_, blockSize_, pBuffer_);
   UpdateCRC(1);
 
   // update head of 2nd section
-  fakeStorage.Read(3U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Read(3U * blockSize_, blockSize_, pBuffer_);
 
-  pBuffer[sizeof(SectionHeadBlock_t) + 7U] = '1';           // Section2 -> Section1
-  pBuffer[offsetof(CommonBlockHead_t, sectionNameHash)]--;  // Update name hash
+  pBuffer_[sizeof(SectionHeadBlock_t) + 7U] = '1';           // Section2 -> Section1
+  pBuffer_[offsetof(CommonBlockHead_t, sectionNameHash)]--;  // Update name hash
 
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 0] = 0xFF; // set version LB
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 1] = 0xFF; // set version HB
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 0] = 0xFF; // set version LB
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 1] = 0xFF; // set version HB
 
-  fakeStorage.Write(3U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Write(3U * blockSize_, blockSize_, pBuffer_);
   UpdateCRC(3);
 
   // test
-  uut.MountStep1();
-  data1.Compare("Section1", uut);
+  uut_.MountStep1();
+  data1.Compare("Section1", uut_);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Open_SectionWith2Heads_sameName_2ndNewer_WithWrapAround)
 {
@@ -2815,52 +2815,52 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Open_SectionWith2Heads_sameN
   // Names are the same, version of the second section is higher. With version wrap-around.
 
   Format(128);
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
   RandomData data1(8,8);
-  data1.Write("Section1", false, uut);
+  data1.Write("Section1", false, uut_);
   RandomData data2(8,8);
-  data2.Write("Section2", false, uut);
-  ASSERT_EQ(4U, fakeStorage.writeAccessCnt);
-  uut.Unmount();
+  data2.Write("Section2", false, uut_);
+  ASSERT_EQ(4U, fakeStorage_.writeAccessCnt);
+  uut_.Unmount();
 
   // set version of first section
-  fakeStorage.Read(1U * blockSize, blockSize, pBuffer);
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 0] = 0xFF;
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 1] = 0xFF;
-  fakeStorage.Write(1U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Read(1U * blockSize_, blockSize_, pBuffer_);
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 0] = 0xFF;
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 1] = 0xFF;
+  fakeStorage_.Write(1U * blockSize_, blockSize_, pBuffer_);
   UpdateCRC(1);
 
   // update head of 2nd section
-  fakeStorage.Read(3U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Read(3U * blockSize_, blockSize_, pBuffer_);
 
-  pBuffer[sizeof(SectionHeadBlock_t) + 7U] = '1';           // Section2 -> Section1
-  pBuffer[offsetof(CommonBlockHead_t, sectionNameHash)]--;  // Update name hash
+  pBuffer_[sizeof(SectionHeadBlock_t) + 7U] = '1';           // Section2 -> Section1
+  pBuffer_[offsetof(CommonBlockHead_t, sectionNameHash)]--;  // Update name hash
 
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 0] = 0x00; // set version LB
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 1] = 0x00; // set version HB
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 0] = 0x00; // set version LB
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 1] = 0x00; // set version HB
 
-  fakeStorage.Write(3U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Write(3U * blockSize_, blockSize_, pBuffer_);
   UpdateCRC(3);
 
   // test
-  uut.MountStep1();
-  data2.Compare("Section1", uut);
+  uut_.MountStep1();
+  data2.Compare("Section1", uut_);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_RemainingBytes)
 {
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Test.dat", false);
+  spISW = uut_.Create("Test.dat", false);
   spISW->Write_uint8(0xFAU);
   spISW->Write_uint8(0x12U);
   spISW->Close();
   spISW.reset();
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Test.dat");
+  spISR = uut_.Open("Test.dat");
 
   ASSERT_FALSE(spISR->IsRemainingBytesSupported());
 
@@ -2879,18 +2879,18 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_RemainingBytes
   ASSERT_EQ(gpcc::stream::IStreamReader::States::closed, spISR->GetState());
   EXPECT_THROW((void)spISR->RemainingBytes(), gpcc::stream::ClosedError);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_EmptySection)
 {
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
+  spISW = uut_.Create("Section1", false);
   spISW.reset();
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
   ASSERT_EQ(gpcc::stream::IStreamReader::States::empty, spISR->GetState());
   uint8_t data;
   ASSERT_THROW(*spISR >> data, gpcc::stream::EmptyError);
@@ -2898,21 +2898,21 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_EmptySection)
   spISR->Close();
   spISR.reset();
 
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::mounted, uut.GetState());
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::mounted, uut_.GetState());
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadAndSectionBecomesEmpty)
 {
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
+  spISW = uut_.Create("Section1", false);
   spISW->Write_uint8(55);
   spISW.reset();
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
   ASSERT_EQ(gpcc::stream::IStreamReader::States::open, spISR->GetState());
   uint8_t data;
   *spISR >> data;
@@ -2921,14 +2921,14 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadAndSection
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadStrings)
 {
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
+  spISW = uut_.Create("Section1", false);
   *spISW << std::string("Str1");
   *spISW << std::string("Str2");
   spISW->Write_line("Str3");
@@ -2937,7 +2937,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadStrings)
   spISW.reset();
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   std::string s;
   *spISR >> s;
@@ -2956,31 +2956,31 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadStrings)
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadString_NullTermIsLastByteInBlock)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < bytesPerBlock - 5U; i++)
+  spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < bytesPerBlock_ - 5U; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
   *spISW << std::string("Str1");
-  EXPECT_EQ(0U, fakeStorage.writeAccessCnt);
+  EXPECT_EQ(0U, fakeStorage_.writeAccessCnt);
   *spISW << static_cast<uint8_t>(0x55);
-  EXPECT_EQ(1U, fakeStorage.writeAccessCnt);
+  EXPECT_EQ(1U, fakeStorage_.writeAccessCnt);
   spISW.reset();
 
-  ASSERT_EQ(3U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(3U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   uint8_t data;
-  for (size_t i = 0; i < bytesPerBlock - 5U; i++)
+  for (size_t i = 0; i < bytesPerBlock_ - 5U; i++)
   {
     *spISR >> data;
     ASSERT_EQ(static_cast<uint8_t>(i & 0xFFU), data);
@@ -2995,27 +2995,27 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadString_Nul
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadString_NullTermIsLastByteInBlockAndNoNextBlock)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < bytesPerBlock - 5U; i++)
+  spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < bytesPerBlock_ - 5U; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
   *spISW << std::string("Str1");
   spISW.reset();
 
-  ASSERT_EQ(2U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(2U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
-  for (size_t i = 0; i < bytesPerBlock - 5U; i++)
+  for (size_t i = 0; i < bytesPerBlock_ - 5U; i++)
   {
     uint8_t data;
     *spISR >> data;
@@ -3029,27 +3029,27 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadString_Nul
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadString_StringSpansOverStorageBlockBoundary)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < bytesPerBlock - 3U; i++)
+  spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < bytesPerBlock_ - 3U; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
   *spISW << std::string("Str1");
   spISW.reset();
 
-  ASSERT_EQ(3U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(3U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
-  for (size_t i = 0; i < bytesPerBlock - 3U; i++)
+  for (size_t i = 0; i < bytesPerBlock_ - 3U; i++)
   {
     uint8_t data;
     *spISR >> data;
@@ -3063,29 +3063,29 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadString_Str
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadString_StringSpansOverStorageBlockBoundaryPlusData)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < bytesPerBlock - 3U; i++)
+  spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < bytesPerBlock_ - 3U; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
   *spISW << std::string("Str1");
   *spISW << static_cast<uint8_t>(0x55U);
   spISW.reset();
 
-  ASSERT_EQ(3U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(3U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   uint8_t data;
-  for (size_t i = 0; i < bytesPerBlock - 3U; i++)
+  for (size_t i = 0; i < bytesPerBlock_ - 3U; i++)
   {
     *spISR >> data;
     ASSERT_EQ(static_cast<uint8_t>(i & 0xFFU), data);
@@ -3100,27 +3100,27 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadString_Str
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadString_StringSpansOverStorageBlockBoundaryNullTermIsFirstByteInNextBlock)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < bytesPerBlock - 4U; i++)
+  spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < bytesPerBlock_ - 4U; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
   *spISW << std::string("Str1");
   spISW.reset();
 
-  ASSERT_EQ(3U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(3U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
-  for (size_t i = 0; i < bytesPerBlock - 4U; i++)
+  for (size_t i = 0; i < bytesPerBlock_ - 4U; i++)
   {
     uint8_t data;
     *spISR >> data;
@@ -3134,30 +3134,30 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadString_Str
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadString_StringSpansOverStorageBlockBoundaryNullTermIsFirstByteInNextBlockPlusData)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < bytesPerBlock - 4U; i++)
+  spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < bytesPerBlock_ - 4U; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
   *spISW << std::string("Str1");
-  EXPECT_EQ(1U, fakeStorage.writeAccessCnt);
+  EXPECT_EQ(1U, fakeStorage_.writeAccessCnt);
   *spISW << static_cast<uint8_t>(0x55U);
   spISW.reset();
 
-  ASSERT_EQ(3U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(3U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   uint8_t data;
-  for (size_t i = 0; i < bytesPerBlock - 4U; i++)
+  for (size_t i = 0; i < bytesPerBlock_ - 4U; i++)
   {
     *spISR >> data;
     ASSERT_EQ(static_cast<uint8_t>(i & 0xFFU), data);
@@ -3172,23 +3172,23 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadString_Str
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadString_NoNullTerminator)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
+  spISW = uut_.Create("Section1", false);
   spISW->Write_char("Str1", 4);
   spISW.reset();
 
-  ASSERT_EQ(2U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(2U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   std::string s;
   ASSERT_THROW(*spISR >> s, gpcc::stream::EmptyError);
@@ -3196,31 +3196,31 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadString_NoN
   spISR->Close();
   spISR.reset();
 
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::mounted, uut.GetState());
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::mounted, uut_.GetState());
 
-  BasicTest_WriteRead(&uut, blockSize, 1);
+  BasicTest_WriteRead(&uut_, blockSize_, 1);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadString_NoNullTerminatorAtEndOfBlock)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < bytesPerBlock - 4U; i++)
+  spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < bytesPerBlock_ - 4U; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
   spISW->Write_char("Str1", 4);
   spISW.reset();
 
-  ASSERT_EQ(2U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(2U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
-  for (size_t i = 0; i < bytesPerBlock - 4U; i++)
+  for (size_t i = 0; i < bytesPerBlock_ - 4U; i++)
   {
     uint8_t data;
     *spISR >> data;
@@ -3233,29 +3233,29 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadString_NoN
   spISR->Close();
   spISR.reset();
 
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::mounted, uut.GetState());
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::mounted, uut_.GetState());
 
-  BasicTest_WriteRead(&uut, blockSize, 1);
+  BasicTest_WriteRead(&uut_, blockSize_, 1);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_DifferentLineEndings)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
+  spISW = uut_.Create("Section1", false);
   spISW->Write_string("Line1\nLine2\rLine3\r\nLine4");
   *spISW << static_cast<uint8_t>(0x55);
-  EXPECT_EQ(0U, fakeStorage.writeAccessCnt);
+  EXPECT_EQ(0U, fakeStorage_.writeAccessCnt);
   spISW.reset();
 
-  ASSERT_EQ(2U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(2U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   uint8_t data;
   std::string s = spISR->Read_line();
@@ -3272,31 +3272,31 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_Diffe
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_EmptyStr_NUL_TermCharIsLastByteInBlock)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < bytesPerBlock - 1U; i++)
+  spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < bytesPerBlock_ - 1U; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
   spISW->Write_uint8(0x00);
-  EXPECT_EQ(0U, fakeStorage.writeAccessCnt);
+  EXPECT_EQ(0U, fakeStorage_.writeAccessCnt);
   *spISW << static_cast<uint8_t>(0x55);
-  EXPECT_EQ(1U, fakeStorage.writeAccessCnt);
+  EXPECT_EQ(1U, fakeStorage_.writeAccessCnt);
   spISW.reset();
 
-  ASSERT_EQ(3U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(3U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   uint8_t data;
-  for (size_t i = 0; i < bytesPerBlock - 1U; i++)
+  for (size_t i = 0; i < bytesPerBlock_ - 1U; i++)
   {
     *spISR >> data;
     ASSERT_EQ(static_cast<uint8_t>(i & 0xFFU), data);
@@ -3310,31 +3310,31 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_Empty
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_EmptyStr_LF_TermCharIsLastByteInBlock)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < bytesPerBlock - 1U; i++)
+  spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < bytesPerBlock_ - 1U; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
   spISW->Write_char('\n');
-  EXPECT_EQ(0U, fakeStorage.writeAccessCnt);
+  EXPECT_EQ(0U, fakeStorage_.writeAccessCnt);
   *spISW << static_cast<uint8_t>(0x55);
-  EXPECT_EQ(1U, fakeStorage.writeAccessCnt);
+  EXPECT_EQ(1U, fakeStorage_.writeAccessCnt);
   spISW.reset();
 
-  ASSERT_EQ(3U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(3U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   uint8_t data;
-  for (size_t i = 0; i < bytesPerBlock - 1U; i++)
+  for (size_t i = 0; i < bytesPerBlock_ - 1U; i++)
   {
     *spISR >> data;
     ASSERT_EQ(static_cast<uint8_t>(i & 0xFFU), data);
@@ -3348,31 +3348,31 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_Empty
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_EmptyStr_CR_TermCharIsLastByteInBlock)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < bytesPerBlock - 1U; i++)
+  spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < bytesPerBlock_ - 1U; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
   spISW->Write_char('\r');
-  EXPECT_EQ(0U, fakeStorage.writeAccessCnt);
+  EXPECT_EQ(0U, fakeStorage_.writeAccessCnt);
   *spISW << static_cast<uint8_t>(0x55);
-  EXPECT_EQ(1U, fakeStorage.writeAccessCnt);
+  EXPECT_EQ(1U, fakeStorage_.writeAccessCnt);
   spISW.reset();
 
-  ASSERT_EQ(3U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(3U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   uint8_t data;
-  for (size_t i = 0; i < bytesPerBlock - 1U; i++)
+  for (size_t i = 0; i < bytesPerBlock_ - 1U; i++)
   {
     *spISR >> data;
     ASSERT_EQ(static_cast<uint8_t>(i & 0xFFU), data);
@@ -3386,32 +3386,32 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_Empty
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_EmptyStr_CRLF_TermCharsAreInBothBlocks)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < bytesPerBlock - 1U; i++)
+  spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < bytesPerBlock_ - 1U; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
   spISW->Write_char('\r');
-  EXPECT_EQ(0U, fakeStorage.writeAccessCnt);
+  EXPECT_EQ(0U, fakeStorage_.writeAccessCnt);
   spISW->Write_char('\n');
-  EXPECT_EQ(1U, fakeStorage.writeAccessCnt);
+  EXPECT_EQ(1U, fakeStorage_.writeAccessCnt);
   *spISW << static_cast<uint8_t>(0x55);
   spISW.reset();
 
-  ASSERT_EQ(3U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(3U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   uint8_t data;
-  for (size_t i = 0; i < bytesPerBlock - 1U; i++)
+  for (size_t i = 0; i < bytesPerBlock_ - 1U; i++)
   {
     *spISR >> data;
     ASSERT_EQ(static_cast<uint8_t>(i & 0xFFU), data);
@@ -3425,32 +3425,32 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_Empty
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_EmptyStr_CRLF_TermCharIsLastByteInBlock)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < bytesPerBlock - 2U; i++)
+  spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < bytesPerBlock_ - 2U; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
   spISW->Write_char('\r');
   spISW->Write_char('\n');
-  EXPECT_EQ(0U, fakeStorage.writeAccessCnt);
+  EXPECT_EQ(0U, fakeStorage_.writeAccessCnt);
   *spISW << static_cast<uint8_t>(0x55);
-  EXPECT_EQ(1U, fakeStorage.writeAccessCnt);
+  EXPECT_EQ(1U, fakeStorage_.writeAccessCnt);
   spISW.reset();
 
-  ASSERT_EQ(3U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(3U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   uint8_t data;
-  for (size_t i = 0; i < bytesPerBlock - 2U; i++)
+  for (size_t i = 0; i < bytesPerBlock_ - 2U; i++)
   {
     *spISR >> data;
     ASSERT_EQ(static_cast<uint8_t>(i & 0xFFU), data);
@@ -3464,29 +3464,29 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_Empty
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_EmptyStr_NUL_EOF)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < bytesPerBlock - 2U; i++)
+  spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < bytesPerBlock_ - 2U; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
   spISW->Write_uint8(0x00);
-  EXPECT_EQ(0U, fakeStorage.writeAccessCnt);
+  EXPECT_EQ(0U, fakeStorage_.writeAccessCnt);
   spISW.reset();
 
-  ASSERT_EQ(2U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(2U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   uint8_t data;
-  for (size_t i = 0; i < bytesPerBlock - 2U; i++)
+  for (size_t i = 0; i < bytesPerBlock_ - 2U; i++)
   {
     *spISR >> data;
     ASSERT_EQ(static_cast<uint8_t>(i & 0xFFU), data);
@@ -3498,29 +3498,29 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_Empty
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_EmptyStr_LF_EOF)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < bytesPerBlock - 2U; i++)
+  spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < bytesPerBlock_ - 2U; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
   spISW->Write_char('\n');
-  EXPECT_EQ(0U, fakeStorage.writeAccessCnt);
+  EXPECT_EQ(0U, fakeStorage_.writeAccessCnt);
   spISW.reset();
 
-  ASSERT_EQ(2U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(2U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   uint8_t data;
-  for (size_t i = 0; i < bytesPerBlock - 2U; i++)
+  for (size_t i = 0; i < bytesPerBlock_ - 2U; i++)
   {
     *spISR >> data;
     ASSERT_EQ(static_cast<uint8_t>(i & 0xFFU), data);
@@ -3532,29 +3532,29 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_Empty
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_EmptyStr_CR_EOF)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < bytesPerBlock - 2U; i++)
+  spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < bytesPerBlock_ - 2U; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
   spISW->Write_char('\r');
-  EXPECT_EQ(0U, fakeStorage.writeAccessCnt);
+  EXPECT_EQ(0U, fakeStorage_.writeAccessCnt);
   spISW.reset();
 
-  ASSERT_EQ(2U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(2U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   uint8_t data;
-  for (size_t i = 0; i < bytesPerBlock - 2U; i++)
+  for (size_t i = 0; i < bytesPerBlock_ - 2U; i++)
   {
     *spISR >> data;
     ASSERT_EQ(static_cast<uint8_t>(i & 0xFFU), data);
@@ -3566,30 +3566,30 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_Empty
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_EmptyStr_CRLF_EOF)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < bytesPerBlock - 3U; i++)
+  spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < bytesPerBlock_ - 3U; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
   spISW->Write_char('\r');
   spISW->Write_char('\n');
-  EXPECT_EQ(0U, fakeStorage.writeAccessCnt);
+  EXPECT_EQ(0U, fakeStorage_.writeAccessCnt);
   spISW.reset();
 
-  ASSERT_EQ(2U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(2U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   uint8_t data;
-  for (size_t i = 0; i < bytesPerBlock - 3U; i++)
+  for (size_t i = 0; i < bytesPerBlock_ - 3U; i++)
   {
     *spISR >> data;
     ASSERT_EQ(static_cast<uint8_t>(i & 0xFFU), data);
@@ -3601,29 +3601,29 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_Empty
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_EmptyStr_NUL_EOFandBlockEnd)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < bytesPerBlock - 1U; i++)
+  spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < bytesPerBlock_ - 1U; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
   spISW->Write_uint8(0x00);
-  EXPECT_EQ(0U, fakeStorage.writeAccessCnt);
+  EXPECT_EQ(0U, fakeStorage_.writeAccessCnt);
   spISW.reset();
 
-  ASSERT_EQ(2U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(2U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   uint8_t data;
-  for (size_t i = 0; i < bytesPerBlock - 1U; i++)
+  for (size_t i = 0; i < bytesPerBlock_ - 1U; i++)
   {
     *spISR >> data;
     ASSERT_EQ(static_cast<uint8_t>(i & 0xFFU), data);
@@ -3635,29 +3635,29 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_Empty
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_EmptyStr_LF_EOFandBlockEnd)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < bytesPerBlock - 1U; i++)
+  spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < bytesPerBlock_ - 1U; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
   spISW->Write_char('\n');
-  EXPECT_EQ(0U, fakeStorage.writeAccessCnt);
+  EXPECT_EQ(0U, fakeStorage_.writeAccessCnt);
   spISW.reset();
 
-  ASSERT_EQ(2U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(2U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   uint8_t data;
-  for (size_t i = 0; i < bytesPerBlock - 1U; i++)
+  for (size_t i = 0; i < bytesPerBlock_ - 1U; i++)
   {
     *spISR >> data;
     ASSERT_EQ(static_cast<uint8_t>(i & 0xFFU), data);
@@ -3669,29 +3669,29 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_Empty
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_EmptyStr_CR_EOFandBlockEnd)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < bytesPerBlock - 1U; i++)
+  spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < bytesPerBlock_ - 1U; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
   spISW->Write_char('\r');
-  EXPECT_EQ(0U, fakeStorage.writeAccessCnt);
+  EXPECT_EQ(0U, fakeStorage_.writeAccessCnt);
   spISW.reset();
 
-  ASSERT_EQ(2U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(2U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   uint8_t data;
-  for (size_t i = 0; i < bytesPerBlock - 1U; i++)
+  for (size_t i = 0; i < bytesPerBlock_ - 1U; i++)
   {
     *spISR >> data;
     ASSERT_EQ(static_cast<uint8_t>(i & 0xFFU), data);
@@ -3703,30 +3703,30 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_Empty
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_EmptyStr_CRLF_EOFandBlockEnd)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < bytesPerBlock - 2U; i++)
+  spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < bytesPerBlock_ - 2U; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
   spISW->Write_char('\r');
   spISW->Write_char('\n');
-  EXPECT_EQ(0U, fakeStorage.writeAccessCnt);
+  EXPECT_EQ(0U, fakeStorage_.writeAccessCnt);
   spISW.reset();
 
-  ASSERT_EQ(2U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(2U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   uint8_t data;
-  for (size_t i = 0; i < bytesPerBlock - 2U; i++)
+  for (size_t i = 0; i < bytesPerBlock_ - 2U; i++)
   {
     *spISR >> data;
     ASSERT_EQ(static_cast<uint8_t>(i & 0xFFU), data);
@@ -3738,31 +3738,31 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_Empty
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_NUL_TermCharIsLastByteInBlock)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < bytesPerBlock - 4U; i++)
+  spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < bytesPerBlock_ - 4U; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
   spISW->Write_string("ABC");
-  EXPECT_EQ(0U, fakeStorage.writeAccessCnt);
+  EXPECT_EQ(0U, fakeStorage_.writeAccessCnt);
   *spISW << static_cast<uint8_t>(0x55);
-  EXPECT_EQ(1U, fakeStorage.writeAccessCnt);
+  EXPECT_EQ(1U, fakeStorage_.writeAccessCnt);
   spISW.reset();
 
-  ASSERT_EQ(3U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(3U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   uint8_t data;
-  for (size_t i = 0; i < bytesPerBlock - 4U; i++)
+  for (size_t i = 0; i < bytesPerBlock_ - 4U; i++)
   {
     *spISR >> data;
     ASSERT_EQ(static_cast<uint8_t>(i & 0xFFU), data);
@@ -3776,31 +3776,31 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_NUL_T
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_LF_TermCharIsLastByteInBlock)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < bytesPerBlock - 4U; i++)
+  spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < bytesPerBlock_ - 4U; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
   spISW->Write_char("ABC\n", 4U);
-  EXPECT_EQ(0U, fakeStorage.writeAccessCnt);
+  EXPECT_EQ(0U, fakeStorage_.writeAccessCnt);
   *spISW << static_cast<uint8_t>(0x55);
-  EXPECT_EQ(1U, fakeStorage.writeAccessCnt);
+  EXPECT_EQ(1U, fakeStorage_.writeAccessCnt);
   spISW.reset();
 
-  ASSERT_EQ(3U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(3U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   uint8_t data;
-  for (size_t i = 0; i < bytesPerBlock - 4U; i++)
+  for (size_t i = 0; i < bytesPerBlock_ - 4U; i++)
   {
     *spISR >> data;
     ASSERT_EQ(static_cast<uint8_t>(i & 0xFFU), data);
@@ -3814,31 +3814,31 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_LF_Te
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_CR_TermCharIsLastByteInBlock)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < bytesPerBlock - 4U; i++)
+  spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < bytesPerBlock_ - 4U; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
   spISW->Write_char("ABC\r", 4U);
-  EXPECT_EQ(0U, fakeStorage.writeAccessCnt);
+  EXPECT_EQ(0U, fakeStorage_.writeAccessCnt);
   *spISW << static_cast<uint8_t>(0x55);
-  EXPECT_EQ(1U, fakeStorage.writeAccessCnt);
+  EXPECT_EQ(1U, fakeStorage_.writeAccessCnt);
   spISW.reset();
 
-  ASSERT_EQ(3U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(3U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   uint8_t data;
-  for (size_t i = 0; i < bytesPerBlock - 4U; i++)
+  for (size_t i = 0; i < bytesPerBlock_ - 4U; i++)
   {
     *spISR >> data;
     ASSERT_EQ(static_cast<uint8_t>(i & 0xFFU), data);
@@ -3852,31 +3852,31 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_CR_Te
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_CRLF_TermCharsAreInBothBlocks)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < bytesPerBlock - 4U; i++)
+  spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < bytesPerBlock_ - 4U; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
   spISW->Write_char("ABC\r\n", 5U);
-  EXPECT_EQ(1U, fakeStorage.writeAccessCnt);
+  EXPECT_EQ(1U, fakeStorage_.writeAccessCnt);
   *spISW << static_cast<uint8_t>(0x55);
-  EXPECT_EQ(1U, fakeStorage.writeAccessCnt);
+  EXPECT_EQ(1U, fakeStorage_.writeAccessCnt);
   spISW.reset();
 
-  ASSERT_EQ(3U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(3U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   uint8_t data;
-  for (size_t i = 0; i < bytesPerBlock - 4U; i++)
+  for (size_t i = 0; i < bytesPerBlock_ - 4U; i++)
   {
     *spISR >> data;
     ASSERT_EQ(static_cast<uint8_t>(i & 0xFFU), data);
@@ -3890,31 +3890,31 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_CRLF_
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_CRLF_TermCharIsLastByteInBlock)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < bytesPerBlock - 5U; i++)
+  spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < bytesPerBlock_ - 5U; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
   spISW->Write_char("ABC\r\n", 5U);
-  EXPECT_EQ(0U, fakeStorage.writeAccessCnt);
+  EXPECT_EQ(0U, fakeStorage_.writeAccessCnt);
   *spISW << static_cast<uint8_t>(0x55);
-  EXPECT_EQ(1U, fakeStorage.writeAccessCnt);
+  EXPECT_EQ(1U, fakeStorage_.writeAccessCnt);
   spISW.reset();
 
-  ASSERT_EQ(3U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(3U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   uint8_t data;
-  for (size_t i = 0; i < bytesPerBlock - 5U; i++)
+  for (size_t i = 0; i < bytesPerBlock_ - 5U; i++)
   {
     *spISR >> data;
     ASSERT_EQ(static_cast<uint8_t>(i & 0xFFU), data);
@@ -3928,29 +3928,29 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_CRLF_
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_NUL_EOF)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < bytesPerBlock - 5U; i++)
+  spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < bytesPerBlock_ - 5U; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
   spISW->Write_string("ABC");
-  EXPECT_EQ(0U, fakeStorage.writeAccessCnt);
+  EXPECT_EQ(0U, fakeStorage_.writeAccessCnt);
   spISW.reset();
 
-  ASSERT_EQ(2U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(2U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   uint8_t data;
-  for (size_t i = 0; i < bytesPerBlock - 5U; i++)
+  for (size_t i = 0; i < bytesPerBlock_ - 5U; i++)
   {
     *spISR >> data;
     ASSERT_EQ(static_cast<uint8_t>(i & 0xFFU), data);
@@ -3962,29 +3962,29 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_NUL_E
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_LF_EOF)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < bytesPerBlock - 5U; i++)
+  spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < bytesPerBlock_ - 5U; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
   spISW->Write_char("ABC\n", 4U);
-  EXPECT_EQ(0U, fakeStorage.writeAccessCnt);
+  EXPECT_EQ(0U, fakeStorage_.writeAccessCnt);
   spISW.reset();
 
-  ASSERT_EQ(2U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(2U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   uint8_t data;
-  for (size_t i = 0; i < bytesPerBlock - 5U; i++)
+  for (size_t i = 0; i < bytesPerBlock_ - 5U; i++)
   {
     *spISR >> data;
     ASSERT_EQ(static_cast<uint8_t>(i & 0xFFU), data);
@@ -3996,29 +3996,29 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_LF_EO
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_CR_EOF)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < bytesPerBlock - 5U; i++)
+  spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < bytesPerBlock_ - 5U; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
   spISW->Write_char("ABC\r", 4U);
-  EXPECT_EQ(0U, fakeStorage.writeAccessCnt);
+  EXPECT_EQ(0U, fakeStorage_.writeAccessCnt);
   spISW.reset();
 
-  ASSERT_EQ(2U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(2U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   uint8_t data;
-  for (size_t i = 0; i < bytesPerBlock - 5U; i++)
+  for (size_t i = 0; i < bytesPerBlock_ - 5U; i++)
   {
     *spISR >> data;
     ASSERT_EQ(static_cast<uint8_t>(i & 0xFFU), data);
@@ -4030,29 +4030,29 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_CR_EO
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_CRLF_EOF)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < bytesPerBlock - 6U; i++)
+  spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < bytesPerBlock_ - 6U; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
   spISW->Write_char("ABC\r\n", 5U);
-  EXPECT_EQ(0U, fakeStorage.writeAccessCnt);
+  EXPECT_EQ(0U, fakeStorage_.writeAccessCnt);
   spISW.reset();
 
-  ASSERT_EQ(2U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(2U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   uint8_t data;
-  for (size_t i = 0; i < bytesPerBlock - 6U; i++)
+  for (size_t i = 0; i < bytesPerBlock_ - 6U; i++)
   {
     *spISR >> data;
     ASSERT_EQ(static_cast<uint8_t>(i & 0xFFU), data);
@@ -4064,29 +4064,29 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_CRLF_
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_NUL_EOFandBlockEnd)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < bytesPerBlock - 4U; i++)
+  spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < bytesPerBlock_ - 4U; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
   spISW->Write_string("ABC");
-  EXPECT_EQ(0U, fakeStorage.writeAccessCnt);
+  EXPECT_EQ(0U, fakeStorage_.writeAccessCnt);
   spISW.reset();
 
-  ASSERT_EQ(2U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(2U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   uint8_t data;
-  for (size_t i = 0; i < bytesPerBlock - 4U; i++)
+  for (size_t i = 0; i < bytesPerBlock_ - 4U; i++)
   {
     *spISR >> data;
     ASSERT_EQ(static_cast<uint8_t>(i & 0xFFU), data);
@@ -4098,29 +4098,29 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_NUL_E
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_LF_EOFandBlockEnd)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < bytesPerBlock - 4U; i++)
+  spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < bytesPerBlock_ - 4U; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
   spISW->Write_char("ABC\n", 4U);
-  EXPECT_EQ(0U, fakeStorage.writeAccessCnt);
+  EXPECT_EQ(0U, fakeStorage_.writeAccessCnt);
   spISW.reset();
 
-  ASSERT_EQ(2U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(2U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   uint8_t data;
-  for (size_t i = 0; i < bytesPerBlock - 4U; i++)
+  for (size_t i = 0; i < bytesPerBlock_ - 4U; i++)
   {
     *spISR >> data;
     ASSERT_EQ(static_cast<uint8_t>(i & 0xFFU), data);
@@ -4132,29 +4132,29 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_LF_EO
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_CR_EOFandBlockEnd)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < bytesPerBlock - 4U; i++)
+  spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < bytesPerBlock_ - 4U; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
   spISW->Write_char("ABC\r", 4U);
-  EXPECT_EQ(0U, fakeStorage.writeAccessCnt);
+  EXPECT_EQ(0U, fakeStorage_.writeAccessCnt);
   spISW.reset();
 
-  ASSERT_EQ(2U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(2U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   uint8_t data;
-  for (size_t i = 0; i < bytesPerBlock - 4U; i++)
+  for (size_t i = 0; i < bytesPerBlock_ - 4U; i++)
   {
     *spISR >> data;
     ASSERT_EQ(static_cast<uint8_t>(i & 0xFFU), data);
@@ -4166,29 +4166,29 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_CR_EO
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_CRLF_EOFandBlockEnd)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < bytesPerBlock - 5U; i++)
+  spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < bytesPerBlock_ - 5U; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
   spISW->Write_char("ABC\r\n", 5U);
-  EXPECT_EQ(0U, fakeStorage.writeAccessCnt);
+  EXPECT_EQ(0U, fakeStorage_.writeAccessCnt);
   spISW.reset();
 
-  ASSERT_EQ(2U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(2U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   uint8_t data;
-  for (size_t i = 0; i < bytesPerBlock - 5U; i++)
+  for (size_t i = 0; i < bytesPerBlock_ - 5U; i++)
   {
     *spISR >> data;
     ASSERT_EQ(static_cast<uint8_t>(i & 0xFFU), data);
@@ -4200,23 +4200,23 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_CRLF_
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_NoTermCharAtEOF)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
+  spISW = uut_.Create("Section1", false);
   spISW->Write_char("Str1", 4);
   spISW.reset();
 
-  ASSERT_EQ(2U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(2U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   std::string s;
   s = spISR->Read_line();
@@ -4225,31 +4225,31 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_NoTer
   spISR->Close();
   spISR.reset();
 
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::mounted, uut.GetState());
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::mounted, uut_.GetState());
 
-  BasicTest_WriteRead(&uut, blockSize, 1);
+  BasicTest_WriteRead(&uut_, blockSize_, 1);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_NoTermCharAtEOF_AtBlockEnd)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < bytesPerBlock - 4U; i++)
+  spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < bytesPerBlock_ - 4U; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
   spISW->Write_char("Str1", 4);
   spISW.reset();
 
-  ASSERT_EQ(2U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(2U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
-  for (size_t i = 0; i < bytesPerBlock - 4U; i++)
+  for (size_t i = 0; i < bytesPerBlock_ - 4U; i++)
   {
     uint8_t data;
     *spISR >> data;
@@ -4263,31 +4263,31 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_NoTer
   spISR->Close();
   spISR.reset();
 
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::mounted, uut.GetState());
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::mounted, uut_.GetState());
 
-  BasicTest_WriteRead(&uut, blockSize, 1);
+  BasicTest_WriteRead(&uut_, blockSize_, 1);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_StringSpansOverStorageBlockBoundary)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < bytesPerBlock - 3U; i++)
+  spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < bytesPerBlock_ - 3U; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
   spISW->Write_char("Str1\n", 5);
   spISW.reset();
 
-  ASSERT_EQ(3U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(3U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
-  for (size_t i = 0; i < bytesPerBlock - 3U; i++)
+  for (size_t i = 0; i < bytesPerBlock_ - 3U; i++)
   {
     uint8_t data;
     *spISR >> data;
@@ -4300,34 +4300,34 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_Strin
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_StringSpansOverStorageBlockBoundary_ErrDuringReadNextBlock)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < bytesPerBlock - 3U; i++)
+  spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < bytesPerBlock_ - 3U; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
   spISW->Write_char("Str1\n", 5);
   spISW.reset();
 
-  ASSERT_EQ(3U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(3U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
-  for (size_t i = 0; i < bytesPerBlock - 3U; i++)
+  for (size_t i = 0; i < bytesPerBlock_ - 3U; i++)
   {
     uint8_t data;
     *spISR >> data;
     ASSERT_EQ(static_cast<uint8_t>(i & 0xFFU), data);
   }
 
-  fakeStorage.readAccessesTillThrow = 1U;
+  fakeStorage_.readAccessesTillThrow = 1U;
 
   std::string s;
   EXPECT_THROW(s = spISR->Read_line(), std::runtime_error);
@@ -4335,29 +4335,29 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_Strin
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_StringSpansOverStorageBlockBoundaryPlusData)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < bytesPerBlock - 3U; i++)
+  spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < bytesPerBlock_ - 3U; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
   spISW->Write_char("Str1\n", 5);
   *spISW << static_cast<uint8_t>(0x55U);
   spISW.reset();
 
-  ASSERT_EQ(3U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(3U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   uint8_t data;
-  for (size_t i = 0; i < bytesPerBlock - 3U; i++)
+  for (size_t i = 0; i < bytesPerBlock_ - 3U; i++)
   {
     *spISR >> data;
     ASSERT_EQ(static_cast<uint8_t>(i & 0xFFU), data);
@@ -4371,27 +4371,27 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_Strin
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_StringSpansOverStorageBlockBoundary_LFisFirstByteInNextBlock)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < bytesPerBlock - 4U; i++)
+  spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < bytesPerBlock_ - 4U; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
   spISW->Write_char("Str1\n", 5);
   spISW.reset();
 
-  ASSERT_EQ(3U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(3U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
-  for (size_t i = 0; i < bytesPerBlock - 4U; i++)
+  for (size_t i = 0; i < bytesPerBlock_ - 4U; i++)
   {
     uint8_t data;
     *spISR >> data;
@@ -4404,32 +4404,32 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_Strin
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_StringSpansOverStorageBlockBoundary_LFisFirstByteInNextBlockPlusData)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < bytesPerBlock - 4U; i++)
+  spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < bytesPerBlock_ - 4U; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
   spISW->Write_char("Str1", 4);
-  EXPECT_EQ(0U, fakeStorage.writeAccessCnt);
+  EXPECT_EQ(0U, fakeStorage_.writeAccessCnt);
   spISW->Write_char('\n');
-  EXPECT_EQ(1U, fakeStorage.writeAccessCnt);
+  EXPECT_EQ(1U, fakeStorage_.writeAccessCnt);
   *spISW << static_cast<uint8_t>(0x55U);
   spISW.reset();
 
-  ASSERT_EQ(3U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(3U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   uint8_t data;
-  for (size_t i = 0; i < bytesPerBlock - 4U; i++)
+  for (size_t i = 0; i < bytesPerBlock_ - 4U; i++)
   {
     *spISR >> data;
     ASSERT_EQ(static_cast<uint8_t>(i & 0xFFU), data);
@@ -4443,29 +4443,29 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadLine_Strin
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadByte_LastByteOfLastBlock)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < bytesPerBlock - 1U; i++)
+  spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < bytesPerBlock_ - 1U; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
   *spISW << static_cast<uint8_t>(0xEEU);
   spISW.reset();
 
-  ASSERT_EQ(2U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(2U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   uint8_t data;
 
-  for (size_t i = 0; i < bytesPerBlock - 1U; i++)
+  for (size_t i = 0; i < bytesPerBlock_ - 1U; i++)
   {
     *spISR >> data;
     ASSERT_EQ(static_cast<uint8_t>(i & 0xFFU), data);
@@ -4481,29 +4481,29 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadByte_LastB
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadByte_ErrorOnlyFewBitsLeft)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < bytesPerBlock - 1U; i++)
+  spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < bytesPerBlock_ - 1U; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
   *spISW << static_cast<uint8_t>(0xEEU);
   spISW.reset();
 
-  ASSERT_EQ(2U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(2U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   uint8_t data;
 
-  for (size_t i = 0; i < bytesPerBlock - 1U; i++)
+  for (size_t i = 0; i < bytesPerBlock_ - 1U; i++)
   {
     *spISR >> data;
     ASSERT_EQ(static_cast<uint8_t>(i & 0xFFU), data);
@@ -4522,87 +4522,87 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadByte_Error
   spISR->Close();
   spISR.reset();
 
-  BasicTest_WriteRead(&uut, blockSize, 1);
+  BasicTest_WriteRead(&uut_, blockSize_, 1);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadChunkOfBytes_LastBytesOfLastBlock)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < 2U * bytesPerBlock; i++)
+  spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < 2U * bytesPerBlock_; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
   spISW.reset();
 
-  ASSERT_EQ(3U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(3U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   std::vector<uint8_t> data;
-  data.resize(2U * bytesPerBlock);
+  data.resize(2U * bytesPerBlock_);
 
-  spISR->Read_uint8(data.data(), 2U * bytesPerBlock);
+  spISR->Read_uint8(data.data(), 2U * bytesPerBlock_);
 
   ASSERT_EQ(gpcc::stream::IStreamReader::States::empty, spISR->GetState());
 
   spISR->Close();
   spISR.reset();
 
-  for (size_t i = 0; i < 2U * bytesPerBlock; i++)
+  for (size_t i = 0; i < 2U * bytesPerBlock_; i++)
   {
     ASSERT_EQ(i & 0xFFU, data[i]);
   }
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadChunkOfBytes_ErrReadBeyondEndOfSection)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < 2U * bytesPerBlock; i++)
+  spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < 2U * bytesPerBlock_; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
   spISW.reset();
 
-  ASSERT_EQ(3U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(3U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   std::vector<uint8_t> data;
-  data.resize((2U * bytesPerBlock) + 2U);
+  data.resize((2U * bytesPerBlock_) + 2U);
 
-  ASSERT_THROW(spISR->Read_uint8(data.data(), (2U * bytesPerBlock) + 2U), gpcc::stream::EmptyError);
+  ASSERT_THROW(spISR->Read_uint8(data.data(), (2U * bytesPerBlock_) + 2U), gpcc::stream::EmptyError);
 
   ASSERT_EQ(gpcc::stream::IStreamReader::States::error, spISR->GetState());
 
   spISR->Close();
   spISR.reset();
 
-  BasicTest_WriteRead(&uut, blockSize, 1);
+  BasicTest_WriteRead(&uut_, blockSize_, 1);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadBits_MoreThanLeft_ButOneMoreByteAvailable)
 {
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
+  spISW = uut_.Create("Section1", false);
   spISW->Write_uint8(0x12U);
   spISW->Write_uint8(0x34U);
   spISW.reset();
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   uint8_t data;
 
@@ -4617,19 +4617,19 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadBits_MoreT
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadBits_MoreThanLeft)
 {
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
+  spISW = uut_.Create("Section1", false);
   spISW->Write_uint8(0x12U);
   spISW.reset();
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   uint8_t data;
 
@@ -4645,22 +4645,22 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadBits_MoreT
   spISR->Close();
   spISR.reset();
 
-  BasicTest_WriteRead(&uut, blockSize, 1);
+  BasicTest_WriteRead(&uut_, blockSize_, 1);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadBits_LastBitsInSection)
 {
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
+  spISW = uut_.Create("Section1", false);
   spISW->Write_uint8(0x12U);
   spISW->Write_uint8(0x34U);
   spISW.reset();
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   uint8_t data;
 
@@ -4693,19 +4693,19 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadBits_LastB
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadBits_OneByOne)
 {
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
+  spISW = uut_.Create("Section1", false);
   spISW->Write_uint8(0x12U);
   spISW.reset();
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   bool bit;
 
@@ -4744,7 +4744,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ReadBits_OneBy
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, ReadWriteBits_ProperInsertionOfGaps)
 {
@@ -4753,7 +4753,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, ReadWriteBits_ProperInsertio
   uint8_t data = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
+  spISW = uut_.Create("Section1", false);
 
   spISW->Write_uint8(0x12U);
 
@@ -4781,7 +4781,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, ReadWriteBits_ProperInsertio
   spISW.reset();
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   bool bit;
   *spISR >> data;
@@ -4828,14 +4828,14 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, ReadWriteBits_ProperInsertio
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_CRCErrorOnFirstDataBlock)
 {
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
+  spISW = uut_.Create("Section1", false);
   *spISW << std::string("Test");
   spISW.reset();
 
@@ -4843,32 +4843,32 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_CRCErrorOnFirs
   InvalidateCRC(2);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  ASSERT_THROW(spISR = uut.Open("Section1"), DataIntegrityError);
+  ASSERT_THROW(spISR = uut_.Open("Section1"), DataIntegrityError);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_CRCErrorOnSecondDataBlock)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < bytesPerBlock + 5U; i++)
+  spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < bytesPerBlock_ + 5U; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
   spISW.reset();
 
-  ASSERT_EQ(3U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(3U, fakeStorage_.writeAccessCnt);
 
   // invalid checksum of 2nd data block
   InvalidateCRC(3);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   uint8_t data;
-  for (size_t i = 0; i < bytesPerBlock - 1U; i++)
+  for (size_t i = 0; i < bytesPerBlock_ - 1U; i++)
   {
     *spISR >> data;
     ASSERT_EQ(static_cast<uint8_t>(i & 0xFFU), data);
@@ -4879,101 +4879,101 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_CRCErrorOnSeco
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ThrowOnFirstDataBlock1)
 {
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
+  spISW = uut_.Create("Section1", false);
   *spISW << std::string("Test");
   spISW.reset();
 
-  fakeStorage.readAccessesTillThrow = 4; // Hash + Head(2) + Data(1 of 2)
+  fakeStorage_.readAccessesTillThrow = 4; // Hash + Head(2) + Data(1 of 2)
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  ASSERT_THROW(spISR = uut.Open("Section1"), std::exception);
+  ASSERT_THROW(spISR = uut_.Open("Section1"), std::exception);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ThrowOnFirstDataBlock2)
 {
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
+  spISW = uut_.Create("Section1", false);
   *spISW << std::string("Test");
   spISW.reset();
 
-  fakeStorage.readAccessesTillThrow = 5; // Hash + Head(2) + Data(2 of 2)
+  fakeStorage_.readAccessesTillThrow = 5; // Hash + Head(2) + Data(2 of 2)
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  ASSERT_THROW(spISR = uut.Open("Section1"), std::exception);
+  ASSERT_THROW(spISR = uut_.Open("Section1"), std::exception);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ThrowOnSecondDataBlock1)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < bytesPerBlock + 5U; i++)
+  spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < bytesPerBlock_ + 5U; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
   spISW.reset();
 
-  ASSERT_EQ(3U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(3U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   uint8_t data;
-  for (size_t i = 0; i < bytesPerBlock - 1U; i++)
+  for (size_t i = 0; i < bytesPerBlock_ - 1U; i++)
   {
     *spISR >> data;
     ASSERT_EQ(static_cast<uint8_t>(i & 0xFFU), data);
   }
 
-  fakeStorage.readAccessesTillThrow = 1;
+  fakeStorage_.readAccessesTillThrow = 1;
   ASSERT_THROW(*spISR >> data, gpcc::stream::IOError);
   ASSERT_EQ(gpcc::stream::IStreamReader::States::error, spISR->GetState());
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_ThrowOnSecondDataBlock2)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
-  for (size_t i = 0; i < bytesPerBlock + 5U; i++)
+  spISW = uut_.Create("Section1", false);
+  for (size_t i = 0; i < bytesPerBlock_ + 5U; i++)
     *spISW << static_cast<uint8_t>(i & 0xFFU);
   spISW.reset();
 
-  ASSERT_EQ(3U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(3U, fakeStorage_.writeAccessCnt);
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   uint8_t data;
-  for (size_t i = 0; i < bytesPerBlock - 1U; i++)
+  for (size_t i = 0; i < bytesPerBlock_ - 1U; i++)
   {
     *spISR >> data;
     ASSERT_EQ(static_cast<uint8_t>(i & 0xFFU), data);
   }
 
-  fakeStorage.readAccessesTillThrow = 2;
+  fakeStorage_.readAccessesTillThrow = 2;
   ASSERT_THROW(*spISR >> data, gpcc::stream::IOError);
   ASSERT_EQ(gpcc::stream::IStreamReader::States::error, spISR->GetState());
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_EnsureAllDataConsumed_OK_1)
 {
@@ -4982,7 +4982,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_EnsureAllDataC
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Section1", false);
+  spISW = uut_.Create("Section1", false);
   spISW->Write_uint8(0xFAU);
   spISW->Write_uint8(0x12U);
   spISW->Write_uint8(0x13U);
@@ -4990,7 +4990,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_EnsureAllDataC
   spISW.reset();
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Section1");
+  spISR = uut_.Open("Section1");
 
   // (3 bytes left) -------------------------------------------------------------------------------------------
   EXPECT_THROW(spISR->EnsureAllDataConsumed(IStreamReader::RemainingNbOfBits::zero), RemainingBitsError);
@@ -5132,7 +5132,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_EnsureAllDataC
 
   spISR->Close();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_EnsureAllDataConsumed_OK_2)
 {
@@ -5141,14 +5141,14 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_EnsureAllDataC
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Test.dat", false);
+  spISW = uut_.Create("Test.dat", false);
   spISW->Write_uint8(0xFAU);
   spISW->Write_uint8(0x12U);
   spISW->Close();
   spISW.reset();
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Test.dat");
+  spISR = uut_.Open("Test.dat");
 
   // (2 bytes left) -------------------------------------------------------------------------------------------
   EXPECT_THROW(spISR->EnsureAllDataConsumed(IStreamReader::RemainingNbOfBits::zero), RemainingBitsError);
@@ -5293,7 +5293,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_EnsureAllDataC
 
   spISR->Close();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_EnsureAllDataConsumed_ErrorState)
 {
@@ -5302,14 +5302,14 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_EnsureAllDataC
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Test.dat", false);
+  spISW = uut_.Create("Test.dat", false);
   spISW->Write_uint8(0xFAU);
   spISW->Write_uint8(0x12U);
   spISW->Close();
   spISW.reset();
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Test.dat");
+  spISR = uut_.Open("Test.dat");
 
   // create error condition
   ASSERT_THROW((void)spISR->Read_uint32(), EmptyError);
@@ -5328,7 +5328,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_EnsureAllDataC
 
   spISR->Close();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_EnsureAllDataConsumed_ClosedState)
 {
@@ -5337,14 +5337,14 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_EnsureAllDataC
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Test.dat", false);
+  spISW = uut_.Create("Test.dat", false);
   spISW->Write_uint8(0xFAU);
   spISW->Write_uint8(0x12U);
   spISW->Close();
   spISW.reset();
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Test.dat");
+  spISR = uut_.Open("Test.dat");
 
   // create pre-condition
   spISR->Close();
@@ -5361,14 +5361,14 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, SectionReader_EnsureAllDataC
   EXPECT_THROW(spISR->EnsureAllDataConsumed(IStreamReader::RemainingNbOfBits::moreThanSeven), ClosedError);
   EXPECT_THROW(spISR->EnsureAllDataConsumed(IStreamReader::RemainingNbOfBits::any), ClosedError);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, AlignToByteBoundary_OK)
 {
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Test.dat", false);
+  spISW = uut_.Create("Test.dat", false);
 
   spISW->Write_Bit(true);
   spISW->Write_Bit(false);
@@ -5383,7 +5383,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, AlignToByteBoundary_OK)
   spISW->Close();
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Test.dat");
+  spISR = uut_.Open("Test.dat");
 
   EXPECT_EQ(0x01U, spISR->Read_uint8());
   EXPECT_EQ(0x00U, spISR->Read_uint8());
@@ -5395,14 +5395,14 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, AlignToByteBoundary_OK)
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, AlignToByteBoundary_StateClosed)
 {
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Test.dat", false);
+  spISW = uut_.Create("Test.dat", false);
 
   spISW->Write_uint32(0xDEADBEEFUL);
 
@@ -5415,7 +5415,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, AlignToByteBoundary_StateClo
   spISW.reset();
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Test.dat");
+  spISR = uut_.Open("Test.dat");
 
   EXPECT_EQ(0xDEADBEEFUL, spISR->Read_uint32());
 
@@ -5424,7 +5424,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, AlignToByteBoundary_StateClo
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, FillBitsAndBytes_OK)
 {
@@ -5433,7 +5433,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, FillBitsAndBytes_OK)
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Test.dat", false);
+  spISW = uut_.Create("Test.dat", false);
 
   spISW->FillBits(1, true);
   spISW->FillBits(1, false);
@@ -5449,7 +5449,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, FillBitsAndBytes_OK)
   spISW.reset();
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Test.dat");
+  spISR = uut_.Open("Test.dat");
 
   EXPECT_EQ(0x3DU, spISR->Read_uint8());
   EXPECT_EQ(0xFFU, spISR->Read_uint8());
@@ -5463,7 +5463,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, FillBitsAndBytes_OK)
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, FillBitsAndBytes_StateClosed)
 {
@@ -5472,7 +5472,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, FillBitsAndBytes_StateClosed
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Test.dat", false);
+  spISW = uut_.Create("Test.dat", false);
 
   spISW->Write_uint32(0xDEADBEEFUL);
 
@@ -5486,7 +5486,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, FillBitsAndBytes_StateClosed
   spISW.reset();
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Test.dat");
+  spISR = uut_.Open("Test.dat");
 
   EXPECT_EQ(0xDEADBEEFUL, spISR->Read_uint32());
 
@@ -5495,21 +5495,21 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, FillBitsAndBytes_StateClosed
   spISR->Close();
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_ZeroBits)
 {
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Test.dat", false);
+  spISW = uut_.Create("Test.dat", false);
   spISW->Write_uint8(0x57U);
   spISW->Write_uint8(0xE9U);
   spISW->Close();
   spISW.reset();
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Test.dat");
+  spISR = uut_.Open("Test.dat");
 
   uint8_t u8;
 
@@ -5529,7 +5529,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_ZeroBits)
   spISR->Close();
   ASSERT_EQ(gpcc::stream::IStreamReader::States::closed, spISR->GetState());
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_BitsLeft_SkipSomeBits)
 {
@@ -5538,13 +5538,13 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_BitsLeft_SkipSomeBits)
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Test.dat", false);
+  spISW = uut_.Create("Test.dat", false);
   spISW->Write_uint8(0x8AU);
   spISW->Close();
   spISW.reset();
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Test.dat");
+  spISR = uut_.Open("Test.dat");
 
   ASSERT_EQ(spISR->Read_bits(4U), 0x0AU);
   ASSERT_EQ(spISR->GetState(), gpcc::stream::IStreamReader::States::open);
@@ -5560,7 +5560,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_BitsLeft_SkipSomeBits)
   spISR->Close();
   ASSERT_EQ(gpcc::stream::IStreamReader::States::closed, spISR->GetState());
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_BitsAndOneByteLeft_SkipAllBits)
 {
@@ -5569,14 +5569,14 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_BitsAndOneByteLeft_Skip
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Test.dat", false);
+  spISW = uut_.Create("Test.dat", false);
   spISW->Write_uint8(0x8AU);
   spISW->Write_uint8(0xDBU);
   spISW->Close();
   spISW.reset();
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Test.dat");
+  spISR = uut_.Open("Test.dat");
 
   ASSERT_EQ(spISR->Read_bits(4U), 0x0AU);
   ASSERT_EQ(spISR->GetState(), gpcc::stream::IStreamReader::States::open);
@@ -5592,7 +5592,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_BitsAndOneByteLeft_Skip
   spISR->Close();
   ASSERT_EQ(gpcc::stream::IStreamReader::States::closed, spISR->GetState());
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_BitsLeft_SkipAll)
 {
@@ -5601,13 +5601,13 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_BitsLeft_SkipAll)
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Test.dat", false);
+  spISW = uut_.Create("Test.dat", false);
   spISW->Write_uint8(0x8AU);
   spISW->Close();
   spISW.reset();
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Test.dat");
+  spISR = uut_.Open("Test.dat");
 
   ASSERT_EQ(spISR->Read_bits(4U), 0x0AU);
   ASSERT_EQ(spISR->GetState(), gpcc::stream::IStreamReader::States::open);
@@ -5620,7 +5620,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_BitsLeft_SkipAll)
   spISR->Close();
   ASSERT_EQ(gpcc::stream::IStreamReader::States::closed, spISR->GetState());
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_BitsLeft_SkipAllPlusOne)
 {
@@ -5629,13 +5629,13 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_BitsLeft_SkipAllPlusOne
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Test.dat", false);
+  spISW = uut_.Create("Test.dat", false);
   spISW->Write_uint8(0x8AU);
   spISW->Close();
   spISW.reset();
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Test.dat");
+  spISR = uut_.Open("Test.dat");
 
   ASSERT_EQ(spISR->Read_bits(4U), 0x0AU);
   ASSERT_EQ(spISR->GetState(), gpcc::stream::IStreamReader::States::open);
@@ -5648,7 +5648,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_BitsLeft_SkipAllPlusOne
   spISR->Close();
   ASSERT_EQ(gpcc::stream::IStreamReader::States::closed, spISR->GetState());
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_BitsAndOneByteLeft_SkipAllBitsAndOneByte)
 {
@@ -5657,14 +5657,14 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_BitsAndOneByteLeft_Skip
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Test.dat", false);
+  spISW = uut_.Create("Test.dat", false);
   spISW->Write_uint8(0x8AU);
   spISW->Write_uint8(0xDBU);
   spISW->Close();
   spISW.reset();
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Test.dat");
+  spISR = uut_.Open("Test.dat");
 
   ASSERT_EQ(spISR->Read_bits(4U), 0x0AU);
   ASSERT_EQ(spISR->GetState(), gpcc::stream::IStreamReader::States::open);
@@ -5677,7 +5677,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_BitsAndOneByteLeft_Skip
   spISR->Close();
   ASSERT_EQ(gpcc::stream::IStreamReader::States::closed, spISR->GetState());
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_BitsAndOneByteLeft_SkipAllBitsAndTwoByte)
 {
@@ -5686,14 +5686,14 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_BitsAndOneByteLeft_Skip
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Test.dat", false);
+  spISW = uut_.Create("Test.dat", false);
   spISW->Write_uint8(0x8AU);
   spISW->Write_uint8(0xDBU);
   spISW->Close();
   spISW.reset();
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Test.dat");
+  spISR = uut_.Open("Test.dat");
 
   ASSERT_EQ(spISR->Read_bits(4U), 0x0AU);
   ASSERT_EQ(spISR->GetState(), gpcc::stream::IStreamReader::States::open);
@@ -5706,7 +5706,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_BitsAndOneByteLeft_Skip
   spISR->Close();
   ASSERT_EQ(gpcc::stream::IStreamReader::States::closed, spISR->GetState());
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_BitsAndOneByteLeft_SkipAllBitsAndOneByteAndOneBit)
 {
@@ -5715,14 +5715,14 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_BitsAndOneByteLeft_Skip
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Test.dat", false);
+  spISW = uut_.Create("Test.dat", false);
   spISW->Write_uint8(0x8AU);
   spISW->Write_uint8(0xDBU);
   spISW->Close();
   spISW.reset();
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Test.dat");
+  spISR = uut_.Open("Test.dat");
 
   ASSERT_EQ(spISR->Read_bits(4U), 0x0AU);
   ASSERT_EQ(spISR->GetState(), gpcc::stream::IStreamReader::States::open);
@@ -5735,7 +5735,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_BitsAndOneByteLeft_Skip
   spISR->Close();
   ASSERT_EQ(gpcc::stream::IStreamReader::States::closed, spISR->GetState());
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_BitsAndTwoByteLeft_SkipAllBitsAndOneByte)
 {
@@ -5744,7 +5744,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_BitsAndTwoByteLeft_Skip
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Test.dat", false);
+  spISW = uut_.Create("Test.dat", false);
   spISW->Write_uint8(0x8AU);
   spISW->Write_uint8(0xDBU);
   spISW->Write_uint8(0x36U);
@@ -5752,7 +5752,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_BitsAndTwoByteLeft_Skip
   spISW.reset();
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Test.dat");
+  spISR = uut_.Open("Test.dat");
 
   ASSERT_EQ(spISR->Read_bits(4U), 0x0AU);
   ASSERT_EQ(spISR->GetState(), gpcc::stream::IStreamReader::States::open);
@@ -5768,7 +5768,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_BitsAndTwoByteLeft_Skip
   spISR->Close();
   ASSERT_EQ(gpcc::stream::IStreamReader::States::closed, spISR->GetState());
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_BitsAndTwoByteLeft_SkipAllBitsAndOneByteAndOneBit)
 {
@@ -5777,7 +5777,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_BitsAndTwoByteLeft_Skip
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Test.dat", false);
+  spISW = uut_.Create("Test.dat", false);
   spISW->Write_uint8(0x8AU);
   spISW->Write_uint8(0xDBU);
   spISW->Write_uint8(0x36U);
@@ -5785,7 +5785,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_BitsAndTwoByteLeft_Skip
   spISW.reset();
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Test.dat");
+  spISR = uut_.Open("Test.dat");
 
   ASSERT_EQ(spISR->Read_bits(4U), 0x0AU);
   ASSERT_EQ(spISR->GetState(), gpcc::stream::IStreamReader::States::open);
@@ -5801,7 +5801,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_BitsAndTwoByteLeft_Skip
   spISR->Close();
   ASSERT_EQ(gpcc::stream::IStreamReader::States::closed, spISR->GetState());
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_OneByteLeft_Skip8Bits)
 {
@@ -5810,14 +5810,14 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_OneByteLeft_Skip8Bits)
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Test.dat", false);
+  spISW = uut_.Create("Test.dat", false);
   spISW->Write_uint8(0x8AU);
   spISW->Write_uint8(0xDBU);
   spISW->Close();
   spISW.reset();
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Test.dat");
+  spISR = uut_.Open("Test.dat");
 
   ASSERT_EQ(spISR->Read_bits(8U), 0x8AU);
   ASSERT_EQ(spISR->GetState(), gpcc::stream::IStreamReader::States::open);
@@ -5830,7 +5830,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_OneByteLeft_Skip8Bits)
   spISR->Close();
   ASSERT_EQ(gpcc::stream::IStreamReader::States::closed, spISR->GetState());
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_OneByteLeft_Skip7Bits)
 {
@@ -5839,14 +5839,14 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_OneByteLeft_Skip7Bits)
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Test.dat", false);
+  spISW = uut_.Create("Test.dat", false);
   spISW->Write_uint8(0x8AU);
   spISW->Write_uint8(0x80U);
   spISW->Close();
   spISW.reset();
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Test.dat");
+  spISR = uut_.Open("Test.dat");
 
   ASSERT_EQ(spISR->Read_bits(8U), 0x8AU);
   ASSERT_EQ(spISR->GetState(), gpcc::stream::IStreamReader::States::open);
@@ -5862,7 +5862,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_OneByteLeft_Skip7Bits)
   spISR->Close();
   ASSERT_EQ(gpcc::stream::IStreamReader::States::closed, spISR->GetState());
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_OneByteLeft_Skip9Bits)
 {
@@ -5871,14 +5871,14 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_OneByteLeft_Skip9Bits)
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Test.dat", false);
+  spISW = uut_.Create("Test.dat", false);
   spISW->Write_uint8(0x8AU);
   spISW->Write_uint8(0x80U);
   spISW->Close();
   spISW.reset();
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Test.dat");
+  spISR = uut_.Open("Test.dat");
 
   ASSERT_EQ(spISR->Read_bits(8U), 0x8AU);
   ASSERT_EQ(spISR->GetState(), gpcc::stream::IStreamReader::States::open);
@@ -5891,7 +5891,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_OneByteLeft_Skip9Bits)
   spISR->Close();
   ASSERT_EQ(gpcc::stream::IStreamReader::States::closed, spISR->GetState());
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_TwoByteLeft_Skip8Bits)
 {
@@ -5900,14 +5900,14 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_TwoByteLeft_Skip8Bits)
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Test.dat", false);
+  spISW = uut_.Create("Test.dat", false);
   spISW->Write_uint8(0x8AU);
   spISW->Write_uint8(0x80U);
   spISW->Close();
   spISW.reset();
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Test.dat");
+  spISR = uut_.Open("Test.dat");
 
   // - precondition established -
 
@@ -5920,7 +5920,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_TwoByteLeft_Skip8Bits)
   spISR->Close();
   ASSERT_EQ(gpcc::stream::IStreamReader::States::closed, spISR->GetState());
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_TwoByteLeft_Skip16Bits)
 {
@@ -5929,14 +5929,14 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_TwoByteLeft_Skip16Bits)
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Test.dat", false);
+  spISW = uut_.Create("Test.dat", false);
   spISW->Write_uint8(0x8AU);
   spISW->Write_uint8(0x80U);
   spISW->Close();
   spISW.reset();
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Test.dat");
+  spISR = uut_.Open("Test.dat");
 
   // - precondition established -
 
@@ -5946,7 +5946,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_TwoByteLeft_Skip16Bits)
   spISR->Close();
   ASSERT_EQ(gpcc::stream::IStreamReader::States::closed, spISR->GetState());
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_TwoByteLeft_Skip9Bits)
 {
@@ -5955,14 +5955,14 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_TwoByteLeft_Skip9Bits)
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Test.dat", false);
+  spISW = uut_.Create("Test.dat", false);
   spISW->Write_uint8(0x8AU);
   spISW->Write_uint8(0x80U);
   spISW->Close();
   spISW.reset();
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Test.dat");
+  spISR = uut_.Open("Test.dat");
 
   // - precondition established -
 
@@ -5975,7 +5975,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_TwoByteLeft_Skip9Bits)
   spISR->Close();
   ASSERT_EQ(gpcc::stream::IStreamReader::States::closed, spISR->GetState());
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_LargerThanBlockSize)
 {
@@ -5984,14 +5984,14 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_LargerThanBlockSize)
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Test.dat", false);
+  spISW = uut_.Create("Test.dat", false);
   for (uint_fast16_t i = 0; i < 256U; i++)
     spISW->Write_uint16(i);
   spISW->Close();
   spISW.reset();
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Test.dat");
+  spISR = uut_.Open("Test.dat");
 
   // - precondition established -
 
@@ -6004,7 +6004,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_LargerThanBlockSize)
   spISR->Close();
   ASSERT_EQ(gpcc::stream::IStreamReader::States::closed, spISR->GetState());
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_LastBitInLastByteOfBlock_MoreBlocks)
 {
@@ -6013,17 +6013,17 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_LastBitInLastByteOfBloc
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Test.dat", false);
-  for (uint_fast16_t i = 0; i < bytesPerBlock; i++)
+  spISW = uut_.Create("Test.dat", false);
+  for (uint_fast16_t i = 0; i < bytesPerBlock_; i++)
     spISW->Write_uint8(i & 0xFFU);
   spISW->Write_uint32(0xDEADBEEFUL);
   spISW->Close();
   spISW.reset();
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Test.dat");
+  spISR = uut_.Open("Test.dat");
 
-  for (uint_fast16_t i = 0; i < bytesPerBlock-1U; i++)
+  for (uint_fast16_t i = 0; i < bytesPerBlock_-1U; i++)
   {
     ASSERT_EQ(spISR->Read_uint8(), i & 0xFFU);
   }
@@ -6039,7 +6039,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_LastBitInLastByteOfBloc
   spISR->Close();
   ASSERT_EQ(gpcc::stream::IStreamReader::States::closed, spISR->GetState());
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_LastBitInLastByteOfBlock_NoMoreBlocks)
 {
@@ -6048,16 +6048,16 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_LastBitInLastByteOfBloc
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Test.dat", false);
-  for (uint_fast16_t i = 0; i < bytesPerBlock; i++)
+  spISW = uut_.Create("Test.dat", false);
+  for (uint_fast16_t i = 0; i < bytesPerBlock_; i++)
     spISW->Write_uint8(i & 0xFFU);
   spISW->Close();
   spISW.reset();
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Test.dat");
+  spISR = uut_.Open("Test.dat");
 
-  for (uint_fast16_t i = 0; i < bytesPerBlock-1U; i++)
+  for (uint_fast16_t i = 0; i < bytesPerBlock_-1U; i++)
   {
     ASSERT_EQ(spISR->Read_uint8(), i & 0xFFU);
   }
@@ -6070,21 +6070,21 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_LastBitInLastByteOfBloc
   spISR->Close();
   ASSERT_EQ(gpcc::stream::IStreamReader::States::closed, spISR->GetState());
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_EmptyStream)
 {
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Test.dat", false);
+  spISW = uut_.Create("Test.dat", false);
   spISW->Write_uint8(0xFAU);
   spISW->Write_uint8(0x12U);
   spISW->Close();
   spISW.reset();
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Test.dat");
+  spISR = uut_.Open("Test.dat");
 
   ASSERT_EQ(spISR->Read_uint8(), 0xFAU);
   ASSERT_EQ(gpcc::stream::IStreamReader::States::open, spISR->GetState());
@@ -6099,41 +6099,41 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_EmptyStream)
   spISR->Close();
   ASSERT_EQ(gpcc::stream::IStreamReader::States::closed, spISR->GetState());
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_ClosedStream)
 {
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Test.dat", false);
+  spISW = uut_.Create("Test.dat", false);
   spISW->Write_uint8(0xFAU);
   spISW->Write_uint8(0x12U);
   spISW->Close();
   spISW.reset();
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Test.dat");
+  spISR = uut_.Open("Test.dat");
   spISR->Close();
 
   ASSERT_THROW(spISR->Skip(1U), gpcc::stream::ClosedError);
   ASSERT_EQ(gpcc::stream::IStreamReader::States::closed, spISR->GetState());
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_StreamInErrorState)
 {
   Format(128);
 
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  spISW = uut.Create("Test.dat", false);
+  spISW = uut_.Create("Test.dat", false);
   spISW->Write_uint8(0xFAU);
   spISW->Write_uint8(0x12U);
   spISW->Close();
   spISW.reset();
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  spISR = uut.Open("Test.dat");
+  spISR = uut_.Open("Test.dat");
 
   uint8_t au8[3];
   ASSERT_THROW(spISR->Read_uint8(au8, 3), gpcc::stream::EmptyError);
@@ -6148,551 +6148,551 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Skip_StreamInErrorState)
 
   ASSERT_EQ(gpcc::stream::IStreamReader::States::closed, spISR->GetState());
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Unmount_OK_DifferentStates)
 {
   Format(128);
-  uut.Unmount();
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::not_mounted, uut.GetState());
+  uut_.Unmount();
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::not_mounted, uut_.GetState());
 
-  uut.MountStep1();
-  uut.Unmount();
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::not_mounted, uut.GetState());
+  uut_.MountStep1();
+  uut_.Unmount();
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::not_mounted, uut_.GetState());
 
-  uut.MountStep1();
-  uut.MountStep2();
+  uut_.MountStep1();
+  uut_.MountStep2();
 
-  fakeStorage.Invalidate(blockSize, blockSize);
+  fakeStorage_.Invalidate(blockSize_, blockSize_);
   std::unique_ptr<gpcc::stream::IStreamWriter> spISW;
-  ASSERT_THROW(spISW = uut.Create("Section1", false), DataIntegrityError);
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::defect, uut.GetState());
+  ASSERT_THROW(spISW = uut_.Create("Section1", false), DataIntegrityError);
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::defect, uut_.GetState());
 
-  uut.Unmount();
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::not_mounted, uut.GetState());
+  uut_.Unmount();
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::not_mounted, uut_.GetState());
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Unmount_WrongState)
 {
   Format(128);
-  uut.Unmount();
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::not_mounted, uut.GetState());
+  uut_.Unmount();
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::not_mounted, uut_.GetState());
 
-  ASSERT_THROW(uut.Unmount(), InsufficientStateError);
+  ASSERT_THROW(uut_.Unmount(), InsufficientStateError);
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Unmount_LockedByReader)
 {
   Format(128);
 
   RandomData data(8,8);
-  data.Write("Section1", false, uut);
+  data.Write("Section1", false, uut_);
 
-  auto spISR = uut.Open("Section1");
+  auto spISR = uut_.Open("Section1");
 
-  ASSERT_THROW(uut.Unmount(), NotAllSectionsClosedError);
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::mounted, uut.GetState());
+  ASSERT_THROW(uut_.Unmount(), NotAllSectionsClosedError);
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::mounted, uut_.GetState());
 
   spISR.reset();
 
-  BasicTest_WriteRead(&uut, blockSize, 1);
+  BasicTest_WriteRead(&uut_, blockSize_, 1);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Unmount_LockedByWriter)
 {
   Format(128);
 
-  auto spISW = uut.Create("Section1", false);
+  auto spISW = uut_.Create("Section1", false);
 
-  ASSERT_THROW(uut.Unmount(), NotAllSectionsClosedError);
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::mounted, uut.GetState());
+  ASSERT_THROW(uut_.Unmount(), NotAllSectionsClosedError);
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::mounted, uut_.GetState());
 
   spISW.reset();
 
-  BasicTest_WriteRead(&uut, blockSize, 1);
+  BasicTest_WriteRead(&uut_, blockSize_, 1);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Delete_BadNames)
 {
   Format(128);
 
-  ASSERT_THROW(uut.Delete(""), std::invalid_argument);
-  ASSERT_THROW(uut.Delete(" Sec1"), std::invalid_argument);
-  ASSERT_THROW(uut.Delete("Sec1 "), std::invalid_argument);
-  ASSERT_THROW(uut.Delete(" Sec1 "), std::invalid_argument);
-  ASSERT_THROW(uut.Delete(" "), std::invalid_argument);
+  ASSERT_THROW(uut_.Delete(""), std::invalid_argument);
+  ASSERT_THROW(uut_.Delete(" Sec1"), std::invalid_argument);
+  ASSERT_THROW(uut_.Delete("Sec1 "), std::invalid_argument);
+  ASSERT_THROW(uut_.Delete(" Sec1 "), std::invalid_argument);
+  ASSERT_THROW(uut_.Delete(" "), std::invalid_argument);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Delete_WrongState)
 {
   Format(128);
 
-  uut.Unmount();
+  uut_.Unmount();
 
   // state is not_mounted
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::not_mounted, uut.GetState());
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::not_mounted, uut_.GetState());
 
-  ASSERT_THROW(uut.Delete("Section1"), InsufficientStateError);
+  ASSERT_THROW(uut_.Delete("Section1"), InsufficientStateError);
 
   // bring uut into state "ro_mount"
-  uut.MountStep1();
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::ro_mount, uut.GetState());
+  uut_.MountStep1();
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::ro_mount, uut_.GetState());
 
-  ASSERT_THROW(uut.Delete("Section1"), InsufficientStateError);
+  ASSERT_THROW(uut_.Delete("Section1"), InsufficientStateError);
 
   // bring uut into state "mounted"
-  uut.MountStep2();
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::mounted, uut.GetState());
+  uut_.MountStep2();
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::mounted, uut_.GetState());
 
   // bring uut into state "defect"
-  fakeStorage.Invalidate(blockSize, blockSize);
+  fakeStorage_.Invalidate(blockSize_, blockSize_);
   RandomData data(8,8);
-  ASSERT_THROW(data.Write("Section2", false, uut), DataIntegrityError);
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::defect, uut.GetState());
+  ASSERT_THROW(data.Write("Section2", false, uut_), DataIntegrityError);
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::defect, uut_.GetState());
 
-  ASSERT_THROW(uut.Delete("Section1"), InsufficientStateError);
+  ASSERT_THROW(uut_.Delete("Section1"), InsufficientStateError);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Delete_LockedByReader)
 {
   Format(128);
 
   RandomData data(8, 8);
-  data.Write("Section1", false, uut);
+  data.Write("Section1", false, uut_);
 
-  auto spISR = uut.Open("Section1");
+  auto spISR = uut_.Open("Section1");
 
-  ASSERT_THROW(uut.Delete("Section1"), gpcc::file_systems::FileAlreadyAccessedError);
+  ASSERT_THROW(uut_.Delete("Section1"), gpcc::file_systems::FileAlreadyAccessedError);
 
   spISR.reset();
 
-  BasicTest_WriteRead(&uut, blockSize, 1);
+  BasicTest_WriteRead(&uut_, blockSize_, 1);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Delete_LockedByWriter)
 {
   Format(128);
 
-  auto spISW = uut.Create("Section1", false);
+  auto spISW = uut_.Create("Section1", false);
 
-  ASSERT_THROW(uut.Delete("Section1"), gpcc::file_systems::FileAlreadyAccessedError);
+  ASSERT_THROW(uut_.Delete("Section1"), gpcc::file_systems::FileAlreadyAccessedError);
 
   spISW.reset();
 
-  BasicTest_WriteRead(&uut, blockSize, 1);
+  BasicTest_WriteRead(&uut_, blockSize_, 1);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Delete_NoSuchSection)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
-  ASSERT_THROW(uut.Delete("Section1"), gpcc::file_systems::NoSuchFileError);
+  fakeStorage_.writeAccessCnt = 0;
+  ASSERT_THROW(uut_.Delete("Section1"), gpcc::file_systems::NoSuchFileError);
 
-  ASSERT_EQ(0U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(0U, fakeStorage_.writeAccessCnt);
 
-  BasicTest_WriteRead(&uut, blockSize, 1);
+  BasicTest_WriteRead(&uut_, blockSize_, 1);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Delete_Powerfail)
 {
   Format(128);
 
-  size_t const freeSpace = uut.GetFreeSpace();
+  size_t const freeSpace = uut_.GetFreeSpace();
 
   RandomData data(8, 8);
-  data.Write("Section1", false, uut);
+  data.Write("Section1", false, uut_);
 
-  fakeStorage.SetEnableUndo(true);
-  fakeStorage.writeAccessCnt = 0;
-  fakeStorage.readAccessCnt  = 0;
+  fakeStorage_.SetEnableUndo(true);
+  fakeStorage_.writeAccessCnt = 0;
+  fakeStorage_.readAccessCnt  = 0;
 
-  uut.Delete("Section1");
+  uut_.Delete("Section1");
 
-  FakeEEPROM copyOfStorage(fakeStorage);
+  FakeEEPROM copyOfStorage(fakeStorage_);
 
-  size_t const nScenarios = fakeStorage.writeAccessCnt;
+  size_t const nScenarios = fakeStorage_.writeAccessCnt;
   for (size_t i = 1; i < nScenarios; i++)
   {
-    uut.Unmount();
+    uut_.Unmount();
 
-    fakeStorage = copyOfStorage;
-    fakeStorage.Undo(i);
-    fakeStorage.SetEnableUndo(false);
+    fakeStorage_ = copyOfStorage;
+    fakeStorage_.Undo(i);
+    fakeStorage_.SetEnableUndo(false);
 
-    uut.MountStep1();
-    uut.MountStep2();
+    uut_.MountStep1();
+    uut_.MountStep2();
 
     std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-    ASSERT_THROW(spISR = uut.Open("Section1"), gpcc::file_systems::NoSuchFileError);
-    ASSERT_EQ(freeSpace, uut.GetFreeSpace());
+    ASSERT_THROW(spISR = uut_.Open("Section1"), gpcc::file_systems::NoSuchFileError);
+    ASSERT_EQ(freeSpace, uut_.GetFreeSpace());
 
-    BasicTest_WriteRead(&uut, blockSize, 1);
+    BasicTest_WriteRead(&uut_, blockSize_, 1);
   }
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Delete_OK)
 {
   Format(128);
 
-  size_t const freeSpace = uut.GetFreeSpace();
+  size_t const freeSpace = uut_.GetFreeSpace();
 
   RandomData data(8, 8);
-  data.Write("Section1", false, uut);
+  data.Write("Section1", false, uut_);
 
-  ASSERT_NO_THROW(uut.Delete("Section1"));
-  ASSERT_EQ(freeSpace, uut.GetFreeSpace());
+  ASSERT_NO_THROW(uut_.Delete("Section1"));
+  ASSERT_EQ(freeSpace, uut_.GetFreeSpace());
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  ASSERT_THROW(spISR = uut.Open("Section1"), gpcc::file_systems::NoSuchFileError);
+  ASSERT_THROW(spISR = uut_.Open("Section1"), gpcc::file_systems::NoSuchFileError);
 
-  BasicTest_WriteRead(&uut, blockSize, 1);
+  BasicTest_WriteRead(&uut_, blockSize_, 1);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Delete_FromFullSectionSystem)
 {
   Format(128);
 
-  size_t const freeSpace = uut.GetFreeSpace();
+  size_t const freeSpace = uut_.GetFreeSpace();
 
   RandomData data1(8, 8);
-  data1.Write("Section1", false, uut);
-  RandomData data2(freeSpace - (2U * bytesPerBlock) - 8U, freeSpace - (2U * bytesPerBlock) - 8U);
-  data2.Write("Section2", false, uut);
+  data1.Write("Section1", false, uut_);
+  RandomData data2(freeSpace - (2U * bytesPerBlock_) - 8U, freeSpace - (2U * bytesPerBlock_) - 8U);
+  data2.Write("Section2", false, uut_);
 
-  ASSERT_NO_THROW(uut.Delete("Section1"));
-  ASSERT_EQ(bytesPerBlock, uut.GetFreeSpace());
+  ASSERT_NO_THROW(uut_.Delete("Section1"));
+  ASSERT_EQ(bytesPerBlock_, uut_.GetFreeSpace());
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  ASSERT_THROW(spISR = uut.Open("Section1"), gpcc::file_systems::NoSuchFileError);
+  ASSERT_THROW(spISR = uut_.Open("Section1"), gpcc::file_systems::NoSuchFileError);
 
-  ASSERT_NO_THROW(uut.Delete("Section2"));
-  ASSERT_THROW(spISR = uut.Open("Section2"), gpcc::file_systems::NoSuchFileError);
-  ASSERT_EQ(freeSpace, uut.GetFreeSpace());
+  ASSERT_NO_THROW(uut_.Delete("Section2"));
+  ASSERT_THROW(spISR = uut_.Open("Section2"), gpcc::file_systems::NoSuchFileError);
+  ASSERT_EQ(freeSpace, uut_.GetFreeSpace());
 
-  BasicTest_WriteRead(&uut, blockSize, 1);
-  uut.Unmount();
+  BasicTest_WriteRead(&uut_, blockSize_, 1);
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Delete_FromNonFullSectionSystem)
 {
   Format(128);
 
-  size_t const freeSpace = uut.GetFreeSpace();
+  size_t const freeSpace = uut_.GetFreeSpace();
 
   RandomData data1(8, 8);
-  data1.Write("Section1", false, uut);
-  RandomData data2(freeSpace - (3U * bytesPerBlock) - 8U, freeSpace - (3U * bytesPerBlock) - 8U);
-  data2.Write("Section2", false, uut);
+  data1.Write("Section1", false, uut_);
+  RandomData data2(freeSpace - (3U * bytesPerBlock_) - 8U, freeSpace - (3U * bytesPerBlock_) - 8U);
+  data2.Write("Section2", false, uut_);
 
-  ASSERT_EQ(0U, uut.GetFreeSpace());
+  ASSERT_EQ(0U, uut_.GetFreeSpace());
 
-  ASSERT_NO_THROW(uut.Delete("Section1"));
-  ASSERT_EQ(2U * bytesPerBlock, uut.GetFreeSpace());
+  ASSERT_NO_THROW(uut_.Delete("Section1"));
+  ASSERT_EQ(2U * bytesPerBlock_, uut_.GetFreeSpace());
 
   std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-  ASSERT_THROW(spISR = uut.Open("Section1"), gpcc::file_systems::NoSuchFileError);
+  ASSERT_THROW(spISR = uut_.Open("Section1"), gpcc::file_systems::NoSuchFileError);
 
-  ASSERT_NO_THROW(uut.Delete("Section2"));
-  ASSERT_THROW(spISR = uut.Open("Section2"), gpcc::file_systems::NoSuchFileError);
-  ASSERT_EQ(freeSpace, uut.GetFreeSpace());
+  ASSERT_NO_THROW(uut_.Delete("Section2"));
+  ASSERT_THROW(spISR = uut_.Open("Section2"), gpcc::file_systems::NoSuchFileError);
+  ASSERT_EQ(freeSpace, uut_.GetFreeSpace());
 
-  BasicTest_WriteRead(&uut, blockSize, 1);
-  uut.Unmount();
+  BasicTest_WriteRead(&uut_, blockSize_, 1);
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Rename_BadNames)
 {
   Format(128);
 
-  ASSERT_THROW(uut.Rename("", "Section2"), std::invalid_argument);
-  ASSERT_THROW(uut.Rename(" Sec1", "Section2"), std::invalid_argument);
-  ASSERT_THROW(uut.Rename("Sec1 ", "Section2"), std::invalid_argument);
-  ASSERT_THROW(uut.Rename(" Sec1 ", "Section2"), std::invalid_argument);
-  ASSERT_THROW(uut.Rename(" ", "Section2"), std::invalid_argument);
+  ASSERT_THROW(uut_.Rename("", "Section2"), std::invalid_argument);
+  ASSERT_THROW(uut_.Rename(" Sec1", "Section2"), std::invalid_argument);
+  ASSERT_THROW(uut_.Rename("Sec1 ", "Section2"), std::invalid_argument);
+  ASSERT_THROW(uut_.Rename(" Sec1 ", "Section2"), std::invalid_argument);
+  ASSERT_THROW(uut_.Rename(" ", "Section2"), std::invalid_argument);
 
-  ASSERT_THROW(uut.Rename("Section1", ""), std::invalid_argument);
-  ASSERT_THROW(uut.Rename("Section1", " Sec2"), std::invalid_argument);
-  ASSERT_THROW(uut.Rename("Section1", "Sec2 "), std::invalid_argument);
-  ASSERT_THROW(uut.Rename("Section1", " Sec2 "), std::invalid_argument);
-  ASSERT_THROW(uut.Rename("Section1", " "), std::invalid_argument);
+  ASSERT_THROW(uut_.Rename("Section1", ""), std::invalid_argument);
+  ASSERT_THROW(uut_.Rename("Section1", " Sec2"), std::invalid_argument);
+  ASSERT_THROW(uut_.Rename("Section1", "Sec2 "), std::invalid_argument);
+  ASSERT_THROW(uut_.Rename("Section1", " Sec2 "), std::invalid_argument);
+  ASSERT_THROW(uut_.Rename("Section1", " "), std::invalid_argument);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Rename_WrongState)
 {
   Format(128);
 
-  uut.Unmount();
+  uut_.Unmount();
 
   // state is not_mounted
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::not_mounted, uut.GetState());
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::not_mounted, uut_.GetState());
 
-  ASSERT_THROW(uut.Rename("Section1", "Section2"), InsufficientStateError);
+  ASSERT_THROW(uut_.Rename("Section1", "Section2"), InsufficientStateError);
 
   // bring uut into state "ro_mount"
-  uut.MountStep1();
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::ro_mount, uut.GetState());
+  uut_.MountStep1();
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::ro_mount, uut_.GetState());
 
-  ASSERT_THROW(uut.Rename("Section1", "Section2"), InsufficientStateError);
+  ASSERT_THROW(uut_.Rename("Section1", "Section2"), InsufficientStateError);
 
   // bring uut into state "mounted"
-  uut.MountStep2();
+  uut_.MountStep2();
 
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::mounted, uut.GetState());
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::mounted, uut_.GetState());
 
   // bring uut into state "defect"
-  fakeStorage.Invalidate(blockSize, blockSize);
+  fakeStorage_.Invalidate(blockSize_, blockSize_);
   RandomData data(8,8);
-  ASSERT_THROW(data.Write("Section2", false, uut), DataIntegrityError);
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::defect, uut.GetState());
+  ASSERT_THROW(data.Write("Section2", false, uut_), DataIntegrityError);
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::defect, uut_.GetState());
 
-  ASSERT_THROW(uut.Rename("Section1", "Section2"), InsufficientStateError);
+  ASSERT_THROW(uut_.Rename("Section1", "Section2"), InsufficientStateError);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Rename_SrcLockedByReader)
 {
   Format(128);
 
   RandomData data(8, 8);
-  data.Write("Section1", false, uut);
+  data.Write("Section1", false, uut_);
 
-  auto spISR = uut.Open("Section1");
+  auto spISR = uut_.Open("Section1");
 
-  ASSERT_THROW(uut.Rename("Section1", "Section2"), gpcc::file_systems::FileAlreadyAccessedError);
+  ASSERT_THROW(uut_.Rename("Section1", "Section2"), gpcc::file_systems::FileAlreadyAccessedError);
 
   spISR.reset();
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Rename_DestLockedByReader)
 {
   Format(128);
 
   RandomData data(8, 8);
-  data.Write("Section1", false, uut);
+  data.Write("Section1", false, uut_);
 
-  auto spISR = uut.Open("Section1");
+  auto spISR = uut_.Open("Section1");
 
-  ASSERT_THROW(uut.Rename("Section2", "Section1"), gpcc::file_systems::FileAlreadyAccessedError);
+  ASSERT_THROW(uut_.Rename("Section2", "Section1"), gpcc::file_systems::FileAlreadyAccessedError);
 
   spISR.reset();
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Rename_SrcLockedByWriter)
 {
   Format(128);
 
-  auto spISW = uut.Create("Section1", false);
+  auto spISW = uut_.Create("Section1", false);
 
-  ASSERT_THROW(uut.Rename("Section1", "Section2"), gpcc::file_systems::FileAlreadyAccessedError);
+  ASSERT_THROW(uut_.Rename("Section1", "Section2"), gpcc::file_systems::FileAlreadyAccessedError);
 
   spISW.reset();
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Rename_DestLockedByWriter)
 {
   Format(128);
 
   RandomData data(8, 8);
-  data.Write("Section1", false, uut);
+  data.Write("Section1", false, uut_);
 
-  auto spISW = uut.Create("Section2", false);
+  auto spISW = uut_.Create("Section2", false);
 
-  ASSERT_THROW(uut.Rename("Section1", "Section2"), gpcc::file_systems::FileAlreadyAccessedError);
+  ASSERT_THROW(uut_.Rename("Section1", "Section2"), gpcc::file_systems::FileAlreadyAccessedError);
 
   spISW.reset();
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Rename_SrcNotFound)
 {
   Format(128);
 
-  ASSERT_THROW(uut.Rename("Section1", "Section2"), gpcc::file_systems::NoSuchFileError);
+  ASSERT_THROW(uut_.Rename("Section1", "Section2"), gpcc::file_systems::NoSuchFileError);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Rename_DestAlreadyExisting)
 {
   Format(128);
 
   RandomData data1(8, 8);
-  data1.Write("Section1", false, uut);
+  data1.Write("Section1", false, uut_);
   RandomData data2(8, 8);
-  data2.Write("Section2", false, uut);
+  data2.Write("Section2", false, uut_);
 
-  ASSERT_THROW(uut.Rename("Section1", "Section2"), gpcc::file_systems::FileAlreadyExistingError);
+  ASSERT_THROW(uut_.Rename("Section1", "Section2"), gpcc::file_systems::FileAlreadyExistingError);
 
-  data1.Compare("Section1", uut);
-  data2.Compare("Section2", uut);
-  uut.Unmount();
+  data1.Compare("Section1", uut_);
+  data2.Compare("Section2", uut_);
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Rename_MaxNameLength)
 {
   Format(128);
 
-  size_t const maxNameLength = blockSize - (sizeof(SectionHeadBlock_t) + 1U + sizeof(uint16_t));
+  size_t const maxNameLength = blockSize_ - (sizeof(SectionHeadBlock_t) + 1U + sizeof(uint16_t));
 
   RandomData data(8, 8);
-  data.Write("Section1", false, uut);
+  data.Write("Section1", false, uut_);
 
   std::string newName("Section2");
   while (newName.length() < maxNameLength)
     newName.append("x");
 
-  uut.Rename("Section1", newName);
+  uut_.Rename("Section1", newName);
 
-  data.Compare(newName, uut);
+  data.Compare(newName, uut_);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Rename_MaxNameLengthPlus1)
 {
   Format(128);
 
-  size_t const maxNameLength = blockSize - (sizeof(SectionHeadBlock_t) + 1U + sizeof(uint16_t));
+  size_t const maxNameLength = blockSize_ - (sizeof(SectionHeadBlock_t) + 1U + sizeof(uint16_t));
 
   RandomData data(8, 8);
-  data.Write("Section1", false, uut);
+  data.Write("Section1", false, uut_);
 
   std::string newName("Section2");
   while (newName.length() <= maxNameLength)
     newName.append("x");
 
-  ASSERT_THROW(uut.Rename("Section1", newName), std::invalid_argument);
+  ASSERT_THROW(uut_.Rename("Section1", newName), std::invalid_argument);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Rename_NoFreeSpace)
 {
   Format(128);
 
-  size_t const freeSpace = uut.GetFreeSpace();
+  size_t const freeSpace = uut_.GetFreeSpace();
 
   RandomData data(freeSpace - 8U, freeSpace - 8U);
-  data.Write("Section1", false, uut);
+  data.Write("Section1", false, uut_);
 
-  ASSERT_THROW(uut.Rename("Section1", "Section2"), gpcc::file_systems::InsufficientSpaceError);
+  ASSERT_THROW(uut_.Rename("Section1", "Section2"), gpcc::file_systems::InsufficientSpaceError);
 
-  data.Compare("Section1", uut);
+  data.Compare("Section1", uut_);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Rename_OneFreeBlock)
 {
   Format(128);
 
-  size_t const freeSpace = uut.GetFreeSpace();
+  size_t const freeSpace = uut_.GetFreeSpace();
 
-  RandomData data(freeSpace - 8U - bytesPerBlock, freeSpace - 8U - bytesPerBlock);
-  data.Write("Section1", false, uut);
+  RandomData data(freeSpace - 8U - bytesPerBlock_, freeSpace - 8U - bytesPerBlock_);
+  data.Write("Section1", false, uut_);
 
-  ASSERT_EQ(0U, uut.GetFreeSpace());
+  ASSERT_EQ(0U, uut_.GetFreeSpace());
 
-  uut.Rename("Section1", "Section2");
+  uut_.Rename("Section1", "Section2");
 
-  ASSERT_THROW(data.Compare("Section1", uut), gpcc::file_systems::NoSuchFileError);
-  data.Compare("Section2", uut);
+  ASSERT_THROW(data.Compare("Section1", uut_), gpcc::file_systems::NoSuchFileError);
+  data.Compare("Section2", uut_);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Rename_SameName_SectionNotExisting)
 {
   Format(128);
 
-  size_t const freeSpace = uut.GetFreeSpace();
+  size_t const freeSpace = uut_.GetFreeSpace();
 
-  ASSERT_THROW(uut.Rename("Section1", "Section1"), gpcc::file_systems::NoSuchFileError);
+  ASSERT_THROW(uut_.Rename("Section1", "Section1"), gpcc::file_systems::NoSuchFileError);
 
-  ASSERT_EQ(freeSpace, uut.GetFreeSpace());
+  ASSERT_EQ(freeSpace, uut_.GetFreeSpace());
 
-  BasicTest_WriteRead(&uut, blockSize, 1);
+  BasicTest_WriteRead(&uut_, blockSize_, 1);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Rename_SameName_SectionExisting)
 {
   Format(128);
 
   RandomData data(8, 8);
-  data.Write("Section1", false, uut);
+  data.Write("Section1", false, uut_);
 
-  size_t const freeSpace = uut.GetFreeSpace();
+  size_t const freeSpace = uut_.GetFreeSpace();
 
-  ASSERT_THROW(uut.Rename("Section1", "Section1"), gpcc::file_systems::FileAlreadyExistingError);
+  ASSERT_THROW(uut_.Rename("Section1", "Section1"), gpcc::file_systems::FileAlreadyExistingError);
 
-  ASSERT_EQ(freeSpace, uut.GetFreeSpace());
+  ASSERT_EQ(freeSpace, uut_.GetFreeSpace());
 
-  BasicTest_WriteRead(&uut, blockSize, 1);
+  BasicTest_WriteRead(&uut_, blockSize_, 1);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Rename_OK)
 {
   Format(128);
 
   RandomData data(8, 8);
-  data.Write("Section1", false, uut);
+  data.Write("Section1", false, uut_);
 
-  size_t const freeSpace = uut.GetFreeSpace();
+  size_t const freeSpace = uut_.GetFreeSpace();
 
-  uut.Rename("Section1", "Section2");
+  uut_.Rename("Section1", "Section2");
 
-  ASSERT_THROW(data.Compare("Section1", uut), gpcc::file_systems::NoSuchFileError);
-  data.Compare("Section2", uut);
+  ASSERT_THROW(data.Compare("Section1", uut_), gpcc::file_systems::NoSuchFileError);
+  data.Compare("Section2", uut_);
 
-  ASSERT_EQ(freeSpace, uut.GetFreeSpace());
+  ASSERT_EQ(freeSpace, uut_.GetFreeSpace());
 
-  BasicTest_WriteRead(&uut, blockSize, 1);
+  BasicTest_WriteRead(&uut_, blockSize_, 1);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Rename_Powerfail)
 {
   Format(128);
 
   RandomData data(8, 8);
-  data.Write("Section1", false, uut);
+  data.Write("Section1", false, uut_);
 
-  size_t const freeSpace = uut.GetFreeSpace();
+  size_t const freeSpace = uut_.GetFreeSpace();
 
-  fakeStorage.SetEnableUndo(true);
-  fakeStorage.writeAccessCnt = 0;
-  fakeStorage.readAccessCnt  = 0;
+  fakeStorage_.SetEnableUndo(true);
+  fakeStorage_.writeAccessCnt = 0;
+  fakeStorage_.readAccessCnt  = 0;
 
-  uut.Rename("Section1", "Section2");
+  uut_.Rename("Section1", "Section2");
 
-  ASSERT_EQ(3U, fakeStorage.writeAccessCnt);
+  ASSERT_EQ(3U, fakeStorage_.writeAccessCnt);
 
-  FakeEEPROM copyOfStorage(fakeStorage);
+  FakeEEPROM copyOfStorage(fakeStorage_);
 
-  size_t const nScenarios = fakeStorage.writeAccessCnt;
+  size_t const nScenarios = fakeStorage_.writeAccessCnt;
   for (size_t i = 1; i < nScenarios; i++)
   {
-    uut.Unmount();
+    uut_.Unmount();
 
-    fakeStorage = copyOfStorage;
-    fakeStorage.Undo(i);
-    fakeStorage.SetEnableUndo(false);
+    fakeStorage_ = copyOfStorage;
+    fakeStorage_.Undo(i);
+    fakeStorage_.SetEnableUndo(false);
 
-    uut.MountStep1();
-    uut.MountStep2();
+    uut_.MountStep1();
+    uut_.MountStep2();
 
     std::unique_ptr<gpcc::stream::IStreamReader> spISR;
-    ASSERT_THROW(spISR = uut.Open("Section1"), gpcc::file_systems::NoSuchFileError);
-    ASSERT_EQ(freeSpace, uut.GetFreeSpace());
+    ASSERT_THROW(spISR = uut_.Open("Section1"), gpcc::file_systems::NoSuchFileError);
+    ASSERT_EQ(freeSpace, uut_.GetFreeSpace());
 
-    data.Compare("Section2", uut);
+    data.Compare("Section2", uut_);
 
-    BasicTest_WriteRead(&uut, blockSize, 1);
+    BasicTest_WriteRead(&uut_, blockSize_, 1);
   }
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Rename_VersionWrapAround)
 {
@@ -6704,69 +6704,69 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, Rename_VersionWrapAround)
 
   // create section
   RandomData data(8,8);
-  data.Write("Section1", false, uut);
+  data.Write("Section1", false, uut_);
 
   // set version of section
-  fakeStorage.Read(1U * blockSize, blockSize, pBuffer);
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 0] = 0xFF;
-  pBuffer[offsetof(SectionHeadBlock_t, version) + 1] = 0xFF;
-  fakeStorage.Write(1U * blockSize, blockSize, pBuffer);
+  fakeStorage_.Read(1U * blockSize_, blockSize_, pBuffer_);
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 0] = 0xFF;
+  pBuffer_[offsetof(SectionHeadBlock_t, version) + 1] = 0xFF;
+  fakeStorage_.Write(1U * blockSize_, blockSize_, pBuffer_);
   UpdateCRC(1);
 
-  size_t const freeSpace = uut.GetFreeSpace();
+  size_t const freeSpace = uut_.GetFreeSpace();
 
   // rename
-  uut.Rename("Section1", "Section2");
+  uut_.Rename("Section1", "Section2");
 
   // check version of new section head
-  fakeStorage.Read(3U * blockSize, blockSize, pBuffer);
-  ASSERT_EQ(0x02, pBuffer[offsetof(CommonBlockHead_t, nextBlock) + 0]);
-  ASSERT_EQ(0x00, pBuffer[offsetof(CommonBlockHead_t, nextBlock) + 1]);
-  ASSERT_EQ(0x00, pBuffer[offsetof(SectionHeadBlock_t, version) + 0]);
-  ASSERT_EQ(0x00, pBuffer[offsetof(SectionHeadBlock_t, version) + 1]);
+  fakeStorage_.Read(3U * blockSize_, blockSize_, pBuffer_);
+  ASSERT_EQ(0x02, pBuffer_[offsetof(CommonBlockHead_t, nextBlock) + 0]);
+  ASSERT_EQ(0x00, pBuffer_[offsetof(CommonBlockHead_t, nextBlock) + 1]);
+  ASSERT_EQ(0x00, pBuffer_[offsetof(SectionHeadBlock_t, version) + 0]);
+  ASSERT_EQ(0x00, pBuffer_[offsetof(SectionHeadBlock_t, version) + 1]);
 
-  ASSERT_THROW(data.Compare("Section1", uut), gpcc::file_systems::NoSuchFileError);
-  data.Compare("Section2", uut);
+  ASSERT_THROW(data.Compare("Section1", uut_), gpcc::file_systems::NoSuchFileError);
+  data.Compare("Section2", uut_);
 
-  ASSERT_EQ(freeSpace, uut.GetFreeSpace());
+  ASSERT_EQ(freeSpace, uut_.GetFreeSpace());
 
-  BasicTest_WriteRead(&uut, blockSize, 1);
+  BasicTest_WriteRead(&uut_, blockSize_, 1);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, EnumerateSections_WrongState)
 {
   Format(128);
 
-  uut.Unmount();
+  uut_.Unmount();
 
   std::list<std::string> sections;
 
   // state is not_mounted
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::not_mounted, uut.GetState());
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::not_mounted, uut_.GetState());
 
-  ASSERT_THROW(sections = uut.Enumerate(), InsufficientStateError);
+  ASSERT_THROW(sections = uut_.Enumerate(), InsufficientStateError);
 
   // bring uut into state "ro_mount"
-  uut.MountStep1();
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::ro_mount, uut.GetState());
+  uut_.MountStep1();
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::ro_mount, uut_.GetState());
 
-  ASSERT_THROW(sections = uut.Enumerate(), InsufficientStateError);
+  ASSERT_THROW(sections = uut_.Enumerate(), InsufficientStateError);
 
   // bring uut into state "mounted"
-  uut.MountStep2();
+  uut_.MountStep2();
 
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::mounted, uut.GetState());
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::mounted, uut_.GetState());
 
   // bring uut into state "defect"
-  fakeStorage.Invalidate(blockSize, blockSize);
+  fakeStorage_.Invalidate(blockSize_, blockSize_);
   RandomData data(8,8);
-  ASSERT_THROW(data.Write("Section2", false, uut), DataIntegrityError);
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::defect, uut.GetState());
+  ASSERT_THROW(data.Write("Section2", false, uut_), DataIntegrityError);
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::defect, uut_.GetState());
 
-  ASSERT_THROW(sections = uut.Enumerate(), InsufficientStateError);
+  ASSERT_THROW(sections = uut_.Enumerate(), InsufficientStateError);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, EnumerateSections_Zero_One_n)
 {
@@ -6775,37 +6775,37 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, EnumerateSections_Zero_One_n
   std::list<std::string> sections;
 
   // zero sections
-  sections = uut.Enumerate();
+  sections = uut_.Enumerate();
   ASSERT_TRUE(sections.empty());
 
   // one section
   RandomData data1(10, 10);
-  data1.Write("Section1", false, uut);
+  data1.Write("Section1", false, uut_);
 
-  sections = uut.Enumerate();
+  sections = uut_.Enumerate();
   ASSERT_EQ(1U, sections.size());
   ASSERT_TRUE(std::find(sections.begin(), sections.end(), "Section1") != sections.end());
 
   // two sections
   RandomData data2(10, 10);
-  data1.Write("Section2", false, uut);
+  data1.Write("Section2", false, uut_);
 
-  sections = uut.Enumerate();
+  sections = uut_.Enumerate();
   ASSERT_EQ(2U, sections.size());
   ASSERT_TRUE(std::find(sections.begin(), sections.end(), "Section1") != sections.end());
   ASSERT_TRUE(std::find(sections.begin(), sections.end(), "Section2") != sections.end());
 
   // three sections
   RandomData data3(10, 10);
-  data1.Write("Section3", false, uut);
+  data1.Write("Section3", false, uut_);
 
-  sections = uut.Enumerate();
+  sections = uut_.Enumerate();
   ASSERT_EQ(3U, sections.size());
   ASSERT_TRUE(std::find(sections.begin(), sections.end(), "Section1") != sections.end());
   ASSERT_TRUE(std::find(sections.begin(), sections.end(), "Section2") != sections.end());
   ASSERT_TRUE(std::find(sections.begin(), sections.end(), "Section3") != sections.end());
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, EnumerateSections_Sort)
 {
@@ -6813,21 +6813,21 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, EnumerateSections_Sort)
 
   // create some sections
   RandomData data1(10, 10);
-  data1.Write("B_Section", false, uut);
+  data1.Write("B_Section", false, uut_);
 
   RandomData data2(10, 10);
-  data2.Write("A_Section", false, uut);
+  data2.Write("A_Section", false, uut_);
 
   RandomData data3(10, 10);
-  data3.Write("Z_Section", false, uut);
+  data3.Write("Z_Section", false, uut_);
 
   RandomData data4(10, 10);
-  data4.Write("A_Section2", false, uut);
+  data4.Write("A_Section2", false, uut_);
 
   RandomData data5(10, 10);
-  data5.Write("C_Section", false, uut);
+  data5.Write("C_Section", false, uut_);
 
-  auto const sections = uut.Enumerate();
+  auto const sections = uut_.Enumerate();
 
   auto it = sections.begin();
   ASSERT_TRUE(*it == "A_Section");
@@ -6842,44 +6842,44 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, EnumerateSections_Sort)
   ++it;
   ASSERT_TRUE(it == sections.end());
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, DetermineSectionSize_WrongState)
 {
   Format(128);
 
-  fakeStorage.writeAccessCnt = 0;
+  fakeStorage_.writeAccessCnt = 0;
   RandomData data(10,10);
-  data.Write("Section1", false, uut);
-  ASSERT_EQ(2U, fakeStorage.writeAccessCnt);
+  data.Write("Section1", false, uut_);
+  ASSERT_EQ(2U, fakeStorage_.writeAccessCnt);
 
-  uut.Unmount();
+  uut_.Unmount();
 
   size_t size;
 
   // state is not_mounted
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::not_mounted, uut.GetState());
-  ASSERT_THROW(size = uut.DetermineSize("Section1", nullptr), InsufficientStateError);
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::not_mounted, uut_.GetState());
+  ASSERT_THROW(size = uut_.DetermineSize("Section1", nullptr), InsufficientStateError);
 
   // bring uut into state "ro_mount"
-  uut.MountStep1();
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::ro_mount, uut.GetState());
-  ASSERT_THROW(size = uut.DetermineSize("Section1", nullptr), InsufficientStateError);
+  uut_.MountStep1();
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::ro_mount, uut_.GetState());
+  ASSERT_THROW(size = uut_.DetermineSize("Section1", nullptr), InsufficientStateError);
 
   // bring uut into state "mounted"
-  uut.MountStep2();
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::mounted, uut.GetState());
-  ASSERT_NO_THROW(size = uut.DetermineSize("Section1", nullptr));
+  uut_.MountStep2();
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::mounted, uut_.GetState());
+  ASSERT_NO_THROW(size = uut_.DetermineSize("Section1", nullptr));
   ASSERT_EQ(18U, size);
 
   // bring uut into state "defect"
-  fakeStorage.Invalidate(3 * blockSize, blockSize);
+  fakeStorage_.Invalidate(3 * blockSize_, blockSize_);
   RandomData data2(8,8);
-  ASSERT_THROW(data2.Write("Section2", false, uut), DataIntegrityError);
-  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::defect, uut.GetState());
-  ASSERT_THROW(size = uut.DetermineSize("Section1", nullptr), InsufficientStateError);
+  ASSERT_THROW(data2.Write("Section2", false, uut_), DataIntegrityError);
+  ASSERT_EQ(eeprom_section_system::EEPROMSectionSystem::States::defect, uut_.GetState());
+  ASSERT_THROW(size = uut_.DetermineSize("Section1", nullptr), InsufficientStateError);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, DetermineSectionSize_BadNames)
 {
@@ -6887,100 +6887,100 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, DetermineSectionSize_BadName
 
   size_t size;
 
-  ASSERT_THROW(size = uut.DetermineSize("", nullptr), std::invalid_argument);
-  ASSERT_THROW(size = uut.DetermineSize(" Sec1", nullptr), std::invalid_argument);
-  ASSERT_THROW(size = uut.DetermineSize("Sec1 ", nullptr), std::invalid_argument);
-  ASSERT_THROW(size = uut.DetermineSize(" Sec1 ", nullptr), std::invalid_argument);
-  ASSERT_THROW(size = uut.DetermineSize(" ", nullptr), std::invalid_argument);
+  ASSERT_THROW(size = uut_.DetermineSize("", nullptr), std::invalid_argument);
+  ASSERT_THROW(size = uut_.DetermineSize(" Sec1", nullptr), std::invalid_argument);
+  ASSERT_THROW(size = uut_.DetermineSize("Sec1 ", nullptr), std::invalid_argument);
+  ASSERT_THROW(size = uut_.DetermineSize(" Sec1 ", nullptr), std::invalid_argument);
+  ASSERT_THROW(size = uut_.DetermineSize(" ", nullptr), std::invalid_argument);
 
   (void)size;
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, DetermineSectionSize_LockedByWriter)
 {
   Format(128);
 
-  auto spISW = uut.Create("Section1", false);
+  auto spISW = uut_.Create("Section1", false);
 
   size_t size;
-  ASSERT_THROW(size = uut.DetermineSize("Section1", nullptr), gpcc::file_systems::FileAlreadyAccessedError);
+  ASSERT_THROW(size = uut_.DetermineSize("Section1", nullptr), gpcc::file_systems::FileAlreadyAccessedError);
   (void)size;
 
   spISW.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, DetermineSectionSize_LockedByReader)
 {
   Format(128);
 
   RandomData data(8,8);
-  data.Write("Section1", false, uut);
+  data.Write("Section1", false, uut_);
 
-  auto spISR = uut.Open("Section1");
+  auto spISR = uut_.Open("Section1");
 
   size_t size;
-  ASSERT_NO_THROW(size = uut.DetermineSize("Section1", nullptr));
+  ASSERT_NO_THROW(size = uut_.DetermineSize("Section1", nullptr));
   ASSERT_EQ(16U, size);
 
   spISR.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, DetermineSectionSize_SectionNotExisting)
 {
   Format(128);
 
   size_t size;
-  ASSERT_THROW(size = uut.DetermineSize("Section1", nullptr), gpcc::file_systems::NoSuchFileError);
+  ASSERT_THROW(size = uut_.DetermineSize("Section1", nullptr), gpcc::file_systems::NoSuchFileError);
   (void)size;
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, DetermineSectionSize_ZeroLength)
 {
   Format(128);
 
-  auto spISW = uut.Create("Section1", false);
+  auto spISW = uut_.Create("Section1", false);
   spISW.reset();
 
   size_t size;
   size_t totalSize;
-  size = uut.DetermineSize("Section1", &totalSize);
+  size = uut_.DetermineSize("Section1", &totalSize);
   ASSERT_EQ(0U, size);
-  ASSERT_EQ(2U * blockSize, totalSize);
+  ASSERT_EQ(2U * blockSize_, totalSize);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, DetermineSectionSize_VariousLength)
 {
   Format(128);
 
   RandomData data1(8, 8);
-  data1.Write("Section1", false, uut);
+  data1.Write("Section1", false, uut_);
 
-  RandomData data2(3U * blockSize, 3U * blockSize);
-  data2.Write("Section2", false, uut);
+  RandomData data2(3U * blockSize_, 3U * blockSize_);
+  data2.Write("Section2", false, uut_);
 
   size_t size;
   size_t totalSize;
 
-  size = uut.DetermineSize("Section1", &totalSize);
+  size = uut_.DetermineSize("Section1", &totalSize);
   ASSERT_EQ(16U, size);
-  ASSERT_EQ(2U * blockSize, totalSize);
+  ASSERT_EQ(2U * blockSize_, totalSize);
 
-  size = uut.DetermineSize("Section2", &totalSize);
-  ASSERT_EQ(3U * blockSize + 8U, size);
-  ASSERT_EQ(5U * blockSize, totalSize);
+  size = uut_.DetermineSize("Section2", &totalSize);
+  ASSERT_EQ(3U * blockSize_ + 8U, size);
+  ASSERT_EQ(5U * blockSize_, totalSize);
 
-  size = uut.DetermineSize("Section1", nullptr);
+  size = uut_.DetermineSize("Section1", nullptr);
   ASSERT_EQ(16U, size);
 
-  size = uut.DetermineSize("Section2", nullptr);
-  ASSERT_EQ(3U * blockSize + 8U, size);
+  size = uut_.DetermineSize("Section2", nullptr);
+  ASSERT_EQ(3U * blockSize_ + 8U, size);
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, MaximumNumberOfSections)
 {
@@ -6988,60 +6988,60 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, MaximumNumberOfSections)
 
   std::list<RandomData> sections;
 
-  size_t const nSections = ((storageSize / blockSize) - 1U) / 2U;
+  size_t const nSections = ((storageSize_ / blockSize_) - 1U) / 2U;
   for (size_t i = 0; i < nSections; i++)
   {
-    RandomData section(0, bytesPerBlock - 8U);
+    RandomData section(0, bytesPerBlock_ - 8U);
     std::string const secName = "Section" + std::to_string(i);
-    section.Write(secName, false, uut);
+    section.Write(secName, false, uut_);
     sections.push_back(std::move(section));
   }
 
-  ASSERT_EQ(0U, uut.GetFreeSpace());
+  ASSERT_EQ(0U, uut_.GetFreeSpace());
 
   auto it = sections.begin();
   for (size_t i = 0; i < nSections; i++)
   {
     std::string const secName = "Section" + std::to_string(i);
-    (*it).Compare(secName, uut);
+    (*it).Compare(secName, uut_);
     ++it;
   }
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_TestsF, MultipleReadersAndWritersAtTheSameTime)
 {
   Format(128);
 
   RandomData data1(30, 30);
-  data1.Write("Data1", false, uut);
+  data1.Write("Data1", false, uut_);
   RandomData data2(30, 30);
-  data2.Write("Data2", false, uut);
+  data2.Write("Data2", false, uut_);
   RandomData data3(30, 30);
-  data3.Write("Data3", false, uut);
+  data3.Write("Data3", false, uut_);
 
-  auto spISW1 = uut.Create("Section1", false);
+  auto spISW1 = uut_.Create("Section1", false);
   *spISW1 << std::string("ABC");
-  auto spISW2 = uut.Create("Section2", false);
-  auto spISW3 = uut.Create("Section3", false);
+  auto spISW2 = uut_.Create("Section2", false);
+  auto spISW3 = uut_.Create("Section3", false);
 
   *spISW2 << std::string("DEF");
-  data1.Compare("Data1", uut);
+  data1.Compare("Data1", uut_);
   *spISW3 << std::string("GHI");
   spISW1->Write_uint8(12);
   spISW2->Write_uint8(13);
-  data2.Compare("Data2", uut);
+  data2.Compare("Data2", uut_);
   spISW3->Write_uint8(14);
 
   spISW1->Close();
   spISW1.reset();
-  data3.Compare("Data3", uut);
+  data3.Compare("Data3", uut_);
   spISW3->Close();
   spISW3.reset();
   spISW2->Close();
   spISW2.reset();
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 
 } // namespace file_systems

--- a/testcases/file_systems/eeprom_section_system/cli/TestESSCLICommands.cpp
+++ b/testcases/file_systems/eeprom_section_system/cli/TestESSCLICommands.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011 Daniel Jerolm
+    Copyright (C) 2011, 2025 Daniel Jerolm
 */
 
 #include <gpcc/file_systems/eeprom_section_system/cli/ESSCLICommands.hpp>
@@ -67,23 +67,23 @@ void GPCC_FileSystems_EEPROMSectionSystem_CLI_TestsF::SetUp(void)
                                             std::bind(&gpcc::file_systems::eeprom_section_system::CLICMDGetState,
                                                       std::placeholders::_1,
                                                       std::placeholders::_2,
-                                                      &uut)));
+                                                      &uut_)));
   cli.AddCommand(gpcc::cli::Command::Create("Format", "\nHelp text",
                                             std::bind(&gpcc::file_systems::eeprom_section_system::CLICMDFormat,
                                                       std::placeholders::_1,
                                                       std::placeholders::_2,
-                                                      &uut,
-                                                      fakeStorage.GetPageSize())));
+                                                      &uut_,
+                                                      fakeStorage_.GetPageSize())));
   cli.AddCommand(gpcc::cli::Command::Create("Unmount", "\nHelp text",
                                             std::bind(&gpcc::file_systems::eeprom_section_system::CLICMDUnmount,
                                                       std::placeholders::_1,
                                                       std::placeholders::_2,
-                                                      &uut)));
+                                                      &uut_)));
   cli.AddCommand(gpcc::cli::Command::Create("Mount", "\nHelp text",
                                             std::bind(&gpcc::file_systems::eeprom_section_system::CLICMDMount,
                                                       std::placeholders::_1,
                                                       std::placeholders::_2,
-                                                      &uut)));
+                                                      &uut_)));
 }
 void GPCC_FileSystems_EEPROMSectionSystem_CLI_TestsF::TearDown(void)
 {
@@ -152,7 +152,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_CLI_TestsF, CLICMDGetState)
   terminal.Input_ENTER();
   terminal.WaitForInputProcessed();
 
-  Format(storagePageSize);
+  Format(storagePageSize_);
 
   terminal.Input("GetState");
   terminal.Input_ENTER();
@@ -160,7 +160,7 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_CLI_TestsF, CLICMDGetState)
 
   ASSERT_TRUE(terminal.Compare(expected));
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_CLI_TestsF, CLICMDGetState_unexpectedParams)
 {
@@ -211,8 +211,8 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_CLI_TestsF, CLICMDFormat_no)
   terminal.Input_ENTER();
   terminal.WaitForInputProcessed();
 
-  ASSERT_EQ(0U, fakeStorage.writeAccessCnt);
-  ASSERT_EQ(gpcc::file_systems::eeprom_section_system::EEPROMSectionSystem::States::not_mounted, uut.GetState());
+  ASSERT_EQ(0U, fakeStorage_.writeAccessCnt);
+  ASSERT_EQ(gpcc::file_systems::eeprom_section_system::EEPROMSectionSystem::States::not_mounted, uut_.GetState());
   ASSERT_TRUE(terminal.Compare(expected));
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_CLI_TestsF, CLICMDFormat_unexpectedParams)
@@ -237,8 +237,8 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_CLI_TestsF, CLICMDFormat_unexpectedP
   terminal.Input_ENTER();
   terminal.WaitForInputProcessed();
 
-  ASSERT_EQ(0U, fakeStorage.writeAccessCnt);
-  ASSERT_EQ(gpcc::file_systems::eeprom_section_system::EEPROMSectionSystem::States::not_mounted, uut.GetState());
+  ASSERT_EQ(0U, fakeStorage_.writeAccessCnt);
+  ASSERT_EQ(gpcc::file_systems::eeprom_section_system::EEPROMSectionSystem::States::not_mounted, uut_.GetState());
   ASSERT_TRUE(terminal.Compare(expected));
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_CLI_TestsF, CLICMDFormat_not_unmounted)
@@ -259,8 +259,8 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_CLI_TestsF, CLICMDFormat_not_unmount
    ""
   };
 
-  Format(storagePageSize);
-  fakeStorage.writeAccessCnt = 0;
+  Format(storagePageSize_);
+  fakeStorage_.writeAccessCnt = 0;
 
   terminal.Input("Format");
   terminal.Input_ENTER();
@@ -269,11 +269,11 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_CLI_TestsF, CLICMDFormat_not_unmount
   terminal.Input_ENTER();
   terminal.WaitForInputProcessed();
 
-  ASSERT_EQ(0U, fakeStorage.writeAccessCnt);
-  ASSERT_EQ(gpcc::file_systems::eeprom_section_system::EEPROMSectionSystem::States::mounted, uut.GetState());
+  ASSERT_EQ(0U, fakeStorage_.writeAccessCnt);
+  ASSERT_EQ(gpcc::file_systems::eeprom_section_system::EEPROMSectionSystem::States::mounted, uut_.GetState());
   ASSERT_TRUE(terminal.Compare(expected));
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_CLI_TestsF, CLICMDFormat_OK)
 {
@@ -300,10 +300,10 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_CLI_TestsF, CLICMDFormat_OK)
   terminal.Input_ENTER();
   terminal.WaitForInputProcessed();
 
-  ASSERT_EQ(gpcc::file_systems::eeprom_section_system::EEPROMSectionSystem::States::mounted, uut.GetState());
+  ASSERT_EQ(gpcc::file_systems::eeprom_section_system::EEPROMSectionSystem::States::mounted, uut_.GetState());
   ASSERT_TRUE(terminal.Compare(expected));
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_CLI_TestsF, CLICMDUnmount_unexpectedParams)
 {
@@ -323,18 +323,18 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_CLI_TestsF, CLICMDUnmount_unexpected
    ""
   };
 
-  Format(storagePageSize);
-  fakeStorage.writeAccessCnt = 0;
+  Format(storagePageSize_);
+  fakeStorage_.writeAccessCnt = 0;
 
   terminal.Input("Unmount x");
   terminal.Input_ENTER();
   terminal.WaitForInputProcessed();
 
-  ASSERT_EQ(0U, fakeStorage.writeAccessCnt);
-  ASSERT_EQ(gpcc::file_systems::eeprom_section_system::EEPROMSectionSystem::States::mounted, uut.GetState());
+  ASSERT_EQ(0U, fakeStorage_.writeAccessCnt);
+  ASSERT_EQ(gpcc::file_systems::eeprom_section_system::EEPROMSectionSystem::States::mounted, uut_.GetState());
   ASSERT_TRUE(terminal.Compare(expected));
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_CLI_TestsF, CLICMDUnmount_notMounted)
 {
@@ -358,8 +358,8 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_CLI_TestsF, CLICMDUnmount_notMounted
   terminal.Input_ENTER();
   terminal.WaitForInputProcessed();
 
-  ASSERT_EQ(0U, fakeStorage.writeAccessCnt);
-  ASSERT_EQ(gpcc::file_systems::eeprom_section_system::EEPROMSectionSystem::States::not_mounted, uut.GetState());
+  ASSERT_EQ(0U, fakeStorage_.writeAccessCnt);
+  ASSERT_EQ(gpcc::file_systems::eeprom_section_system::EEPROMSectionSystem::States::not_mounted, uut_.GetState());
   ASSERT_TRUE(terminal.Compare(expected));
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_CLI_TestsF, CLICMDUnmount_OK)
@@ -380,15 +380,15 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_CLI_TestsF, CLICMDUnmount_OK)
    ""
   };
 
-  Format(storagePageSize);
-  fakeStorage.writeAccessCnt = 0;
+  Format(storagePageSize_);
+  fakeStorage_.writeAccessCnt = 0;
 
   terminal.Input("Unmount");
   terminal.Input_ENTER();
   terminal.WaitForInputProcessed();
 
-  ASSERT_EQ(0U, fakeStorage.writeAccessCnt);
-  ASSERT_EQ(gpcc::file_systems::eeprom_section_system::EEPROMSectionSystem::States::not_mounted, uut.GetState());
+  ASSERT_EQ(0U, fakeStorage_.writeAccessCnt);
+  ASSERT_EQ(gpcc::file_systems::eeprom_section_system::EEPROMSectionSystem::States::not_mounted, uut_.GetState());
   ASSERT_TRUE(terminal.Compare(expected));
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_CLI_TestsF, CLICMDMount_unexpectedParams)
@@ -409,16 +409,16 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_CLI_TestsF, CLICMDMount_unexpectedPa
    ""
   };
 
-  Format(storagePageSize);
-  uut.Unmount();
-  fakeStorage.writeAccessCnt = 0;
+  Format(storagePageSize_);
+  uut_.Unmount();
+  fakeStorage_.writeAccessCnt = 0;
 
   terminal.Input("Mount x");
   terminal.Input_ENTER();
   terminal.WaitForInputProcessed();
 
-  ASSERT_EQ(0U, fakeStorage.writeAccessCnt);
-  ASSERT_EQ(gpcc::file_systems::eeprom_section_system::EEPROMSectionSystem::States::not_mounted, uut.GetState());
+  ASSERT_EQ(0U, fakeStorage_.writeAccessCnt);
+  ASSERT_EQ(gpcc::file_systems::eeprom_section_system::EEPROMSectionSystem::States::not_mounted, uut_.GetState());
   ASSERT_TRUE(terminal.Compare(expected));
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_CLI_TestsF, CLICMDMount_unmountedBefore)
@@ -439,19 +439,19 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_CLI_TestsF, CLICMDMount_unmountedBef
    ">"
   };
 
-  Format(storagePageSize);
-  uut.Unmount();
-  fakeStorage.writeAccessCnt = 0;
+  Format(storagePageSize_);
+  uut_.Unmount();
+  fakeStorage_.writeAccessCnt = 0;
 
   terminal.Input("Mount");
   terminal.Input_ENTER();
   terminal.WaitForInputProcessed();
 
-  ASSERT_EQ(0U, fakeStorage.writeAccessCnt);
-  ASSERT_EQ(gpcc::file_systems::eeprom_section_system::EEPROMSectionSystem::States::mounted, uut.GetState());
+  ASSERT_EQ(0U, fakeStorage_.writeAccessCnt);
+  ASSERT_EQ(gpcc::file_systems::eeprom_section_system::EEPROMSectionSystem::States::mounted, uut_.GetState());
   ASSERT_TRUE(terminal.Compare(expected));
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_CLI_TestsF, CLICMDMount_ro_mountedBefore)
 {
@@ -471,20 +471,20 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_CLI_TestsF, CLICMDMount_ro_mountedBe
    ""
   };
 
-  Format(storagePageSize);
-  uut.Unmount();
-  uut.MountStep1();
-  fakeStorage.writeAccessCnt = 0;
+  Format(storagePageSize_);
+  uut_.Unmount();
+  uut_.MountStep1();
+  fakeStorage_.writeAccessCnt = 0;
 
   terminal.Input("Mount");
   terminal.Input_ENTER();
   terminal.WaitForInputProcessed();
 
-  ASSERT_EQ(0U, fakeStorage.writeAccessCnt);
-  ASSERT_EQ(gpcc::file_systems::eeprom_section_system::EEPROMSectionSystem::States::mounted, uut.GetState());
+  ASSERT_EQ(0U, fakeStorage_.writeAccessCnt);
+  ASSERT_EQ(gpcc::file_systems::eeprom_section_system::EEPROMSectionSystem::States::mounted, uut_.GetState());
   ASSERT_TRUE(terminal.Compare(expected));
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 TEST_F(GPCC_FileSystems_EEPROMSectionSystem_CLI_TestsF, CLICMDMount_mountedBefore)
 {
@@ -504,18 +504,18 @@ TEST_F(GPCC_FileSystems_EEPROMSectionSystem_CLI_TestsF, CLICMDMount_mountedBefor
    ""
   };
 
-  Format(storagePageSize);
-  fakeStorage.writeAccessCnt = 0;
+  Format(storagePageSize_);
+  fakeStorage_.writeAccessCnt = 0;
 
   terminal.Input("Mount");
   terminal.Input_ENTER();
   terminal.WaitForInputProcessed();
 
-  ASSERT_EQ(0U, fakeStorage.writeAccessCnt);
-  ASSERT_EQ(gpcc::file_systems::eeprom_section_system::EEPROMSectionSystem::States::mounted, uut.GetState());
+  ASSERT_EQ(0U, fakeStorage_.writeAccessCnt);
+  ASSERT_EQ(gpcc::file_systems::eeprom_section_system::EEPROMSectionSystem::States::mounted, uut_.GetState());
   ASSERT_TRUE(terminal.Compare(expected));
 
-  uut.Unmount();
+  uut_.Unmount();
 }
 
 } // namespace file_systems

--- a/testcases/log/logfacilities/TestILogFacility.hpp
+++ b/testcases/log/logfacilities/TestILogFacility.hpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011 Daniel Jerolm
+    Copyright (C) 2011, 2025 Daniel Jerolm
 */
 
 #ifndef TESTILOGFACILITY_HPP_201601061558
@@ -573,19 +573,6 @@ TYPED_TEST_P(ILogFacility_Tests2F, Log)
   ASSERT_EQ(1U, this->backend.records.size());
   ASSERT_TRUE(this->backend.records[0]== "[DEBUG] TL1: Test");
 }
-
-#ifndef SKIP_VERYBIGMEM_TESTS
-TYPED_TEST_P(ILogFacility_Tests2F, Log_Performance)
-{
-  this->StopUUT();
-
-  for (uint_fast32_t i = 0U; i < 1000000U; ++i)
-  {
-    this->logger.Log(LogType::Error, "Test");
-  }
-}
-#endif
-
 TYPED_TEST_P(ILogFacility_Tests2F, Log_WhileStopped)
 {
   this->StopUUT();
@@ -1005,9 +992,6 @@ REGISTER_TYPED_TEST_SUITE_P(ILogFacility_Tests1F,
 REGISTER_TYPED_TEST_SUITE_P(ILogFacility_Tests2F,
                             Instantiation,
                             Log,
-#ifndef SKIP_VERYBIGMEM_TESTS
-                            Log_Performance,
-#endif
                             Log_WhileStopped,
                             Log_ButNoBackend,
                             ReportLogMessageCreationFailed_ButNoBackend,

--- a/testcases/stream/TestMemStreamReader.cpp
+++ b/testcases/stream/TestMemStreamReader.cpp
@@ -33,13 +33,13 @@ class GPCC_Stream_MemStreamReader_Tests: public Test
     GPCC_Stream_MemStreamReader_Tests(void);
 
   protected:
-    float const f1;
-    float const f2;
-    double const d1;
-    double const d2;
+    float const f1_;
+    float const f2_;
+    double const d1_;
+    double const d2_;
 
-    uint8_t memory[128];
-    size_t n;
+    uint8_t memory_[128];
+    size_t n_;
 
     void SetUp(void) override;
     void TearDown(void) override;
@@ -51,18 +51,18 @@ class GPCC_Stream_MemStreamReader_Tests: public Test
 };
 GPCC_Stream_MemStreamReader_Tests::GPCC_Stream_MemStreamReader_Tests(void)
 : Test()
-, f1(32.3)
-, f2(-12.3E-6)
-, d1(83.1)
-, d2(67.342E16)
-, memory()
-, n(0)
+, f1_(32.3)
+, f2_(-12.3E-6)
+, d1_(83.1)
+, d2_(67.342E16)
+, memory_()
+, n_(0)
 {
 }
 
 void GPCC_Stream_MemStreamReader_Tests::SetUp(void)
 {
-  memset(memory, 0x00, sizeof(memory));
+  memset(memory_, 0x00, sizeof(memory_));
 }
 void GPCC_Stream_MemStreamReader_Tests::TearDown(void)
 {
@@ -77,13 +77,13 @@ void GPCC_Stream_MemStreamReader_Tests::PrepareLittleEndianTestData1(void)
   /* 0x30  */    'r',  'T',  'e',  'x',  't',  0x00, 'L',  'i',  'n',  'e',  '1',  '\n', 'L',  'i',  'n',  'e',
   /* 0x40  */    '2',  '\r', 'L',  'i',  'n',  'e',  '3',  '\r', '\n', 'L',  'i',  'n',  'e',  '4',  0x00 };
 
-  n = sizeof(data);
-  assert(n <= sizeof(memory));
-  memcpy(memory, data, n);
+  n_ = sizeof(data);
+  assert(n_ <= sizeof(memory_));
+  memcpy(memory_, data, n_);
 
-  MemStreamWriter msw(memory + 32U, sizeof(float) + sizeof(double), IStreamWriter::Endian::Little);
-  msw << f1;
-  msw << d1;
+  MemStreamWriter msw(memory_ + 32U, sizeof(float) + sizeof(double), IStreamWriter::Endian::Little);
+  msw << f1_;
+  msw << d1_;
   msw.Close();
 }
 void GPCC_Stream_MemStreamReader_Tests::PrepeareLitteEndianTestData2(void)
@@ -97,13 +97,13 @@ void GPCC_Stream_MemStreamReader_Tests::PrepeareLitteEndianTestData2(void)
   /* 0x40 */     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
   /* 0x50 */     0x00, 0x00, 0x00, 0x00, 0xEB, 0x67, 0x01, 'c',  'h',  'a',  'r',  'T',  'e',  'x',  't',  0x00 };
 
-  n = sizeof(data);
-  assert(n <= sizeof(memory));
-  memcpy(memory, data, n);
+  n_ = sizeof(data);
+  assert(n_ <= sizeof(memory_));
+  memcpy(memory_, data, n_);
 
-  MemStreamWriter msw(memory + 0x3C, 2*sizeof(float) + 2*sizeof(double), IStreamWriter::Endian::Little);
-  msw << f1 << f2;
-  msw << d1 << d2;
+  MemStreamWriter msw(memory_ + 0x3C, 2*sizeof(float) + 2*sizeof(double), IStreamWriter::Endian::Little);
+  msw << f1_ << f2_;
+  msw << d1_ << d2_;
   msw.Close();
 }
 void GPCC_Stream_MemStreamReader_Tests::PrepareBigEndianTestData1(void)
@@ -116,13 +116,13 @@ void GPCC_Stream_MemStreamReader_Tests::PrepareBigEndianTestData1(void)
   /* 0x30  */    'r',  'T',  'e',  'x',  't',  0x00, 'L',  'i',  'n',  'e',  '1',  '\n', 'L',  'i',  'n',  'e',
   /* 0x40  */    '2',  '\r', 'L',  'i',  'n',  'e',  '3',  '\r', '\n', 'L',  'i',  'n',  'e',  '4',  0x00 };
 
-  n = sizeof(data);
-  assert(n <= sizeof(memory));
-  memcpy(memory, data, n);
+  n_ = sizeof(data);
+  assert(n_ <= sizeof(memory_));
+  memcpy(memory_, data, n_);
 
-  MemStreamWriter msw(memory + 32, sizeof(float) + sizeof(double), IStreamWriter::Endian::Big);
-  msw << f1;
-  msw << d1;
+  MemStreamWriter msw(memory_ + 32, sizeof(float) + sizeof(double), IStreamWriter::Endian::Big);
+  msw << f1_;
+  msw << d1_;
   msw.Close();
 }
 bool GPCC_Stream_MemStreamReader_Tests::AnyNotFF(uint8_t const * p, size_t s)
@@ -141,7 +141,7 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, pMemIsnullptrButSizeIsNotZero)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, ZeroSize1)
 {
-  MemStreamReader uut(memory, 0, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 0, IStreamReader::Endian::Little);
   ASSERT_EQ(IStreamReader::States::empty, uut.GetState());
   ASSERT_EQ(static_cast<size_t>(0), uut.RemainingBytes());
   uut.Close();
@@ -159,7 +159,7 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, CopyConstruction)
 {
   PrepareLittleEndianTestData1();
 
-  MemStreamReader uut1(memory, sizeof(memory), IStreamReader::Endian::Little);
+  MemStreamReader uut1(memory_, sizeof(memory_), IStreamReader::Endian::Little);
   ASSERT_EQ(IStreamReader::States::open, uut1.GetState());
 
   // create a copy
@@ -192,7 +192,7 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, CopyConstruction_Endian_Little)
 {
   PrepareLittleEndianTestData1();
 
-  MemStreamReader uut1(memory, sizeof(memory), IStreamReader::Endian::Little);
+  MemStreamReader uut1(memory_, sizeof(memory_), IStreamReader::Endian::Little);
   ASSERT_EQ(IStreamReader::States::open, uut1.GetState());
   ASSERT_EQ(IStreamReader::Endian::Little, uut1.GetEndian());
 
@@ -205,7 +205,7 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, CopyConstruction_Endian_Big)
 {
   PrepareLittleEndianTestData1();
 
-  MemStreamReader uut1(memory, sizeof(memory), IStreamReader::Endian::Big);
+  MemStreamReader uut1(memory_, sizeof(memory_), IStreamReader::Endian::Big);
   ASSERT_EQ(IStreamReader::States::open, uut1.GetState());
   ASSERT_EQ(IStreamReader::Endian::Big, uut1.GetEndian());
 
@@ -218,7 +218,7 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, CopyConstruction_BitPos)
 {
   PrepareLittleEndianTestData1();
 
-  MemStreamReader uut1(memory, sizeof(memory), IStreamReader::Endian::Little);
+  MemStreamReader uut1(memory_, sizeof(memory_), IStreamReader::Endian::Little);
   ASSERT_EQ(IStreamReader::States::open, uut1.GetState());
 
   uint8_t data;
@@ -251,7 +251,7 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, CopyConstruction_StateClosed)
 {
   PrepareLittleEndianTestData1();
 
-  MemStreamReader uut1(memory, sizeof(memory), IStreamReader::Endian::Little);
+  MemStreamReader uut1(memory_, sizeof(memory_), IStreamReader::Endian::Little);
   uut1.Close();
   ASSERT_EQ(IStreamReader::States::closed, uut1.GetState());
 
@@ -263,7 +263,7 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, CopyConstruction_StateEmpty)
 {
   PrepareLittleEndianTestData1();
 
-  MemStreamReader uut1(memory, 0, IStreamReader::Endian::Little);
+  MemStreamReader uut1(memory_, 0, IStreamReader::Endian::Little);
   ASSERT_EQ(IStreamReader::States::empty, uut1.GetState());
 
   // create a copy
@@ -279,7 +279,7 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, CopyConstruction_StateEmpty)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, CopyConstruction_StateError)
 {
-  MemStreamReader uut1(memory, 0, IStreamReader::Endian::Little);
+  MemStreamReader uut1(memory_, 0, IStreamReader::Endian::Little);
   ASSERT_THROW((void)uut1.Read_uint8(), EmptyError);
   ASSERT_EQ(IStreamReader::States::error, uut1.GetState());
 
@@ -297,7 +297,7 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, MoveConstruction)
 {
   PrepareLittleEndianTestData1();
 
-  MemStreamReader uut1(memory, sizeof(memory), IStreamReader::Endian::Little);
+  MemStreamReader uut1(memory_, sizeof(memory_), IStreamReader::Endian::Little);
   ASSERT_EQ(IStreamReader::States::open, uut1.GetState());
 
   uint8_t data;
@@ -322,7 +322,7 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, MoveConstruction_Endian_Little)
 {
   PrepareLittleEndianTestData1();
 
-  MemStreamReader uut1(memory, sizeof(memory), IStreamReader::Endian::Little);
+  MemStreamReader uut1(memory_, sizeof(memory_), IStreamReader::Endian::Little);
   ASSERT_EQ(IStreamReader::States::open, uut1.GetState());
   ASSERT_EQ(IStreamReader::Endian::Little, uut1.GetEndian());
 
@@ -335,7 +335,7 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, MoveConstruction_Endian_Big)
 {
   PrepareLittleEndianTestData1();
 
-  MemStreamReader uut1(memory, sizeof(memory), IStreamReader::Endian::Big);
+  MemStreamReader uut1(memory_, sizeof(memory_), IStreamReader::Endian::Big);
   ASSERT_EQ(IStreamReader::States::open, uut1.GetState());
   ASSERT_EQ(IStreamReader::Endian::Big, uut1.GetEndian());
 
@@ -348,7 +348,7 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, MoveConstruction_BitPos)
 {
   PrepareLittleEndianTestData1();
 
-  MemStreamReader uut1(memory, sizeof(memory), IStreamReader::Endian::Little);
+  MemStreamReader uut1(memory_, sizeof(memory_), IStreamReader::Endian::Little);
   ASSERT_EQ(IStreamReader::States::open, uut1.GetState());
 
   uint8_t data;
@@ -374,7 +374,7 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, MoveConstruction_StateClosed)
 {
   PrepareLittleEndianTestData1();
 
-  MemStreamReader uut1(memory, sizeof(memory), IStreamReader::Endian::Little);
+  MemStreamReader uut1(memory_, sizeof(memory_), IStreamReader::Endian::Little);
   uut1.Close();
   ASSERT_EQ(IStreamReader::States::closed, uut1.GetState());
 
@@ -386,7 +386,7 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, MoveConstruction_StateEmpty)
 {
   PrepareLittleEndianTestData1();
 
-  MemStreamReader uut1(memory, 0, IStreamReader::Endian::Little);
+  MemStreamReader uut1(memory_, 0, IStreamReader::Endian::Little);
   ASSERT_EQ(IStreamReader::States::empty, uut1.GetState());
 
   // move-create a new instance
@@ -402,7 +402,7 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, MoveConstruction_StateEmpty)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, MoveConstruction_StateError)
 {
-  MemStreamReader uut1(memory, 0, IStreamReader::Endian::Little);
+  MemStreamReader uut1(memory_, 0, IStreamReader::Endian::Little);
   ASSERT_THROW((void)uut1.Read_uint8(), EmptyError);
   ASSERT_EQ(IStreamReader::States::error, uut1.GetState());
 
@@ -420,7 +420,7 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, CopyAssignment)
 {
   PrepareLittleEndianTestData1();
 
-  MemStreamReader uut1(memory, sizeof(memory), IStreamReader::Endian::Little);
+  MemStreamReader uut1(memory_, sizeof(memory_), IStreamReader::Endian::Little);
   ASSERT_EQ(IStreamReader::States::open, uut1.GetState());
 
   // create a copy
@@ -454,10 +454,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, CopyAssignment_Endian_Little)
 {
   PrepareLittleEndianTestData1();
 
-  MemStreamReader uut1(memory, sizeof(memory), IStreamReader::Endian::Little);
+  MemStreamReader uut1(memory_, sizeof(memory_), IStreamReader::Endian::Little);
   ASSERT_EQ(IStreamReader::States::open, uut1.GetState());
 
-  MemStreamReader uut2(memory, sizeof(memory), IStreamReader::Endian::Big);
+  MemStreamReader uut2(memory_, sizeof(memory_), IStreamReader::Endian::Big);
   ASSERT_EQ(IStreamReader::Endian::Big, uut2.GetEndian());
 
   uint8_t data;
@@ -488,10 +488,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, CopyAssignment_Endian_Big)
 {
   PrepareLittleEndianTestData1();
 
-  MemStreamReader uut1(memory, sizeof(memory), IStreamReader::Endian::Big);
+  MemStreamReader uut1(memory_, sizeof(memory_), IStreamReader::Endian::Big);
   ASSERT_EQ(IStreamReader::States::open, uut1.GetState());
 
-  MemStreamReader uut2(memory, sizeof(memory), IStreamReader::Endian::Little);
+  MemStreamReader uut2(memory_, sizeof(memory_), IStreamReader::Endian::Little);
   ASSERT_EQ(IStreamReader::Endian::Little, uut2.GetEndian());
 
   uint8_t data;
@@ -522,7 +522,7 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, CopyAssignment_BitPos)
 {
   PrepareLittleEndianTestData1();
 
-  MemStreamReader uut1(memory, sizeof(memory), IStreamReader::Endian::Little);
+  MemStreamReader uut1(memory_, sizeof(memory_), IStreamReader::Endian::Little);
   ASSERT_EQ(IStreamReader::States::open, uut1.GetState());
 
   // create a copy
@@ -556,7 +556,7 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, CopyAssignment_StateClosed)
 {
   PrepareLittleEndianTestData1();
 
-  MemStreamReader uut1(memory, sizeof(memory), IStreamReader::Endian::Little);
+  MemStreamReader uut1(memory_, sizeof(memory_), IStreamReader::Endian::Little);
   ASSERT_EQ(IStreamReader::States::open, uut1.GetState());
 
   // create a copy
@@ -578,10 +578,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, CopyAssignment_StateEmpty)
 {
   PrepareLittleEndianTestData1();
 
-  MemStreamReader uut1(memory, 0, IStreamReader::Endian::Little);
+  MemStreamReader uut1(memory_, 0, IStreamReader::Endian::Little);
   ASSERT_EQ(IStreamReader::States::empty, uut1.GetState());
 
-  MemStreamReader uut2(memory, sizeof(memory), IStreamReader::Endian::Little);
+  MemStreamReader uut2(memory_, sizeof(memory_), IStreamReader::Endian::Little);
 
   uint8_t data;
 
@@ -598,11 +598,11 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, CopyAssignment_StateError)
 {
   PrepareLittleEndianTestData1();
 
-  MemStreamReader uut1(memory, 0, IStreamReader::Endian::Little);
+  MemStreamReader uut1(memory_, 0, IStreamReader::Endian::Little);
   ASSERT_EQ(IStreamReader::States::empty, uut1.GetState());
   ASSERT_THROW((void)uut1.Read_char(), std::exception);
 
-  MemStreamReader uut2(memory, sizeof(memory), IStreamReader::Endian::Little);
+  MemStreamReader uut2(memory_, sizeof(memory_), IStreamReader::Endian::Little);
 
   uint8_t data;
 
@@ -618,12 +618,12 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, CopyAssignment_StateError)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, CopyAssignment_RecoverFromErrorState)
 {
-  assert(sizeof(memory) >= 5U);
+  assert(sizeof(memory_) >= 5U);
   PrepareLittleEndianTestData1();
 
-  MemStreamReader uut1(memory, 5, IStreamReader::Endian::Little);
+  MemStreamReader uut1(memory_, 5, IStreamReader::Endian::Little);
 
-  MemStreamReader uut2(memory, 0, IStreamReader::Endian::Little);
+  MemStreamReader uut2(memory_, 0, IStreamReader::Endian::Little);
   ASSERT_THROW((void)uut2.Read_char(), std::exception);
   ASSERT_EQ(IStreamReader::States::error, uut2.GetState());
 
@@ -639,12 +639,12 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, CopyAssignment_RecoverFromErrorState)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, CopyAssignment_RecoverFromClosedState)
 {
-  assert(sizeof(memory) >= 5U);
+  assert(sizeof(memory_) >= 5U);
   PrepareLittleEndianTestData1();
 
-  MemStreamReader uut1(memory, 5, IStreamReader::Endian::Little);
+  MemStreamReader uut1(memory_, 5, IStreamReader::Endian::Little);
 
-  MemStreamReader uut2(memory, 0, IStreamReader::Endian::Little);
+  MemStreamReader uut2(memory_, 0, IStreamReader::Endian::Little);
   uut2.Close();
   ASSERT_EQ(IStreamReader::States::closed, uut2.GetState());
 
@@ -662,7 +662,7 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, CopyAssignment_Self)
 {
   PrepareLittleEndianTestData1();
 
-  MemStreamReader uut1(memory, sizeof(memory), IStreamReader::Endian::Little);
+  MemStreamReader uut1(memory_, sizeof(memory_), IStreamReader::Endian::Little);
   ASSERT_EQ(IStreamReader::States::open, uut1.GetState());
   uint8_t data;
 
@@ -684,10 +684,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, MoveAssignment)
 {
   PrepareLittleEndianTestData1();
 
-  MemStreamReader uut1(memory, sizeof(memory), IStreamReader::Endian::Little);
+  MemStreamReader uut1(memory_, sizeof(memory_), IStreamReader::Endian::Little);
   ASSERT_EQ(IStreamReader::States::open, uut1.GetState());
 
-  MemStreamReader uut2(memory, 0, IStreamReader::Endian::Little);
+  MemStreamReader uut2(memory_, 0, IStreamReader::Endian::Little);
   ASSERT_EQ(IStreamReader::States::empty, uut2.GetState());
 
   uint8_t data;
@@ -713,10 +713,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, MoveAssignment_Endian_Little)
 {
   PrepareLittleEndianTestData1();
 
-  MemStreamReader uut1(memory, sizeof(memory), IStreamReader::Endian::Little);
+  MemStreamReader uut1(memory_, sizeof(memory_), IStreamReader::Endian::Little);
   ASSERT_EQ(IStreamReader::States::open, uut1.GetState());
 
-  MemStreamReader uut2(memory, 0, IStreamReader::Endian::Big);
+  MemStreamReader uut2(memory_, 0, IStreamReader::Endian::Big);
   ASSERT_EQ(IStreamReader::States::empty, uut2.GetState());
 
   uint8_t data;
@@ -743,10 +743,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, MoveAssignment_Endian_Big)
 {
   PrepareLittleEndianTestData1();
 
-  MemStreamReader uut1(memory, sizeof(memory), IStreamReader::Endian::Big);
+  MemStreamReader uut1(memory_, sizeof(memory_), IStreamReader::Endian::Big);
   ASSERT_EQ(IStreamReader::States::open, uut1.GetState());
 
-  MemStreamReader uut2(memory, 0, IStreamReader::Endian::Little);
+  MemStreamReader uut2(memory_, 0, IStreamReader::Endian::Little);
   ASSERT_EQ(IStreamReader::States::empty, uut2.GetState());
 
   uint8_t data;
@@ -773,10 +773,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, MoveAssignment_BitPos)
 {
   PrepareLittleEndianTestData1();
 
-  MemStreamReader uut1(memory, sizeof(memory), IStreamReader::Endian::Little);
+  MemStreamReader uut1(memory_, sizeof(memory_), IStreamReader::Endian::Little);
   ASSERT_EQ(IStreamReader::States::open, uut1.GetState());
 
-  MemStreamReader uut2(memory, 0, IStreamReader::Endian::Little);
+  MemStreamReader uut2(memory_, 0, IStreamReader::Endian::Little);
   ASSERT_EQ(IStreamReader::States::empty, uut2.GetState());
 
   uint8_t data;
@@ -804,10 +804,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, MoveAssignment_StateClosed)
 {
   PrepareLittleEndianTestData1();
 
-  MemStreamReader uut1(memory, sizeof(memory), IStreamReader::Endian::Little);
+  MemStreamReader uut1(memory_, sizeof(memory_), IStreamReader::Endian::Little);
   ASSERT_EQ(IStreamReader::States::open, uut1.GetState());
 
-  MemStreamReader uut2(memory, sizeof(memory), IStreamReader::Endian::Little);
+  MemStreamReader uut2(memory_, sizeof(memory_), IStreamReader::Endian::Little);
   ASSERT_EQ(IStreamReader::States::open, uut2.GetState());
 
   uut1.Close();
@@ -826,10 +826,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, MoveAssignment_StateEmpty)
 {
   PrepareLittleEndianTestData1();
 
-  MemStreamReader uut1(memory, 0, IStreamReader::Endian::Little);
+  MemStreamReader uut1(memory_, 0, IStreamReader::Endian::Little);
   ASSERT_EQ(IStreamReader::States::empty, uut1.GetState());
 
-  MemStreamReader uut2(memory, sizeof(memory), IStreamReader::Endian::Little);
+  MemStreamReader uut2(memory_, sizeof(memory_), IStreamReader::Endian::Little);
 
   uint8_t data;
 
@@ -846,11 +846,11 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, MoveAssignment_StateError)
 {
   PrepareLittleEndianTestData1();
 
-  MemStreamReader uut1(memory, 0, IStreamReader::Endian::Little);
+  MemStreamReader uut1(memory_, 0, IStreamReader::Endian::Little);
   ASSERT_EQ(IStreamReader::States::empty, uut1.GetState());
   ASSERT_THROW((void)uut1.Read_char(), std::exception);
 
-  MemStreamReader uut2(memory, sizeof(memory), IStreamReader::Endian::Little);
+  MemStreamReader uut2(memory_, sizeof(memory_), IStreamReader::Endian::Little);
 
   uint8_t data;
 
@@ -865,12 +865,12 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, MoveAssignment_StateError)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, MoveAssignment_RecoverFromErrorState)
 {
-  assert(sizeof(memory) >= 5U);
+  assert(sizeof(memory_) >= 5U);
   PrepareLittleEndianTestData1();
 
-  MemStreamReader uut1(memory, 5, IStreamReader::Endian::Little);
+  MemStreamReader uut1(memory_, 5, IStreamReader::Endian::Little);
 
-  MemStreamReader uut2(memory, 0, IStreamReader::Endian::Little);
+  MemStreamReader uut2(memory_, 0, IStreamReader::Endian::Little);
   ASSERT_THROW((void)uut2.Read_char(), std::exception);
   ASSERT_EQ(IStreamReader::States::error, uut2.GetState());
 
@@ -886,12 +886,12 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, MoveAssignment_RecoverFromErrorState)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, MoveAssignment_RecoverFromClosedState)
 {
-  assert(sizeof(memory) >= 5U);
+  assert(sizeof(memory_) >= 5U);
   PrepareLittleEndianTestData1();
 
-  MemStreamReader uut1(memory, 5, IStreamReader::Endian::Little);
+  MemStreamReader uut1(memory_, 5, IStreamReader::Endian::Little);
 
-  MemStreamReader uut2(memory, 0, IStreamReader::Endian::Little);
+  MemStreamReader uut2(memory_, 0, IStreamReader::Endian::Little);
   uut2.Close();
   ASSERT_EQ(IStreamReader::States::closed, uut2.GetState());
 
@@ -909,7 +909,7 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, MoveAssignment_Self)
 {
   PrepareLittleEndianTestData1();
 
-  MemStreamReader uut1(memory, sizeof(memory), IStreamReader::Endian::Little);
+  MemStreamReader uut1(memory_, sizeof(memory_), IStreamReader::Endian::Little);
   ASSERT_EQ(IStreamReader::States::open, uut1.GetState());
   uint8_t data;
 
@@ -929,7 +929,7 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, MoveAssignment_Self)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadFromZeroSizedStream)
 {
-  MemStreamReader uut(memory, 0, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 0, IStreamReader::Endian::Little);
   ASSERT_EQ(IStreamReader::States::empty, uut.GetState());
   ASSERT_EQ(static_cast<size_t>(0), uut.RemainingBytes());
 
@@ -943,9 +943,9 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadFromZeroSizedStream)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadNothing)
 {
-  MemStreamReader uut(memory, sizeof(memory), IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, sizeof(memory_), IStreamReader::Endian::Little);
 
-  ASSERT_EQ(sizeof(memory), uut.RemainingBytes());
+  ASSERT_EQ(sizeof(memory_), uut.RemainingBytes());
   ASSERT_EQ(IStreamReader::States::open, uut.GetState());
 
   ASSERT_NO_THROW(uut.Close());
@@ -954,7 +954,7 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadNothing)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, DoubleClose)
 {
-  MemStreamReader uut(memory, sizeof(memory), IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, sizeof(memory_), IStreamReader::Endian::Little);
 
   ASSERT_EQ(IStreamReader::States::open, uut.GetState());
 
@@ -968,7 +968,7 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, DoubleClose)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, NoClose)
 {
-  std::unique_ptr<MemStreamReader> spUUT(new MemStreamReader(memory, sizeof(memory), IStreamReader::Endian::Little));
+  std::unique_ptr<MemStreamReader> spUUT(new MemStreamReader(memory_, sizeof(memory_), IStreamReader::Endian::Little));
 
   // close is performed by destructor
   spUUT.reset();
@@ -977,7 +977,7 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadLittleStreamOp)
 {
   PrepareLittleEndianTestData1();
 
-  MemStreamReader uut(memory, sizeof(memory), IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, sizeof(memory_), IStreamReader::Endian::Little);
 
   ASSERT_EQ(IStreamReader::Endian::Little, uut.GetEndian());
 
@@ -1021,11 +1021,11 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadLittleStreamOp)
 
   float f;
   uut >> f;
-  ASSERT_TRUE((f > f1 - 0.1f) && (f < f1 + 0.1f));
+  ASSERT_TRUE((f > f1_ - 0.1f) && (f < f1_ + 0.1f));
 
   double d;
   uut >> d;
-  ASSERT_TRUE((d > d1 - 0.1) && (d < d1 + 0.1));
+  ASSERT_TRUE((d > d1_ - 0.1) && (d < d1_ + 0.1));
 
   bool b;
   uut >> b;
@@ -1055,7 +1055,7 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadLittleStreamOp)
   uut >> s;
   ASSERT_TRUE(s == "Line1\nLine2\rLine3\r\nLine4");
 
-  ASSERT_EQ(sizeof(memory) - n, uut.RemainingBytes());
+  ASSERT_EQ(sizeof(memory_) - n_, uut.RemainingBytes());
   ASSERT_EQ(IStreamReader::States::open, uut.GetState());
 
   uut.Close();
@@ -1066,7 +1066,7 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadLittleFuncCalls)
 {
   PrepareLittleEndianTestData1();
 
-  MemStreamReader uut(memory, sizeof(memory), IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, sizeof(memory_), IStreamReader::Endian::Little);
 
   ASSERT_EQ(IStreamReader::Endian::Little, uut.GetEndian());
 
@@ -1101,10 +1101,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadLittleFuncCalls)
   ASSERT_EQ(0, u8);
 
   float f = uut.Read_float();
-  ASSERT_TRUE((f > f1 - 0.1f) && (f < f1 + 0.1f));
+  ASSERT_TRUE((f > f1_ - 0.1f) && (f < f1_ + 0.1f));
 
   double d = uut.Read_double();
-  ASSERT_TRUE((d > d1 - 0.1) && (d < d1 + 0.1));
+  ASSERT_TRUE((d > d1_ - 0.1) && (d < d1_ + 0.1));
 
   bool b;
   b = uut.Read_bool();
@@ -1139,7 +1139,7 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadLittleFuncCalls)
   ASSERT_TRUE(s == "Line4");
   // see test cases "ReadLine_NoEnd1" and "ReadLine_NoEnd2" to test Read_line() with no line ending at end of stream
 
-  ASSERT_EQ(sizeof(memory) - n, uut.RemainingBytes());
+  ASSERT_EQ(sizeof(memory_) - n_, uut.RemainingBytes());
   ASSERT_EQ(IStreamReader::States::open, uut.GetState());
 
   uut.Close();
@@ -1153,7 +1153,7 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadBigStreamOp)
   float f1 = 32.3;
   double d1 = 83.1;
 
-  MemStreamReader uut(memory, sizeof(memory), IStreamReader::Endian::Big);
+  MemStreamReader uut(memory_, sizeof(memory_), IStreamReader::Endian::Big);
 
   ASSERT_EQ(IStreamReader::Endian::Big, uut.GetEndian());
 
@@ -1231,7 +1231,7 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadBigStreamOp)
   uut >> s;
   ASSERT_TRUE(s == "Line1\nLine2\rLine3\r\nLine4");
 
-  ASSERT_EQ(sizeof(memory) - n, uut.RemainingBytes());
+  ASSERT_EQ(sizeof(memory_) - n_, uut.RemainingBytes());
   ASSERT_EQ(IStreamReader::States::open, uut.GetState());
 
   uut.Close();
@@ -1245,7 +1245,7 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadBigFuncCalls)
   float f1 = 32.3;
   double d1 = 83.1;
 
-  MemStreamReader uut(memory, sizeof(memory), IStreamReader::Endian::Big);
+  MemStreamReader uut(memory_, sizeof(memory_), IStreamReader::Endian::Big);
 
   ASSERT_EQ(IStreamReader::Endian::Big, uut.GetEndian());
 
@@ -1318,7 +1318,7 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadBigFuncCalls)
   ASSERT_TRUE(s == "Line4");
   // see test cases "ReadLine_NoEnd1" and "ReadLine_NoEnd2" to test Read_line() with no line ending at end of stream
 
-  ASSERT_EQ(sizeof(memory) - n, uut.RemainingBytes());
+  ASSERT_EQ(sizeof(memory_) - n_, uut.RemainingBytes());
   ASSERT_EQ(IStreamReader::States::open, uut.GetState());
 
   uut.Close();
@@ -1329,7 +1329,7 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadMultipleElements)
 {
   PrepeareLitteEndianTestData2();
 
-  MemStreamReader uut(memory, sizeof(memory), IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, sizeof(memory_), IStreamReader::Endian::Little);
 
   ASSERT_EQ(IStreamReader::Endian::Little, uut.GetEndian());
 
@@ -1377,12 +1377,12 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadMultipleElements)
 
   // 60
 
-  float const data_float[] = { f1, f2 };
+  float const data_float[] = { f1_, f2_ };
   float read_data_float[2];
   uut.Read_float(read_data_float, 2);
   ASSERT_TRUE(memcmp(data_float, read_data_float, sizeof(data_float)) == 0);
 
-  double const data_double[] = { d1, d2 };
+  double const data_double[] = { d1_, d2_ };
   double read_data_double[2];
   uut.Read_double(read_data_double, 2);
   ASSERT_TRUE(memcmp(data_double, read_data_double, sizeof(data_double)) == 0);
@@ -1413,7 +1413,7 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadMultipleElements)
 
   // 96
 
-  ASSERT_EQ(sizeof(memory) - n, uut.RemainingBytes());
+  ASSERT_EQ(sizeof(memory_) - n_, uut.RemainingBytes());
   ASSERT_EQ(IStreamReader::States::open, uut.GetState());
 
   uut.Close();
@@ -1422,10 +1422,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadMultipleElements)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadBits_UpperZero)
 {
-  memory[0] = 0x1F;
-  memory[1] = 0xFF;
+  memory_[0] = 0x1F;
+  memory_[1] = 0xFF;
 
-  MemStreamReader uut(memory, sizeof(memory), IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, sizeof(memory_), IStreamReader::Endian::Little);
 
   uint8_t u8;
 
@@ -1446,10 +1446,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadBits_UpperZero)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadBits_NextByteAlignsProperly)
 {
-  memory[0] = 0xFA;
-  memory[1] = 0x12;
+  memory_[0] = 0xFA;
+  memory_[1] = 0x12;
 
-  MemStreamReader uut(memory, sizeof(memory), IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, sizeof(memory_), IStreamReader::Endian::Little);
 
   uint8_t u8;
 
@@ -1467,10 +1467,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadBits_NextByteAlignsProperly)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, EmptyByByteRead)
 {
-  memory[0] = 0xFA;
-  memory[1] = 0x12;
+  memory_[0] = 0xFA;
+  memory_[1] = 0x12;
 
-  MemStreamReader uut(memory, 2, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 2, IStreamReader::Endian::Little);
 
   uint8_t u8;
 
@@ -1490,10 +1490,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, EmptyByByteRead)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, EmptyByBitRead)
 {
-  memory[0] = 0xFA;
-  memory[1] = 0x12;
+  memory_[0] = 0xFA;
+  memory_[1] = 0x12;
 
-  MemStreamReader uut(memory, 2, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 2, IStreamReader::Endian::Little);
 
   ASSERT_EQ(IStreamReader::States::open, uut.GetState());
   ASSERT_EQ(static_cast<size_t>(2), uut.RemainingBytes());
@@ -1552,10 +1552,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, EmptyByBitRead)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadByteFromEmptyStream)
 {
-  memory[0] = 0xFA;
-  memory[1] = 0x12;
+  memory_[0] = 0xFA;
+  memory_[1] = 0x12;
 
-  MemStreamReader uut(memory, 2, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 2, IStreamReader::Endian::Little);
 
   uint8_t u8;
 
@@ -1579,10 +1579,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadByteFromEmptyStream)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadBitFromEmptyStream)
 {
-  memory[0] = 0xFA;
-  memory[1] = 0x12;
+  memory_[0] = 0xFA;
+  memory_[1] = 0x12;
 
-  MemStreamReader uut(memory, 2, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 2, IStreamReader::Endian::Little);
 
   uint8_t u8;
   bool b;
@@ -1608,10 +1608,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadBitFromEmptyStream)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadTooManyBitsFromAlmostEmptyStream)
 {
-  memory[0] = 0xFA;
-  memory[1] = 0x12;
+  memory_[0] = 0xFA;
+  memory_[1] = 0x12;
 
-  MemStreamReader uut(memory, 2, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 2, IStreamReader::Endian::Little);
 
   uint8_t u8;
   bool b;
@@ -1643,10 +1643,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadTooManyBitsFromAlmostEmptyStream)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadStringFromEmptyStream)
 {
-  memory[0] = 0xFA;
-  memory[1] = 0x12;
+  memory_[0] = 0xFA;
+  memory_[1] = 0x12;
 
-  MemStreamReader uut(memory, 2, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 2, IStreamReader::Endian::Little);
 
   uint8_t u8;
 
@@ -1670,10 +1670,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadStringFromEmptyStream)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadLineFromEmptyStream)
 {
-  memory[0] = 0xFA;
-  memory[1] = 0x12;
+  memory_[0] = 0xFA;
+  memory_[1] = 0x12;
 
-  MemStreamReader uut(memory, 2, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 2, IStreamReader::Endian::Little);
 
   uint8_t u8;
 
@@ -1697,10 +1697,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadLineFromEmptyStream)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadByteInErrorState)
 {
-  memory[0] = 0xFA;
-  memory[1] = 0x12;
+  memory_[0] = 0xFA;
+  memory_[1] = 0x12;
 
-  MemStreamReader uut(memory, 2, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 2, IStreamReader::Endian::Little);
 
   uint8_t au8[3];
 
@@ -1718,10 +1718,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadByteInErrorState)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadBitInErrorState)
 {
-  memory[0] = 0xFA;
-  memory[1] = 0x12;
+  memory_[0] = 0xFA;
+  memory_[1] = 0x12;
 
-  MemStreamReader uut(memory, 2, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 2, IStreamReader::Endian::Little);
 
   uint8_t au8[3];
 
@@ -1741,10 +1741,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadBitInErrorState)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadStringInErrorState)
 {
-  memory[0] = 0xFA;
-  memory[1] = 0x12;
+  memory_[0] = 0xFA;
+  memory_[1] = 0x12;
 
-  MemStreamReader uut(memory, 2, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 2, IStreamReader::Endian::Little);
 
   uint8_t au8[3];
 
@@ -1762,10 +1762,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadStringInErrorState)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadLineInErrorState)
 {
-  memory[0] = 0xFA;
-  memory[1] = 0x12;
+  memory_[0] = 0xFA;
+  memory_[1] = 0x12;
 
-  MemStreamReader uut(memory, 2, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 2, IStreamReader::Endian::Little);
 
   uint8_t au8[3];
 
@@ -1783,10 +1783,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadLineInErrorState)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadByteFromClosedStream)
 {
-  memory[0] = 0xFA;
-  memory[1] = 0x12;
+  memory_[0] = 0xFA;
+  memory_[1] = 0x12;
 
-  MemStreamReader uut(memory, 2, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 2, IStreamReader::Endian::Little);
   uut.Close();
 
   uint8_t u8;
@@ -1796,10 +1796,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadByteFromClosedStream)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadBitFromClosedStream)
 {
-  memory[0] = 0xFA;
-  memory[1] = 0x12;
+  memory_[0] = 0xFA;
+  memory_[1] = 0x12;
 
-  MemStreamReader uut(memory, 2, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 2, IStreamReader::Endian::Little);
   uut.Close();
 
   bool b;
@@ -1809,10 +1809,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadBitFromClosedStream)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadStringFromClosedStream)
 {
-  memory[0] = 0xFA;
-  memory[1] = 0x12;
+  memory_[0] = 0xFA;
+  memory_[1] = 0x12;
 
-  MemStreamReader uut(memory, 2, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 2, IStreamReader::Endian::Little);
   uut.Close();
 
   ASSERT_THROW(std::string str = uut.Read_string(), ClosedError);
@@ -1820,10 +1820,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadStringFromClosedStream)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadLineFromClosedStream)
 {
-  memory[0] = 0xFA;
-  memory[1] = 0x12;
+  memory_[0] = 0xFA;
+  memory_[1] = 0x12;
 
-  MemStreamReader uut(memory, 2, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 2, IStreamReader::Endian::Little);
   uut.Close();
 
   ASSERT_THROW(std::string str = uut.Read_line(), ClosedError);
@@ -1831,10 +1831,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadLineFromClosedStream)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, CloseStreamInErrorState)
 {
-  memory[0] = 0xFA;
-  memory[1] = 0x12;
+  memory_[0] = 0xFA;
+  memory_[1] = 0x12;
 
-  MemStreamReader uut(memory, 2, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 2, IStreamReader::Endian::Little);
 
   uint8_t au8[3];
 
@@ -1848,24 +1848,24 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, CloseStreamInErrorState)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, RemainingBytesSupported)
 {
-  memory[0] = 0xFA;
-  memory[1] = 0x12;
+  memory_[0] = 0xFA;
+  memory_[1] = 0x12;
 
-  MemStreamReader uut(memory, 2, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 2, IStreamReader::Endian::Little);
 
   ASSERT_TRUE(uut.IsRemainingBytesSupported());
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, RemainingBytesInDifferentStates)
 {
-  memory[0] = 0xFA;
-  memory[1] = 0x12;
-  memory[2] = 0x45;
-  memory[3] = 0xB6;
+  memory_[0] = 0xFA;
+  memory_[1] = 0x12;
+  memory_[2] = 0x45;
+  memory_[3] = 0xB6;
 
   uint8_t u8;
   uint16_t u16;
 
-  MemStreamReader uut(memory, 4, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 4, IStreamReader::Endian::Little);
 
   ASSERT_EQ(IStreamReader::States::open, uut.GetState());
   ASSERT_EQ(static_cast<size_t>(4), uut.RemainingBytes());
@@ -1903,7 +1903,7 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadZeroElements)
   uint8_t readMem[16];
   memset(readMem, 0xFF, sizeof(readMem));
 
-  MemStreamReader uut(memory, sizeof(memory), IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, sizeof(memory_), IStreamReader::Endian::Little);
 
   ASSERT_EQ(IStreamReader::Endian::Little, uut.GetEndian());
 
@@ -1938,7 +1938,7 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadZeroElements)
   ASSERT_FALSE(AnyNotFF(readMem, sizeof(readMem)));
 
 
-  ASSERT_EQ(sizeof(memory), uut.RemainingBytes());
+  ASSERT_EQ(sizeof(memory_), uut.RemainingBytes());
   ASSERT_EQ(IStreamReader::States::open, uut.GetState());
 
   uut.Close();
@@ -1947,13 +1947,13 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadZeroElements)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadEmptyString1)
 {
-  MemStreamReader uut(memory, sizeof(memory), IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, sizeof(memory_), IStreamReader::Endian::Little);
 
   std::string s = uut.Read_string();
 
   ASSERT_EQ(static_cast<size_t>(0), s.length());
 
-  ASSERT_EQ(sizeof(memory) - 1, uut.RemainingBytes());
+  ASSERT_EQ(sizeof(memory_) - 1, uut.RemainingBytes());
   ASSERT_EQ(IStreamReader::States::open, uut.GetState());
 
   uut.Close();
@@ -1962,9 +1962,9 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadEmptyString1)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadEmptyString2)
 {
-  assert(sizeof(memory) >= 1);
+  assert(sizeof(memory_) >= 1);
 
-  MemStreamReader uut(memory, 1, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 1, IStreamReader::Endian::Little);
 
   std::string s = uut.Read_string();
 
@@ -1979,15 +1979,15 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadEmptyString2)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadStringButNoNullTerminator1)
 {
-  assert(sizeof(memory) >= 5);
+  assert(sizeof(memory_) >= 5);
 
-  memory[0] = 'H';
-  memory[1] = 'e';
-  memory[2] = 'l';
-  memory[3] = 'l';
-  memory[4] = 'o';
+  memory_[0] = 'H';
+  memory_[1] = 'e';
+  memory_[2] = 'l';
+  memory_[3] = 'l';
+  memory_[4] = 'o';
 
-  MemStreamReader uut(memory, sizeof(5), IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, sizeof(5), IStreamReader::Endian::Little);
 
   ASSERT_THROW(std::string s = uut.Read_string(), std::runtime_error);
 
@@ -1997,11 +1997,11 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadStringButNoNullTerminator1)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadStringButNoNullTerminator2)
 {
-  assert(sizeof(memory) >= 1);
+  assert(sizeof(memory_) >= 1);
 
-  memory[0] = 'A';
+  memory_[0] = 'A';
 
-  MemStreamReader uut(memory, 1, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 1, IStreamReader::Endian::Little);
 
   ASSERT_THROW(std::string s = uut.Read_string(), std::runtime_error);
 
@@ -2013,8 +2013,8 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadLine_Empty_NUL)
 {
   // two empty lines, terminated by NUL
 
-  assert(sizeof(memory) > 2U);
-  MemStreamReader uut(memory, sizeof(memory), IStreamReader::Endian::Little);
+  assert(sizeof(memory_) > 2U);
+  MemStreamReader uut(memory_, sizeof(memory_), IStreamReader::Endian::Little);
 
   std::string s = uut.Read_line();
   ASSERT_TRUE(s.empty());
@@ -2022,7 +2022,7 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadLine_Empty_NUL)
   s = uut.Read_line();
   ASSERT_TRUE(s.empty());
 
-  ASSERT_EQ(sizeof(memory) - 2U, uut.RemainingBytes());
+  ASSERT_EQ(sizeof(memory_) - 2U, uut.RemainingBytes());
   ASSERT_EQ(IStreamReader::States::open, uut.GetState());
 
   uut.Close();
@@ -2030,12 +2030,12 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadLine_Empty_NUL)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadLine_Empty_LF)
 {
-  // two empty lines, terminated by \n
+  // two empty lines, terminated by \n_
 
-  assert(sizeof(memory) > 2U);
-  memory[0] = '\n';
-  memory[1] = '\n';
-  MemStreamReader uut(memory, sizeof(memory), IStreamReader::Endian::Little);
+  assert(sizeof(memory_) > 2U);
+  memory_[0] = '\n';
+  memory_[1] = '\n';
+  MemStreamReader uut(memory_, sizeof(memory_), IStreamReader::Endian::Little);
 
   std::string s = uut.Read_line();
   ASSERT_TRUE(s.empty());
@@ -2043,7 +2043,7 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadLine_Empty_LF)
   s = uut.Read_line();
   ASSERT_TRUE(s.empty());
 
-  ASSERT_EQ(sizeof(memory) - 2U, uut.RemainingBytes());
+  ASSERT_EQ(sizeof(memory_) - 2U, uut.RemainingBytes());
   ASSERT_EQ(IStreamReader::States::open, uut.GetState());
 
   uut.Close();
@@ -2053,10 +2053,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadLine_Empty_CR)
 {
   // two empty lines, terminated by \r
 
-  assert(sizeof(memory) > 2U);
-  memory[0] = '\r';
-  memory[1] = '\r';
-  MemStreamReader uut(memory, sizeof(memory), IStreamReader::Endian::Little);
+  assert(sizeof(memory_) > 2U);
+  memory_[0] = '\r';
+  memory_[1] = '\r';
+  MemStreamReader uut(memory_, sizeof(memory_), IStreamReader::Endian::Little);
 
   std::string s = uut.Read_line();
   ASSERT_TRUE(s.empty());
@@ -2064,7 +2064,7 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadLine_Empty_CR)
   s = uut.Read_line();
   ASSERT_TRUE(s.empty());
 
-  ASSERT_EQ(sizeof(memory) - 2U, uut.RemainingBytes());
+  ASSERT_EQ(sizeof(memory_) - 2U, uut.RemainingBytes());
   ASSERT_EQ(IStreamReader::States::open, uut.GetState());
 
   uut.Close();
@@ -2072,13 +2072,13 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadLine_Empty_CR)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadLine_Empty_CRLF)
 {
-  // two empty lines, terminated by \r\n
-  assert(sizeof(memory) > 4U);
-  memory[0] = '\r';
-  memory[1] = '\n';
-  memory[2] = '\r';
-  memory[3] = '\n';
-  MemStreamReader uut(memory, sizeof(memory), IStreamReader::Endian::Little);
+  // two empty lines, terminated by \r\n_
+  assert(sizeof(memory_) > 4U);
+  memory_[0] = '\r';
+  memory_[1] = '\n';
+  memory_[2] = '\r';
+  memory_[3] = '\n';
+  MemStreamReader uut(memory_, sizeof(memory_), IStreamReader::Endian::Little);
 
   std::string s = uut.Read_line();
   ASSERT_TRUE(s.empty());
@@ -2086,7 +2086,7 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadLine_Empty_CRLF)
   s = uut.Read_line();
   ASSERT_TRUE(s.empty());
 
-  ASSERT_EQ(sizeof(memory) - 4U, uut.RemainingBytes());
+  ASSERT_EQ(sizeof(memory_) - 4U, uut.RemainingBytes());
   ASSERT_EQ(IStreamReader::States::open, uut.GetState());
 
   uut.Close();
@@ -2095,9 +2095,9 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadLine_Empty_CRLF)
 TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadLine_Empty_NUL_plus_END)
 {
   // one empty line, terminated by NUL; No more data in stream
-  assert(sizeof(memory) >= 1U);
+  assert(sizeof(memory_) >= 1U);
 
-  MemStreamReader uut(memory, 1U, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 1U, IStreamReader::Endian::Little);
 
   std::string s = uut.Read_line();
   ASSERT_TRUE(s.empty());
@@ -2110,10 +2110,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadLine_Empty_NUL_plus_END)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadLine_Empty_LF_plus_END)
 {
-  // one empty line, terminated by \n; No more data in stream
-  assert(sizeof(memory) >= 1U);
-  memory[0] = '\n';
-  MemStreamReader uut(memory, 1U, IStreamReader::Endian::Little);
+  // one empty line, terminated by \n_; No more data in stream
+  assert(sizeof(memory_) >= 1U);
+  memory_[0] = '\n';
+  MemStreamReader uut(memory_, 1U, IStreamReader::Endian::Little);
 
   std::string s = uut.Read_line();
   ASSERT_TRUE(s.empty());
@@ -2127,9 +2127,9 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadLine_Empty_LF_plus_END)
 TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadLine_Empty_CR_plus_END)
 {
   // one empty line, terminated by \r; No more data in stream
-  assert(sizeof(memory) >= 1U);
-  memory[0] = '\r';
-  MemStreamReader uut(memory, 1U, IStreamReader::Endian::Little);
+  assert(sizeof(memory_) >= 1U);
+  memory_[0] = '\r';
+  MemStreamReader uut(memory_, 1U, IStreamReader::Endian::Little);
 
   std::string s = uut.Read_line();
   ASSERT_TRUE(s.empty());
@@ -2142,11 +2142,11 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadLine_Empty_CR_plus_END)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadLine_Empty_CRLF_plus_END)
 {
-  // one empty line, terminated by \r\n; No more data in stream
-  assert(sizeof(memory) >= 2U);
-  memory[0] = '\r';
-  memory[1] = '\n';
-  MemStreamReader uut(memory, 2U, IStreamReader::Endian::Little);
+  // one empty line, terminated by \r\n_; No more data in stream
+  assert(sizeof(memory_) >= 2U);
+  memory_[0] = '\r';
+  memory_[1] = '\n';
+  MemStreamReader uut(memory_, 2U, IStreamReader::Endian::Little);
 
   std::string s = uut.Read_line();
   ASSERT_TRUE(s.empty());
@@ -2159,14 +2159,14 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadLine_Empty_CRLF_plus_END)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadLine_NoEnd1)
 {
-  assert(sizeof(memory) >= 5U);
-  memory[0] = 'H';
-  memory[1] = 'e';
-  memory[2] = 'l';
-  memory[3] = 'l';
-  memory[4] = 'o';
+  assert(sizeof(memory_) >= 5U);
+  memory_[0] = 'H';
+  memory_[1] = 'e';
+  memory_[2] = 'l';
+  memory_[3] = 'l';
+  memory_[4] = 'o';
 
-  MemStreamReader uut(memory, 5U, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 5U, IStreamReader::Endian::Little);
 
   std::string s = uut.Read_line();
   ASSERT_TRUE(s == "Hello");
@@ -2179,10 +2179,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadLine_NoEnd1)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadLine_NoEnd2)
 {
-  assert(sizeof(memory) >= 1U);
-  memory[0] = 'A';
+  assert(sizeof(memory_) >= 1U);
+  memory_[0] = 'A';
 
-  MemStreamReader uut(memory, 1U, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 1U, IStreamReader::Endian::Little);
 
   std::string s = uut.Read_line();
   ASSERT_TRUE(s == "A");
@@ -2195,10 +2195,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadLine_NoEnd2)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, Skip_ZeroBits)
 {
-  memory[0] = 0x57U;
-  memory[1] = 0xE9U;
+  memory_[0] = 0x57U;
+  memory_[1] = 0xE9U;
 
-  MemStreamReader uut(memory, 2, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 2, IStreamReader::Endian::Little);
 
   uint8_t u8;
 
@@ -2223,9 +2223,9 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, Skip_ZeroBits)
 TEST_F(GPCC_Stream_MemStreamReader_Tests, Skip_BitsLeft_SkipSomeBits)
 {
   // There are 4 bits left that have not been read yet. We skip 3 of them.
-  memory[0] = 0x8AU;
+  memory_[0] = 0x8AU;
 
-  MemStreamReader uut(memory, 1U, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 1U, IStreamReader::Endian::Little);
 
   ASSERT_EQ(uut.Read_bits(4U), 0x0AU);
   ASSERT_EQ(uut.RemainingBytes(), 0U);
@@ -2247,10 +2247,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, Skip_BitsLeft_SkipSomeBits)
 TEST_F(GPCC_Stream_MemStreamReader_Tests, Skip_BitsAndOneByteLeft_SkipAllBits)
 {
   // There are 4 bits + 1 Byte left that have not been read yet. We skip 4 bits.
-  memory[0] = 0x8AU;
-  memory[1] = 0xDBU;
+  memory_[0] = 0x8AU;
+  memory_[1] = 0xDBU;
 
-  MemStreamReader uut(memory, 2U, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 2U, IStreamReader::Endian::Little);
 
   ASSERT_EQ(uut.Read_bits(4U), 0x0AU);
   ASSERT_EQ(uut.RemainingBytes(), 1U);
@@ -2272,9 +2272,9 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, Skip_BitsAndOneByteLeft_SkipAllBits)
 TEST_F(GPCC_Stream_MemStreamReader_Tests, Skip_BitsLeft_SkipAll)
 {
   // There are 4 bits left that have not been read yet. We skip them all.
-  memory[0] = 0x8AU;
+  memory_[0] = 0x8AU;
 
-  MemStreamReader uut(memory, 1U, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 1U, IStreamReader::Endian::Little);
 
   ASSERT_EQ(uut.Read_bits(4U), 0x0AU);
   ASSERT_EQ(uut.RemainingBytes(), 0U);
@@ -2292,9 +2292,9 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, Skip_BitsLeft_SkipAll)
 TEST_F(GPCC_Stream_MemStreamReader_Tests, Skip_BitsLeft_SkipAllPlusOne)
 {
   // There are 4 bits left that have not been read yet. We skip them all + 1.
-  memory[0] = 0x8AU;
+  memory_[0] = 0x8AU;
 
-  MemStreamReader uut(memory, 1U, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 1U, IStreamReader::Endian::Little);
 
   ASSERT_EQ(uut.Read_bits(4U), 0x0AU);
   ASSERT_EQ(uut.RemainingBytes(), 0U);
@@ -2311,10 +2311,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, Skip_BitsLeft_SkipAllPlusOne)
 TEST_F(GPCC_Stream_MemStreamReader_Tests, Skip_BitsAndOneByteLeft_SkipAllBitsAndOneByte)
 {
   // There are 4 bits + 1 byte left that have not been read yet. We skip 12 bits.
-  memory[0] = 0x8AU;
-  memory[1] = 0xDBU;
+  memory_[0] = 0x8AU;
+  memory_[1] = 0xDBU;
 
-  MemStreamReader uut(memory, 2U, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 2U, IStreamReader::Endian::Little);
 
   ASSERT_EQ(uut.Read_bits(4U), 0x0AU);
   ASSERT_EQ(uut.RemainingBytes(), 1U);
@@ -2332,10 +2332,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, Skip_BitsAndOneByteLeft_SkipAllBitsAnd
 TEST_F(GPCC_Stream_MemStreamReader_Tests, Skip_BitsAndOneByteLeft_SkipAllBitsAndTwoByte)
 {
   // There are 4 bits + 1 byte left that have not been read yet. We skip 4+8+8=20 bits.
-  memory[0] = 0x8AU;
-  memory[1] = 0xDBU;
+  memory_[0] = 0x8AU;
+  memory_[1] = 0xDBU;
 
-  MemStreamReader uut(memory, 2U, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 2U, IStreamReader::Endian::Little);
 
   ASSERT_EQ(uut.Read_bits(4U), 0x0AU);
   ASSERT_EQ(uut.RemainingBytes(), 1U);
@@ -2352,10 +2352,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, Skip_BitsAndOneByteLeft_SkipAllBitsAnd
 TEST_F(GPCC_Stream_MemStreamReader_Tests, Skip_BitsAndOneByteLeft_SkipAllBitsAndOneByteAndOneBit)
 {
   // There are 4 bits + 1 byte left that have not been read yet. We skip 4+8+1 = 13 bits.
-  memory[0] = 0x8AU;
-  memory[1] = 0xDBU;
+  memory_[0] = 0x8AU;
+  memory_[1] = 0xDBU;
 
-  MemStreamReader uut(memory, 2U, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 2U, IStreamReader::Endian::Little);
 
   ASSERT_EQ(uut.Read_bits(4U), 0x0AU);
   ASSERT_EQ(uut.RemainingBytes(), 1U);
@@ -2372,11 +2372,11 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, Skip_BitsAndOneByteLeft_SkipAllBitsAnd
 TEST_F(GPCC_Stream_MemStreamReader_Tests, Skip_BitsAndTwoByteLeft_SkipAllBitsAndOneByte)
 {
   // There are 4 bits + 2 byte left that have not been read yet. We skip 4+8=12 bits.
-  memory[0] = 0x8AU;
-  memory[1] = 0xDBU;
-  memory[2] = 0x36U;
+  memory_[0] = 0x8AU;
+  memory_[1] = 0xDBU;
+  memory_[2] = 0x36U;
 
-  MemStreamReader uut(memory, 3U, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 3U, IStreamReader::Endian::Little);
 
   ASSERT_EQ(uut.Read_bits(4U), 0x0AU);
   ASSERT_EQ(uut.RemainingBytes(), 2U);
@@ -2398,11 +2398,11 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, Skip_BitsAndTwoByteLeft_SkipAllBitsAnd
 TEST_F(GPCC_Stream_MemStreamReader_Tests, Skip_BitsAndTwoByteLeft_SkipAllBitsAndOneByteAndOneBit)
 {
   // There are 4 bits + 2 byte left that have not been read yet. We skip 4+8+1=13 bits.
-  memory[0] = 0x8AU;
-  memory[1] = 0xDBU;
-  memory[2] = 0x36U;
+  memory_[0] = 0x8AU;
+  memory_[1] = 0xDBU;
+  memory_[2] = 0x36U;
 
-  MemStreamReader uut(memory, 3U, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 3U, IStreamReader::Endian::Little);
 
   ASSERT_EQ(uut.Read_bits(4U), 0x0AU);
   ASSERT_EQ(uut.RemainingBytes(), 2U);
@@ -2424,10 +2424,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, Skip_BitsAndTwoByteLeft_SkipAllBitsAnd
 TEST_F(GPCC_Stream_MemStreamReader_Tests, Skip_OneByteLeft_Skip8Bits)
 {
   // There is 1 byte left that has not been read yet. We skip 8 bits.
-  memory[0] = 0x8AU;
-  memory[1] = 0xDBU;
+  memory_[0] = 0x8AU;
+  memory_[1] = 0xDBU;
 
-  MemStreamReader uut(memory, 2U, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 2U, IStreamReader::Endian::Little);
 
   ASSERT_EQ(uut.Read_bits(8U), 0x8AU);
   ASSERT_EQ(uut.RemainingBytes(), 1U);
@@ -2445,10 +2445,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, Skip_OneByteLeft_Skip8Bits)
 TEST_F(GPCC_Stream_MemStreamReader_Tests, Skip_OneByteLeft_Skip7Bits)
 {
   // There is 1 byte left that has not been read yet. We skip 7 bits.
-  memory[0] = 0x8AU;
-  memory[1] = 0x80U;
+  memory_[0] = 0x8AU;
+  memory_[1] = 0x80U;
 
-  MemStreamReader uut(memory, 2U, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 2U, IStreamReader::Endian::Little);
 
   ASSERT_EQ(uut.Read_bits(8U), 0x8AU);
   ASSERT_EQ(uut.RemainingBytes(), 1U);
@@ -2470,10 +2470,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, Skip_OneByteLeft_Skip7Bits)
 TEST_F(GPCC_Stream_MemStreamReader_Tests, Skip_OneByteLeft_Skip9Bits)
 {
   // There is 1 byte left that has not been read yet. We skip 9 bits.
-  memory[0] = 0x8AU;
-  memory[1] = 0x80U;
+  memory_[0] = 0x8AU;
+  memory_[1] = 0x80U;
 
-  MemStreamReader uut(memory, 2U, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 2U, IStreamReader::Endian::Little);
 
   ASSERT_EQ(uut.Read_bits(8U), 0x8AU);
   ASSERT_EQ(uut.RemainingBytes(), 1U);
@@ -2490,10 +2490,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, Skip_OneByteLeft_Skip9Bits)
 TEST_F(GPCC_Stream_MemStreamReader_Tests, Skip_TwoByteLeft_Skip8Bits)
 {
   // There are 2 bytes left that have not been read yet. We skip 8 bits.
-  memory[0] = 0x8AU;
-  memory[1] = 0x80U;
+  memory_[0] = 0x8AU;
+  memory_[1] = 0x80U;
 
-  MemStreamReader uut(memory, 2U, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 2U, IStreamReader::Endian::Little);
 
   // - precondition established -
 
@@ -2511,10 +2511,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, Skip_TwoByteLeft_Skip8Bits)
 TEST_F(GPCC_Stream_MemStreamReader_Tests, Skip_TwoByteLeft_Skip16Bits)
 {
   // There are 2 bytes left that have not been read yet. We skip 16 bits.
-  memory[0] = 0x8AU;
-  memory[1] = 0x80U;
+  memory_[0] = 0x8AU;
+  memory_[1] = 0x80U;
 
-  MemStreamReader uut(memory, 2U, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 2U, IStreamReader::Endian::Little);
 
   // - precondition established -
 
@@ -2528,10 +2528,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, Skip_TwoByteLeft_Skip16Bits)
 TEST_F(GPCC_Stream_MemStreamReader_Tests, Skip_TwoByteLeft_Skip9Bits)
 {
   // There are 2 bytes left that have not been read yet. We skip 9 bits.
-  memory[0] = 0x8AU;
-  memory[1] = 0x80U;
+  memory_[0] = 0x8AU;
+  memory_[1] = 0x80U;
 
-  MemStreamReader uut(memory, 2U, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 2U, IStreamReader::Endian::Little);
 
   // - precondition established -
 
@@ -2548,10 +2548,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, Skip_TwoByteLeft_Skip9Bits)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, Skip_EmptyStream)
 {
-  memory[0] = 0xFA;
-  memory[1] = 0x12;
+  memory_[0] = 0xFA;
+  memory_[1] = 0x12;
 
-  MemStreamReader uut(memory, 2, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 2, IStreamReader::Endian::Little);
 
   uint8_t u8;
 
@@ -2575,10 +2575,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, Skip_EmptyStream)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, Skip_ClosedStream)
 {
-  memory[0] = 0xFA;
-  memory[1] = 0x12;
+  memory_[0] = 0xFA;
+  memory_[1] = 0x12;
 
-  MemStreamReader uut(memory, 2, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 2, IStreamReader::Endian::Little);
   uut.Close();
 
   ASSERT_THROW(uut.Skip(1U), ClosedError);
@@ -2586,10 +2586,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, Skip_ClosedStream)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, Skip_StreamInErrorState)
 {
-  memory[0] = 0xFA;
-  memory[1] = 0x12;
+  memory_[0] = 0xFA;
+  memory_[1] = 0x12;
 
-  MemStreamReader uut(memory, 2, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 2, IStreamReader::Endian::Little);
 
   uint8_t au8[3];
 
@@ -2607,16 +2607,16 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, Skip_StreamInErrorState)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, SubStream_FrontMidBack)
 {
-  memory[0] = 0xFA;
-  memory[1] = 0x12;
-  memory[2] = 0x34;
-  memory[3] = 0x56;
-  memory[4] = 0x78;
-  memory[5] = 0x9A;
-  memory[6] = 0xBC;
-  memory[7] = 0xDE;
+  memory_[0] = 0xFA;
+  memory_[1] = 0x12;
+  memory_[2] = 0x34;
+  memory_[3] = 0x56;
+  memory_[4] = 0x78;
+  memory_[5] = 0x9A;
+  memory_[6] = 0xBC;
+  memory_[7] = 0xDE;
 
-  MemStreamReader uut(memory, 8, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 8, IStreamReader::Endian::Little);
 
   // create a sub-stream at front
   auto uut2 = uut.SubStream(2);
@@ -2661,12 +2661,12 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, SubStream_FrontMidBack)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, SubStream_DropBits)
 {
-  memory[0] = 0xFA;
-  memory[1] = 0x12;
-  memory[2] = 0x34;
-  memory[3] = 0x56;
+  memory_[0] = 0xFA;
+  memory_[1] = 0x12;
+  memory_[2] = 0x34;
+  memory_[3] = 0x56;
 
-  MemStreamReader uut(memory, 4, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 4, IStreamReader::Endian::Little);
 
   EXPECT_EQ(uut.Read_bits(4), 0x0AU);
 
@@ -2691,12 +2691,12 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, SubStream_DropBits)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, SubStream_ZeroSize)
 {
-  memory[0] = 0xFA;
-  memory[1] = 0x12;
-  memory[2] = 0x34;
-  memory[3] = 0x56;
+  memory_[0] = 0xFA;
+  memory_[1] = 0x12;
+  memory_[2] = 0x34;
+  memory_[3] = 0x56;
 
-  MemStreamReader uut(memory, 4, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 4, IStreamReader::Endian::Little);
 
   EXPECT_EQ(uut.Read_bits(4), 0x0AU);
 
@@ -2727,12 +2727,12 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, SubStream_ZeroSize)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, SubStream_TooLarge)
 {
-  memory[0] = 0xFA;
-  memory[1] = 0x12;
-  memory[2] = 0x34;
-  memory[3] = 0x56;
+  memory_[0] = 0xFA;
+  memory_[1] = 0x12;
+  memory_[2] = 0x34;
+  memory_[3] = 0x56;
 
-  MemStreamReader uut(memory, 4, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 4, IStreamReader::Endian::Little);
 
   EXPECT_THROW(MemStreamReader uut2 = uut.SubStream(5); (void)uut2;, EmptyError);
 
@@ -2760,10 +2760,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, SubStream_TooLarge)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, SubStream_Empty)
 {
-  memory[0] = 0xFA;
-  memory[1] = 0x12;
+  memory_[0] = 0xFA;
+  memory_[1] = 0x12;
 
-  MemStreamReader uut(memory, 2, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 2, IStreamReader::Endian::Little);
 
   uut.Skip(16);
   ASSERT_TRUE(uut.GetState() == IStreamReader::States::empty);
@@ -2786,10 +2786,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, SubStream_Empty)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, SubStream_Closed)
 {
-  memory[0] = 0xFA;
-  memory[1] = 0x12;
+  memory_[0] = 0xFA;
+  memory_[1] = 0x12;
 
-  MemStreamReader uut(memory, 2, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 2, IStreamReader::Endian::Little);
   uut.Close();
 
   // -- precondition established --
@@ -2803,10 +2803,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, SubStream_Closed)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, SubStream_ErrorState)
 {
-  memory[0] = 0xFA;
-  memory[1] = 0x12;
+  memory_[0] = 0xFA;
+  memory_[1] = 0x12;
 
-  MemStreamReader uut(memory, 2, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 2, IStreamReader::Endian::Little);
   EXPECT_THROW(uut.Skip(24), EmptyError);
   ASSERT_TRUE(uut.GetState() == IStreamReader::States::error);
 
@@ -2821,10 +2821,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, SubStream_ErrorState)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, Shrink_AttemptToEnlarge)
 {
-  memory[0] = 0xFAU;
-  memory[1] = 0x12U;
+  memory_[0] = 0xFAU;
+  memory_[1] = 0x12U;
 
-  MemStreamReader uut(memory, 2, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 2, IStreamReader::Endian::Little);
   ASSERT_EQ(uut.RemainingBytes(), 2U);
 
   // attempt to enlarge in state "open"
@@ -2838,10 +2838,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, Shrink_AttemptToEnlarge)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, Shrink_NoEffect)
 {
-  memory[0] = 0xFAU;
-  memory[1] = 0x12U;
+  memory_[0] = 0xFAU;
+  memory_[1] = 0x12U;
 
-  MemStreamReader uut(memory, 2, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 2, IStreamReader::Endian::Little);
   ASSERT_EQ(uut.RemainingBytes(), 2U);
 
   // There are 2 bytes left. This shrink should have no effect.
@@ -2887,10 +2887,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, Shrink_NoEffect)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, Shrink_OneByte_NoBitsLeftToBeRead)
 {
-  memory[0] = 0xFAU;
-  memory[1] = 0x12U;
+  memory_[0] = 0xFAU;
+  memory_[1] = 0x12U;
 
-  MemStreamReader uut(memory, 2, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 2, IStreamReader::Endian::Little);
   ASSERT_EQ(uut.RemainingBytes(), 2U);
 
   // There are 2 bytes left to be read. Let's shrink to 1 byte.
@@ -2906,11 +2906,11 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, Shrink_OneByte_NoBitsLeftToBeRead)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, Shrink_OneByte_BitsLeftToBeRead)
 {
-  memory[0] = 0xFAU;
-  memory[1] = 0x12U;
-  memory[2] = 0xD7U;
+  memory_[0] = 0xFAU;
+  memory_[1] = 0x12U;
+  memory_[2] = 0xD7U;
 
-  MemStreamReader uut(memory, 3, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 3, IStreamReader::Endian::Little);
   ASSERT_EQ(uut.RemainingBytes(), 3U);
 
   uint8_t data;
@@ -2933,11 +2933,11 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, Shrink_OneByte_BitsLeftToBeRead)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, Shrink_AllBytes_WithBitsLeft)
 {
-  memory[0] = 0xFAU;
-  memory[1] = 0x12U;
-  memory[2] = 0xD7U;
+  memory_[0] = 0xFAU;
+  memory_[1] = 0x12U;
+  memory_[2] = 0xD7U;
 
-  MemStreamReader uut(memory, 3, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 3, IStreamReader::Endian::Little);
   ASSERT_EQ(uut.RemainingBytes(), 3U);
 
   uint8_t data;
@@ -2957,11 +2957,11 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, Shrink_AllBytes_WithBitsLeft)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, Shrink_AllBytes_WithoutBitsLeft)
 {
-  memory[0] = 0xFAU;
-  memory[1] = 0x12U;
-  memory[2] = 0xD7U;
+  memory_[0] = 0xFAU;
+  memory_[1] = 0x12U;
+  memory_[2] = 0xD7U;
 
-  MemStreamReader uut(memory, 3, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 3, IStreamReader::Endian::Little);
   ASSERT_EQ(uut.RemainingBytes(), 3U);
 
   // There are 3 bytes left. Let's shrink to zero bytes.
@@ -2971,20 +2971,20 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, Shrink_AllBytes_WithoutBitsLeft)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, Shrink_StreamClosed)
 {
-  memory[0] = 0xFAU;
-  memory[1] = 0x12U;
+  memory_[0] = 0xFAU;
+  memory_[1] = 0x12U;
 
-  MemStreamReader uut(memory, 2, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 2, IStreamReader::Endian::Little);
   uut.Close();
 
   EXPECT_THROW(uut.Shrink(0), ClosedError);
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, Shrink_StreamInErrorState)
 {
-  memory[0] = 0xFAU;
-  memory[1] = 0x12U;
+  memory_[0] = 0xFAU;
+  memory_[1] = 0x12U;
 
-  MemStreamReader uut(memory, 2, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 2, IStreamReader::Endian::Little);
 
   ASSERT_THROW(uut.Skip(24), EmptyError);
   ASSERT_TRUE(uut.GetState() == IStreamReader::States::error);
@@ -2993,141 +2993,141 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, Shrink_StreamInErrorState)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, GetReadPtr_OK)
 {
-  memory[0] = 0x12U;
-  memory[1] = 0x34U;
-  memory[2] = 0x56U;
-  memory[3] = 0x78U;
+  memory_[0] = 0x12U;
+  memory_[1] = 0x34U;
+  memory_[2] = 0x56U;
+  memory_[3] = 0x78U;
 
-  MemStreamReader uut(memory, 4, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 4, IStreamReader::Endian::Little);
 
-  EXPECT_EQ(uut.GetReadPtr(memory, 4U), &memory[0]);
+  EXPECT_EQ(uut.GetReadPtr(memory_, 4U), &memory_[0]);
 
-  // skip memory[0]
+  // skip memory_[0]
   uut.Skip(8U);
-  EXPECT_EQ(uut.GetReadPtr(memory, 4U), &memory[1]);
+  EXPECT_EQ(uut.GetReadPtr(memory_, 4U), &memory_[1]);
 
-  // skip 1st bit of memory[1]
+  // skip 1st bit of memory_[1]
   uut.Skip(1U);
-  EXPECT_EQ(uut.GetReadPtr(memory, 4U), &memory[2]);
+  EXPECT_EQ(uut.GetReadPtr(memory_, 4U), &memory_[2]);
 
-  // skip remaining bits of memory[1]
+  // skip remaining bits of memory_[1]
   uut.Skip(7U);
-  EXPECT_EQ(uut.GetReadPtr(memory, 4U), &memory[2]);
+  EXPECT_EQ(uut.GetReadPtr(memory_, 4U), &memory_[2]);
 
-  // skip memory[2]
+  // skip memory_[2]
   uut.Skip(8U);
-  EXPECT_EQ(uut.GetReadPtr(memory, 4U), &memory[3]);
+  EXPECT_EQ(uut.GetReadPtr(memory_, 4U), &memory_[3]);
 
-  // skip memory[3]
+  // skip memory_[3]
   uut.Skip(8U);
 
   EXPECT_TRUE(uut.GetState() == IStreamReader::States::empty);
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, GetReadPtr_OK_LastByteBitByBit)
 {
-  memory[0] = 0x12U;
-  memory[1] = 0x34U;
-  memory[2] = 0x56U;
-  memory[3] = 0x78U;
+  memory_[0] = 0x12U;
+  memory_[1] = 0x34U;
+  memory_[2] = 0x56U;
+  memory_[3] = 0x78U;
 
-  MemStreamReader uut(memory, 4, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 4, IStreamReader::Endian::Little);
 
-  EXPECT_EQ(uut.GetReadPtr(memory, 4U), &memory[0]);
+  EXPECT_EQ(uut.GetReadPtr(memory_, 4U), &memory_[0]);
 
-  // skip memory[0..2]
+  // skip memory_[0..2]
   uut.Skip(3U * 8U);
-  EXPECT_EQ(uut.GetReadPtr(memory, 4U), &memory[3]);
+  EXPECT_EQ(uut.GetReadPtr(memory_, 4U), &memory_[3]);
 
-  // skip 1st bit of memory[3]
+  // skip 1st bit of memory_[3]
   uut.Skip(1U);
-  EXPECT_THROW((void)uut.GetReadPtr(memory, 4U), std::logic_error);
+  EXPECT_THROW((void)uut.GetReadPtr(memory_, 4U), std::logic_error);
 
   EXPECT_TRUE(uut.GetState() == IStreamReader::States::open);
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, GetReadPtr_ZeroLength)
 {
-  memory[0] = 0xFAU;
-  memory[1] = 0x12U;
+  memory_[0] = 0xFAU;
+  memory_[1] = 0x12U;
 
-  MemStreamReader uut(memory, 0U, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 0U, IStreamReader::Endian::Little);
   ASSERT_TRUE(uut.GetState() == IStreamReader::States::empty);
 
-  EXPECT_THROW((void)uut.GetReadPtr(memory, 0U), std::logic_error);
+  EXPECT_THROW((void)uut.GetReadPtr(memory_, 0U), std::logic_error);
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, GetReadPtr_CopyOfMSR_OK)
 {
-  memory[0] = 0x12U;
-  memory[1] = 0x34U;
-  memory[2] = 0x56U;
-  memory[3] = 0x78U;
+  memory_[0] = 0x12U;
+  memory_[1] = 0x34U;
+  memory_[2] = 0x56U;
+  memory_[3] = 0x78U;
 
-  MemStreamReader uut(memory, 4, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 4, IStreamReader::Endian::Little);
 
-  // skip memory[0]
+  // skip memory_[0]
   uut.Skip(8U);
 
   MemStreamReader uut2(uut);
 
-  EXPECT_EQ(uut2.GetReadPtr(memory, 4U), &memory[1]);
+  EXPECT_EQ(uut2.GetReadPtr(memory_, 4U), &memory_[1]);
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, GetReadPtr_StateEmpty)
 {
-  memory[0] = 0xFAU;
-  memory[1] = 0x12U;
+  memory_[0] = 0xFAU;
+  memory_[1] = 0x12U;
 
-  MemStreamReader uut(memory, 2, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 2, IStreamReader::Endian::Little);
   uut.Skip(16U);
   ASSERT_TRUE(uut.GetState() == IStreamReader::States::empty);
 
-  EXPECT_THROW((void)uut.GetReadPtr(memory, 2U), std::logic_error);
+  EXPECT_THROW((void)uut.GetReadPtr(memory_, 2U), std::logic_error);
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, GetReadPtr_StateClose)
 {
-  memory[0] = 0xFAU;
-  memory[1] = 0x12U;
+  memory_[0] = 0xFAU;
+  memory_[1] = 0x12U;
 
-  MemStreamReader uut(memory, 2, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 2, IStreamReader::Endian::Little);
   uut.Skip(16U);
   uut.Close();
   ASSERT_TRUE(uut.GetState() == IStreamReader::States::closed);
 
-  EXPECT_THROW((void)uut.GetReadPtr(memory, 2U), std::logic_error);
+  EXPECT_THROW((void)uut.GetReadPtr(memory_, 2U), std::logic_error);
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, GetReadPtr_StateError)
 {
-  memory[0] = 0xFAU;
-  memory[1] = 0x12U;
+  memory_[0] = 0xFAU;
+  memory_[1] = 0x12U;
 
-  MemStreamReader uut(memory, 2, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 2, IStreamReader::Endian::Little);
   ASSERT_THROW(uut.Skip(24U), std::exception);
   ASSERT_TRUE(uut.GetState() == IStreamReader::States::error);
 
-  EXPECT_THROW((void)uut.GetReadPtr(memory, 2U), std::logic_error);
+  EXPECT_THROW((void)uut.GetReadPtr(memory_, 2U), std::logic_error);
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, GetReadPtr_ParamsNotPlausible)
 {
-  memory[0] = 0x12U;
-  memory[1] = 0x34U;
-  memory[2] = 0x56U;
-  memory[3] = 0x78U;
+  memory_[0] = 0x12U;
+  memory_[1] = 0x34U;
+  memory_[2] = 0x56U;
+  memory_[3] = 0x78U;
 
-  MemStreamReader uut(memory, 4, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 4, IStreamReader::Endian::Little);
 
-  EXPECT_THROW((void)uut.GetReadPtr((&memory[0]) - 1U, 4U), std::logic_error);
-  EXPECT_THROW((void)uut.GetReadPtr((&memory[0]) + 1U, 4U), std::logic_error);
-  EXPECT_THROW((void)uut.GetReadPtr((&memory[0]) + 0U, 3U), std::logic_error);
-  EXPECT_THROW((void)uut.GetReadPtr((&memory[0]) + 0U, 5U), std::logic_error);
+  EXPECT_THROW((void)uut.GetReadPtr((&memory_[0]) - 1U, 4U), std::logic_error);
+  EXPECT_THROW((void)uut.GetReadPtr((&memory_[0]) + 1U, 4U), std::logic_error);
+  EXPECT_THROW((void)uut.GetReadPtr((&memory_[0]) + 0U, 3U), std::logic_error);
+  EXPECT_THROW((void)uut.GetReadPtr((&memory_[0]) + 0U, 5U), std::logic_error);
 
   EXPECT_TRUE(uut.GetState() == IStreamReader::States::open);
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, GetReadPtr_OtherMSRnotAccepted)
 {
-  memory[0] = 0x12U;
-  memory[1] = 0x34U;
-  memory[2] = 0x56U;
-  memory[3] = 0x78U;
+  memory_[0] = 0x12U;
+  memory_[1] = 0x34U;
+  memory_[2] = 0x56U;
+  memory_[3] = 0x78U;
 
-  MemStreamReader uut(memory, 4, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 4, IStreamReader::Endian::Little);
 
   uint8_t memory2[4];
   memory2[0] = 0xDEU;
@@ -3139,11 +3139,11 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, GetReadPtr_OtherMSRnotAccepted)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, EnsureAllDataConsumed_OK_1)
 {
-  memory[0] = 0x00;
-  memory[1] = 0x00;
-  memory[2] = 0x00;
+  memory_[0] = 0x00;
+  memory_[1] = 0x00;
+  memory_[2] = 0x00;
 
-  MemStreamReader uut(memory, 3, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 3, IStreamReader::Endian::Little);
 
   // (3 bytes left) -------------------------------------------------------------------------------------------
   EXPECT_THROW(uut.EnsureAllDataConsumed(IStreamReader::RemainingNbOfBits::zero), RemainingBitsError);
@@ -3289,10 +3289,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, EnsureAllDataConsumed_OK_1)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, EnsureAllDataConsumed_OK_2)
 {
-  memory[0] = 0x00;
-  memory[1] = 0x00;
+  memory_[0] = 0x00;
+  memory_[1] = 0x00;
 
-  MemStreamReader uut(memory, 2, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 2, IStreamReader::Endian::Little);
 
   // (2 bytes left) -------------------------------------------------------------------------------------------
   EXPECT_THROW(uut.EnsureAllDataConsumed(IStreamReader::RemainingNbOfBits::zero), RemainingBitsError);
@@ -3441,10 +3441,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, EnsureAllDataConsumed_OK_2)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, EnsureAllDataConsumed_ErrorState)
 {
-  memory[0] = 0x00;
-  memory[1] = 0x00;
+  memory_[0] = 0x00;
+  memory_[1] = 0x00;
 
-  MemStreamReader uut(memory, 2, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 2, IStreamReader::Endian::Little);
 
   // create error condition
   ASSERT_THROW((void)uut.Read_uint32(), EmptyError);
@@ -3463,10 +3463,10 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, EnsureAllDataConsumed_ErrorState)
 }
 TEST_F(GPCC_Stream_MemStreamReader_Tests, EnsureAllDataConsumed_ClosedState)
 {
-  memory[0] = 0x00;
-  memory[1] = 0x00;
+  memory_[0] = 0x00;
+  memory_[1] = 0x00;
 
-  MemStreamReader uut(memory, 2, IStreamReader::Endian::Little);
+  MemStreamReader uut(memory_, 2, IStreamReader::Endian::Little);
 
   // create pre-condition
   uut.Close();

--- a/testcases/stream/TestMemStreamReader.cpp
+++ b/testcases/stream/TestMemStreamReader.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011 Daniel Jerolm
+    Copyright (C) 2011, 2025 Daniel Jerolm
 */
 
 #include <gpcc/stream/MemStreamReader.hpp>
@@ -1021,7 +1021,7 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadLittleStreamOp)
 
   float f;
   uut >> f;
-  ASSERT_TRUE((f > f1 - 0.1) && (f < f1 + 0.1));
+  ASSERT_TRUE((f > f1 - 0.1f) && (f < f1 + 0.1f));
 
   double d;
   uut >> d;
@@ -1101,7 +1101,7 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadLittleFuncCalls)
   ASSERT_EQ(0, u8);
 
   float f = uut.Read_float();
-  ASSERT_TRUE((f > f1 - 0.1) && (f < f1 + 0.1));
+  ASSERT_TRUE((f > f1 - 0.1f) && (f < f1 + 0.1f));
 
   double d = uut.Read_double();
   ASSERT_TRUE((d > d1 - 0.1) && (d < d1 + 0.1));
@@ -1197,7 +1197,7 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadBigStreamOp)
 
   float f;
   uut >> f;
-  ASSERT_TRUE((f > f1 - 0.1) && (f < f1 + 0.1));
+  ASSERT_TRUE((f > f1 - 0.1f) && (f < f1 + 0.1f));
 
   double d;
   uut >> d;
@@ -1280,7 +1280,7 @@ TEST_F(GPCC_Stream_MemStreamReader_Tests, ReadBigFuncCalls)
   ASSERT_EQ(static_cast<uint8_t>(0x00), u8);
 
   float f = uut.Read_float();
-  ASSERT_TRUE((f > f1 - 0.1) && (f < f1 + 0.1));
+  ASSERT_TRUE((f > f1 - 0.1f) && (f < f1 + 0.1f));
 
   double d = uut.Read_double();
   ASSERT_TRUE((d > d1 - 0.1) && (d < d1 + 0.1));

--- a/testcases/stream/TestMemStreamWriter.cpp
+++ b/testcases/stream/TestMemStreamWriter.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011 Daniel Jerolm
+    Copyright (C) 2011, 2025 Daniel Jerolm
 */
 
 #include <gpcc/stream/MemStreamWriter.hpp>
@@ -855,10 +855,10 @@ TEST_F(GPCC_Stream_MemStreamWriter_Tests, WriteLittleFuncCalls)
 
   uut.Write_uint8(0x00); // write offset afterwards: 16
 
-  uut.Write_int8(0x85);
-  uut.Write_int16(0x891A);
-  uut.Write_int32(0x9AFF5673);
-  uut.Write_int64(0xA2BCDEF77625392C);
+  uut.Write_int8(static_cast<int8_t>(0x85L));
+  uut.Write_int16(static_cast<int16_t>(0x891AL));
+  uut.Write_int32(static_cast<int32_t>(0x9AFF5673L));
+  uut.Write_int64(static_cast<int64_t>(0xA2BCDEF77625392CLL));
 
   uut.Write_uint8(0x00); // write offset afterwards: 32
 
@@ -1003,10 +1003,10 @@ TEST_F(GPCC_Stream_MemStreamWriter_Tests, WriteBigFuncCalls)
 
   uut.Write_uint8(0x00); // write offset afterwards: 16
 
-  uut.Write_int8(0x85);
-  uut.Write_int16(0x891A);
-  uut.Write_int32(0x9AFF5673);
-  uut.Write_int64(0xA2BCDEF77625392C);
+  uut.Write_int8(static_cast<int8_t>(0x85L));
+  uut.Write_int16(static_cast<int16_t>(0x891AL));
+  uut.Write_int32(static_cast<int32_t>(0x9AFF5673L));
+  uut.Write_int64(static_cast<int64_t>(0xA2BCDEF77625392CLL));
 
   uut.Write_uint8(0x00); // write offset afterwards: 32
 


### PR DESCRIPTION
The warning configuration options of GCC have been reviewed and those that seem reasonable have been applied to GPCC.

Review should focus on cmake files.

All changes to code just fix warnings that have popped up after appliance of new settings. There are no functional changed. All tests are OK.