### PR TITLE
fix: remove compiler warnings

### DIFF
--- a/history.txt
+++ b/history.txt
@@ -202,6 +202,9 @@ Next to do:
 
 History:
 ===============================================================================
+2025-04-23
+- Remove compiler warnings detected by gcc-arm-none-eabi.posix-epos
+
 2025-03-28
 - Revised compiler configuration regarding warnings.
   - Release unittest build with 0 errors, 0 warnings.

--- a/src/cood/remote_access/infrastructure/Multiplexer.cpp
+++ b/src/cood/remote_access/infrastructure/Multiplexer.cpp
@@ -55,7 +55,7 @@ Multiplexer::Multiplexer(void)
 , ports_()
 {
   auto const uipThis = reinterpret_cast<uintptr_t>(this);
-  #if UINTPTR_WIDTH == UINT32_WIDTH
+  #if UINTPTR_MAX == UINT32_MAX
     ownerID_ = static_cast<uint32_t>(uipThis);
   #else
     ownerID_ = (static_cast<uint32_t>(uipThis)) ^ (static_cast<uint32_t>(uipThis >> 32U));

--- a/src/string/StringComposer.cpp
+++ b/src/string/StringComposer.cpp
@@ -959,10 +959,17 @@ void StringComposer::PrintiToBuffer(char* const buffer, size_t const bufferSize,
   int const width = CalcWidthForsnprintf(type);
   char fmt[maxFmtStrBufSize];
   int status;
+
+  // fmt is generated. Don't complain.
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wformat-nonliteral"
+
   if (!SetupFormatString(fmt, type))
     status = sniprintf(buffer, bufferSize, fmt, width, value);
   else
     status = sniprintf(buffer, bufferSize, fmt, width, prec_, value);
+
+  #pragma GCC diagnostic pop
 
   if (status < 0)
     throw std::logic_error("sniprintf failed");


### PR DESCRIPTION
gcc 14.2 for EPOS emitted some warnings gcc 13.3 for Ubuntu did not emit.