### PR TITLE
fix: Remove compiler warnings

### DIFF
--- a/history.txt
+++ b/history.txt
@@ -4,6 +4,8 @@ GPCC Implementation History and Current Activities
 
 Next to do:
 ===============================================================================
+- Fix UBSan findings
+
 - StringComposer::SetupFormatString contains a TODO
 
 - Use github's issue tracking instead of this file

--- a/history.txt
+++ b/history.txt
@@ -4,8 +4,6 @@ GPCC Implementation History and Current Activities
 
 Next to do:
 ===============================================================================
-- Fix UBSan findings
-
 - StringComposer::SetupFormatString contains a TODO
 
 - Use github's issue tracking instead of this file
@@ -204,6 +202,9 @@ Next to do:
 
 History:
 ===============================================================================
+2025-05-29
+- Fix UBSan findings
+
 2025-04-23
 - Remove compiler warnings detected by gcc-arm-none-eabi.posix-epos
 

--- a/include/gpcc/container/IntrusiveDList.tcc
+++ b/include/gpcc/container/IntrusiveDList.tcc
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2019 Daniel Jerolm
+    Copyright (C) 2019, 2025 Daniel Jerolm
 */
 
 #include "IntrusiveDList.hpp"
@@ -33,7 +33,7 @@ template <class T>
 IntrusiveDList<T>::iterator::iterator(void) noexcept
 : pItem(nullptr)
 {
-};
+}
 
 /**
  * \brief Compares two iterators for equality.
@@ -257,7 +257,7 @@ template <class T>
 IntrusiveDList<T>::iterator::iterator(T* const _pItem) noexcept
 : pItem(_pItem)
 {
-};
+}
 
 // ==> class IntrusiveDList::iterator
 
@@ -279,7 +279,7 @@ template <class T>
 IntrusiveDList<T>::const_iterator::const_iterator(void) noexcept
 : pItem(nullptr)
 {
-};
+}
 
 /**
  * \brief Copy-constructor. Creates a const_iterator via copy-construction from an iterator.
@@ -301,7 +301,7 @@ template <class T>
 IntrusiveDList<T>::const_iterator::const_iterator(iterator const & other) noexcept
 : pItem(other.pItem)
 {
-};
+}
 
 /**
  * \brief Move-constructor. Creates a const_iterator via move-construction from an iterator.
@@ -324,7 +324,7 @@ template <class T>
 IntrusiveDList<T>::const_iterator::const_iterator(iterator && other) noexcept
 : pItem(other.pItem)
 {
-};
+}
 
 /**
  * \brief Copy-assignment operator. Copy-assigns an iterator to this.
@@ -607,7 +607,7 @@ template <class T>
 IntrusiveDList<T>::const_iterator::const_iterator(T* const _pItem) noexcept
 : pItem(_pItem)
 {
-};
+}
 
 // ==> class IntrusiveDList::const_iterator
 

--- a/src/cli/exceptions.cpp
+++ b/src/cli/exceptions.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2021 Daniel Jerolm
+    Copyright (C) 2021, 2025 Daniel Jerolm
 */
 
 #include <gpcc/cli/exceptions.hpp>
@@ -33,7 +33,7 @@ UserEnteredInvalidArgsError::UserEnteredInvalidArgsError(void)
 : std::runtime_error("User entered invalid arguments.")
 , details("")
 {
-};
+}
 
 /**
  * \brief Constructor. Creates a @ref UserEnteredInvalidArgsError exception with details provided.\n
@@ -65,7 +65,7 @@ UserEnteredInvalidArgsError::UserEnteredInvalidArgsError(std::string const & _de
 : std::runtime_error("User entered invalid arguments.")
 , details(_details)
 {
-};
+}
 
 /**
  * \brief Constructor. Creates a @ref UserEnteredInvalidArgsError exception with details provided.\n
@@ -97,7 +97,7 @@ UserEnteredInvalidArgsError::UserEnteredInvalidArgsError(std::string && _details
 : std::runtime_error("User entered invalid arguments.")
 , details(std::move(_details))
 {
-};
+}
 
 } // namespace cli
 } // namespace gpcc

--- a/src/container/BitField.cpp
+++ b/src/container/BitField.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011, 2024 Daniel Jerolm
+    Copyright (C) 2011, 2024, 2025 Daniel Jerolm
 */
 
 #include <gpcc/container/BitField.hpp>
@@ -572,7 +572,9 @@ void BitField::Resize(size_t const newSize)
       if (newElements > currElements)
       {
         // (enlarge)
-        memcpy(spNewStorage.get(), spStorage.get(), currElements * sizeof(storage_t));
+        if (currElements != 0U)
+          memcpy(spNewStorage.get(), spStorage.get(), currElements * sizeof(storage_t));
+
         memset(spNewStorage.get() + currElements, 0x00, (newElements - currElements) * sizeof(storage_t));
       }
       else
@@ -619,7 +621,9 @@ void BitField::Resize(size_t const newSize)
 void BitField::ClearAll(void) noexcept
 {
   size_t const nElements = nbOf_storage_t_elements(nBits);
-  memset(spStorage.get(), 0x00, nElements * sizeof(storage_t));
+
+  if (nElements != 0U)
+    memset(spStorage.get(), 0x00, nElements * sizeof(storage_t));
 }
 
 /**
@@ -639,7 +643,9 @@ void BitField::ClearAll(void) noexcept
 void BitField::SetAll(void) noexcept
 {
   size_t const nElements = nbOf_storage_t_elements(nBits);
-  memset(spStorage.get(), 0xFF, nElements * sizeof(storage_t));
+
+  if (nElements != 0U)
+    memset(spStorage.get(), 0xFF, nElements * sizeof(storage_t));
 }
 
 /**

--- a/src/cood/ObjectRECORD.cpp
+++ b/src/cood/ObjectRECORD.cpp
@@ -55,7 +55,7 @@ namespace cood {
  * \param _structsNativeSizeInByte
  * Size of the structure referenced by `_pStruct` in bytes.\n
  * The value shall contain any padding bytes or gap bytes required by the native rules for data representation
- * and memory layout.
+ * and memory layout. Zero is not allowed.
  *
  * \param _pMutex
  * Pointer to a mutex protecting access to the native data referenced by `_pStruct`.\n
@@ -92,6 +92,9 @@ ObjectRECORD::ObjectRECORD(std::string            const & _name,
 {
   if (pStruct == nullptr)
     throw std::invalid_argument("ObjectRECORD::ObjectRECORD: '_pStruct' is nullptr");
+
+  if (structsNativeSizeInByte == 0U)
+    throw std::invalid_argument("ObjectRECORD::ObjectRECORD: '_structsNativeSizeInByte' is zero");
 
   if (structsNativeSizeInByte > (static_cast<size_t>(std::numeric_limits<decltype(SubIdxDescr::byteOffset)>::max()) + 1U))
     throw std::invalid_argument("ObjectRECORD::ObjectRECORD: '_structsNativeSizeInByte' exceeds max. byte offset in SubIdxDescr");

--- a/src/cood/ObjectVAR.cpp
+++ b/src/cood/ObjectVAR.cpp
@@ -363,26 +363,33 @@ SDOAbortCode ObjectVAR::Write(uint8_t const subIdx,
   }
 
   // finally write to the object's data
-  switch (nBytesNative)
+  if (nElements_ == 1U)
   {
-    case 1U:
-      *static_cast<uint8_t*>(pData_) = *pTempMem;
-      break;
+    switch (nBytesNative)
+    {
+      case 1U:
+        *static_cast<uint8_t*>(pData_) = static_cast<uint8_t>(localMem);
+        break;
 
-    case 2U:
-      *static_cast<uint16_t*>(pData_) = *reinterpret_cast<uint16_t*>(pTempMem);
-      break;
+      case 2U:
+        *static_cast<uint16_t*>(pData_) = static_cast<uint16_t>(localMem);
+        break;
 
-    case 4U:
-      *static_cast<uint32_t*>(pData_) = *reinterpret_cast<uint32_t*>(pTempMem);
-      break;
+      case 4U:
+        *static_cast<uint32_t*>(pData_) = static_cast<uint32_t>(localMem);
+        break;
 
-    case 8U:
-      *static_cast<uint64_t*>(pData_) = localMem;
-      break;
+      case 8U:
+        *static_cast<uint64_t*>(pData_) = localMem;
+        break;
 
-    default:
-      memcpy(pData_, pTempMem, nBytesNative);
+      default:
+        memcpy(pData_, pTempMem, nBytesNative);
+    }
+  }
+  else
+  {
+    memcpy(pData_, pTempMem, nBytesNative);
   }
 
   try

--- a/src/log/internal/LogMessage.cpp
+++ b/src/log/internal/LogMessage.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011 Daniel Jerolm
+    Copyright (C) 2011, 2025 Daniel Jerolm
 */
 
 #include "LogMessage.hpp"
@@ -38,7 +38,7 @@ LogMessage::LogMessage(string::SharedString const & _srcName, LogType const _typ
 , type(static_cast<uint8_t>(_type))
 , pNext(nullptr)
 {
-};
+}
 
 } // namespace internal
 } // namespace log

--- a/src/osal/os/chibios_arm/Thread.cpp
+++ b/src/osal/os/chibios_arm/Thread.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011, 2024 Daniel Jerolm
+    Copyright (C) 2011, 2024, 2025 Daniel Jerolm
 */
 
 #ifdef OS_CHIBIOS_ARM
@@ -16,7 +16,6 @@
 #include <gpcc/osal/Panic.hpp>
 #include <gpcc/string/StringComposer.hpp>
 #include <gpcc/string/tools.hpp>
-#include <cxxabi.h>
 #include <stdexcept>
 #include <system_error>
 
@@ -980,11 +979,6 @@ msg_t Thread::InternalThreadEntry2(void) noexcept
       threadState = ThreadState::terminated;
 
       return TEC_TerminateNow;
-    }
-    catch (abi::__forced_unwind const &)
-    {
-      // catching abi::__forced_unwind should be impossible on this platform
-      PANIC();
     }
     catch (std::exception const & e)
     {

--- a/src/osal/os/linux_arm/Thread.cpp
+++ b/src/osal/os/linux_arm/Thread.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011, 2024 Daniel Jerolm
+    Copyright (C) 2011, 2024, 2025 Daniel Jerolm
 */
 
 #ifdef OS_LINUX_ARM
@@ -15,7 +15,6 @@
 #include <gpcc/osal/MutexLocker.hpp>
 #include <gpcc/osal/Panic.hpp>
 #include <gpcc/string/StringComposer.hpp>
-#include <cxxabi.h>
 #include <sched.h>
 #include <time.h>
 #include <unistd.h>
@@ -1145,8 +1144,8 @@ ThreadRegistry& Thread::InternalGetThreadRegistry(void)
  *
  * __Exception safety:__\n
  * Strong guarantee.\n
- * The only exception which could be thrown is the special exception `abi::__forced_unwind` which is used by
- * pthread-library to implement deferred thread cancellation.
+ * The only exception which could be thrown is the special exception `abi::__forced_unwind` (or similar) which is used
+ * by pthread-library to implement deferred thread cancellation.
  *
  * __Thread cancellation safety:__\n
  * Welcome and properly handled.
@@ -1180,8 +1179,8 @@ void* Thread::InternalThreadEntry1(void* arg)
  *
  * __Exception safety:__\n
  * Strong guarantee.\n
- * The only exception which could be thrown is the special exception `abi::__forced_unwind` which is used by
- * pthread-library to implement deferred thread cancellation.
+ * The only exception which could be thrown is the special exception `abi::__forced_unwind` (or similar) which is used
+ * by pthread-library to implement deferred thread cancellation.
  *
  * __Thread cancellation safety:__\n
  * Welcome and properly handled.
@@ -1211,7 +1210,11 @@ void* Thread::InternalThreadEntry2(void)
     // set threadState to ThreadState::terminated
     threadState = ThreadState::terminated;
   }
-  catch (abi::__forced_unwind const &)
+  catch (std::exception const & e)
+  {
+    Panic("Thread::InternalThreadEntry2: Caught exception: ", e);
+  }
+  catch (...)
   {
     // Thread was cancelled using POSIX functionality.
     // Do not forget to set threadState to ThreadState::terminated and rethrow the exception.
@@ -1224,18 +1227,10 @@ void* Thread::InternalThreadEntry2(void)
     }
     catch (...)
     {
-      PANIC(); // Handling of deferred cancellation (abi::__forced_unwind) failed
+      PANIC(); // Handling of deferred cancellation failed
     }
 
     throw;
-  }
-  catch (std::exception const & e)
-  {
-    Panic("Thread::InternalThreadEntry2: Caught exception: ", e);
-  }
-  catch (...)
-  {
-    Panic("Thread::InternalThreadEntry2: Caught unknown exception");
   }
 
   return retVal;

--- a/src/osal/os/linux_arm_tfc/Thread.cpp
+++ b/src/osal/os/linux_arm_tfc/Thread.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011, 2024 Daniel Jerolm
+    Copyright (C) 2011, 2024, 2025 Daniel Jerolm
 */
 
 #ifdef OS_LINUX_ARM_TFC
@@ -23,7 +23,6 @@
 #include "internal/UnmanagedConditionVariable.hpp"
 #include "internal/UnmanagedMutex.hpp"
 #include "internal/UnmanagedMutexLocker.hpp"
-#include <cxxabi.h>
 #include <sched.h>
 #include <unistd.h>
 #include <stdexcept>
@@ -1244,8 +1243,8 @@ ThreadRegistry& Thread::InternalGetThreadRegistry(void)
  *
  * __Exception safety:__\n
  * Strong guarantee.\n
- * The only exception which could be thrown is the special exception `abi::__forced_unwind` which is used by
- * pthread-library to implement deferred thread cancellation.
+ * The only exception which could be thrown is the special exception `abi::__forced_unwind` (or similar) which is used
+ * by pthread-library to implement deferred thread cancellation.
  *
  * __Thread cancellation safety:__\n
  * Welcome and properly handled.
@@ -1279,8 +1278,8 @@ void* Thread::InternalThreadEntry1(void* arg)
  *
  * __Exception safety:__\n
  * Strong guarantee.\n
- * The only exception which could be thrown is the special exception `abi::__forced_unwind` which is used by
- * pthread-library to implement deferred thread cancellation.
+ * The only exception which could be thrown is the special exception `abi::__forced_unwind` (or similar) which is used
+ * by pthread-library to implement deferred thread cancellation.
  *
  * __Thread cancellation safety:__\n
  * Welcome and properly handled.
@@ -1327,7 +1326,11 @@ void* Thread::InternalThreadEntry2(void)
 
     mutexLocker.Unlock();
   }
-  catch (abi::__forced_unwind const &)
+  catch (std::exception const & e)
+  {
+    Panic("Thread::InternalThreadEntry2: Caught exception: ", e);
+  }
+  catch (...)
   {
     // Thread was cancelled using POSIX functionality.
     try
@@ -1356,18 +1359,10 @@ void* Thread::InternalThreadEntry2(void)
     }
     catch (...)
     {
-      PANIC(); // Handling of deferred cancellation (abi::__forced_unwind) failed
+      PANIC(); // Handling of deferred cancellation failed
     }
 
     throw;
-  }
-  catch (std::exception const & e)
-  {
-    Panic("Thread::InternalThreadEntry2: Caught exception: ", e);
-  }
-  catch (...)
-  {
-    Panic("Thread::InternalThreadEntry2: Caught unknown exception");
   }
 
   return retVal;

--- a/src/osal/os/linux_x64/Thread.cpp
+++ b/src/osal/os/linux_x64/Thread.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011, 2024 Daniel Jerolm
+    Copyright (C) 2011, 2024, 2025 Daniel Jerolm
 */
 
 #ifdef OS_LINUX_X64
@@ -15,7 +15,6 @@
 #include <gpcc/osal/MutexLocker.hpp>
 #include <gpcc/osal/Panic.hpp>
 #include <gpcc/string/StringComposer.hpp>
-#include <cxxabi.h>
 #include <sched.h>
 #include <time.h>
 #include <unistd.h>
@@ -1145,8 +1144,8 @@ ThreadRegistry& Thread::InternalGetThreadRegistry(void)
  *
  * __Exception safety:__\n
  * Strong guarantee.\n
- * The only exception which could be thrown is the special exception `abi::__forced_unwind` which is used by
- * pthread-library to implement deferred thread cancellation.
+ * The only exception which could be thrown is the special exception `abi::__forced_unwind` (or similar) which is used
+ * by pthread-library to implement deferred thread cancellation.
  *
  * __Thread cancellation safety:__\n
  * Welcome and properly handled.
@@ -1180,8 +1179,8 @@ void* Thread::InternalThreadEntry1(void* arg)
  *
  * __Exception safety:__\n
  * Strong guarantee.\n
- * The only exception which could be thrown is the special exception `abi::__forced_unwind` which is used by
- * pthread-library to implement deferred thread cancellation.
+ * The only exception which could be thrown is the special exception `abi::__forced_unwind` (or similar) which is used
+ * by pthread-library to implement deferred thread cancellation.
  *
  * __Thread cancellation safety:__\n
  * Welcome and properly handled.
@@ -1211,7 +1210,11 @@ void* Thread::InternalThreadEntry2(void)
     // set threadState to ThreadState::terminated
     threadState = ThreadState::terminated;
   }
-  catch (abi::__forced_unwind const &)
+  catch (std::exception const & e)
+  {
+    Panic("Thread::InternalThreadEntry2: Caught exception: ", e);
+  }
+  catch (...)
   {
     // Thread was cancelled using POSIX functionality.
     // Do not forget to set threadState to ThreadState::terminated and rethrow the exception.
@@ -1224,18 +1227,10 @@ void* Thread::InternalThreadEntry2(void)
     }
     catch (...)
     {
-      PANIC(); // Handling of deferred cancellation (abi::__forced_unwind) failed
+      PANIC(); // Handling of deferred cancellation failed
     }
 
     throw;
-  }
-  catch (std::exception const & e)
-  {
-    Panic("Thread::InternalThreadEntry2: Caught exception: ", e);
-  }
-  catch (...)
-  {
-    Panic("Thread::InternalThreadEntry2: Caught unknown exception");
   }
 
   return retVal;

--- a/src/osal/os/linux_x64_tfc/Thread.cpp
+++ b/src/osal/os/linux_x64_tfc/Thread.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011, 2024 Daniel Jerolm
+    Copyright (C) 2011, 2024, 2025 Daniel Jerolm
 */
 
 #ifdef OS_LINUX_X64_TFC
@@ -23,7 +23,6 @@
 #include "internal/UnmanagedConditionVariable.hpp"
 #include "internal/UnmanagedMutex.hpp"
 #include "internal/UnmanagedMutexLocker.hpp"
-#include <cxxabi.h>
 #include <sched.h>
 #include <unistd.h>
 #include <stdexcept>
@@ -1244,8 +1243,8 @@ ThreadRegistry& Thread::InternalGetThreadRegistry(void)
  *
  * __Exception safety:__\n
  * Strong guarantee.\n
- * The only exception which could be thrown is the special exception `abi::__forced_unwind` which is used by
- * pthread-library to implement deferred thread cancellation.
+ * The only exception which could be thrown is the special exception `abi::__forced_unwind` (or similar) which is used
+ * by pthread-library to implement deferred thread cancellation.
  *
  * __Thread cancellation safety:__\n
  * Welcome and properly handled.
@@ -1279,8 +1278,8 @@ void* Thread::InternalThreadEntry1(void* arg)
  *
  * __Exception safety:__\n
  * Strong guarantee.\n
- * The only exception which could be thrown is the special exception `abi::__forced_unwind` which is used by
- * pthread-library to implement deferred thread cancellation.
+ * The only exception which could be thrown is the special exception `abi::__forced_unwind` (or similar) which is used
+ * by pthread-library to implement deferred thread cancellation.
  *
  * __Thread cancellation safety:__\n
  * Welcome and properly handled.
@@ -1327,7 +1326,11 @@ void* Thread::InternalThreadEntry2(void)
 
     mutexLocker.Unlock();
   }
-  catch (abi::__forced_unwind const &)
+  catch (std::exception const & e)
+  {
+    Panic("Thread::InternalThreadEntry2: Caught exception: ", e);
+  }
+  catch (...)
   {
     // Thread was cancelled using POSIX functionality.
     try
@@ -1356,18 +1359,10 @@ void* Thread::InternalThreadEntry2(void)
     }
     catch (...)
     {
-      PANIC(); // Handling of deferred cancellation (abi::__forced_unwind) failed
+      PANIC(); // Handling of deferred cancellation failed
     }
 
     throw;
-  }
-  catch (std::exception const & e)
-  {
-    Panic("Thread::InternalThreadEntry2: Caught exception: ", e);
-  }
-  catch (...)
-  {
-    Panic("Thread::InternalThreadEntry2: Caught unknown exception");
   }
 
   return retVal;

--- a/testcases/file_systems/eeprom_section_system/FakeEEPROM.cpp
+++ b/testcases/file_systems/eeprom_section_system/FakeEEPROM.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011 Daniel Jerolm
+    Copyright (C) 2011, 2025 Daniel Jerolm
 */
 
 #include "FakeEEPROM.hpp"
@@ -36,7 +36,9 @@ FakeEEPROM::FakeEEPROM(size_t const _size, size_t const _pageSize)
     throw std::invalid_argument("FakeEEPROM::FakeEEPROM: _pageSize does not divide _size without remainder");
 
   spMem.reset(new uint8_t[size]);
-  memset(spMem.get(), 0x00, size);
+
+  if (size != 0U)
+    memset(spMem.get(), 0x00, size);
 }
 FakeEEPROM::FakeEEPROM(FakeEEPROM const & other)
 : gpcc::stdif::IRandomAccessStorage(other)
@@ -51,7 +53,8 @@ FakeEEPROM::FakeEEPROM(FakeEEPROM const & other)
 , enableUndo(other.enableUndo)
 , undoList(other.undoList)
 {
-  memcpy(spMem.get(), other.spMem.get(), size);
+  if (size != 0U)
+    memcpy(spMem.get(), other.spMem.get(), size);
 }
 FakeEEPROM::FakeEEPROM(FakeEEPROM && other)
 : gpcc::stdif::IRandomAccessStorage(std::move(other))
@@ -84,7 +87,8 @@ FakeEEPROM& FakeEEPROM::operator=(FakeEEPROM const & other)
     writeAndCheckAccessTillFailure = other.writeAndCheckAccessTillFailure;
     readAccessesTillThrow = other.readAccessesTillThrow;
     pageSize = other.pageSize;
-    memcpy(spMem.get(), other.spMem.get(), size);
+    if (size != 0U)
+      memcpy(spMem.get(), other.spMem.get(), size);
     enableUndo = other.enableUndo;
     undoList = other.undoList;
 
@@ -138,7 +142,8 @@ void FakeEEPROM::Read(uint32_t address, size_t n, void* pBuffer) const
   }
 
   CheckAccessBounds(address, n);
-  memcpy(pBuffer, spMem.get() + address, n);
+  if (n != 0U)
+    memcpy(pBuffer, spMem.get() + address, n);
 }
 void FakeEEPROM::Write(uint32_t address, size_t n, void const * pBuffer)
 {
@@ -156,7 +161,8 @@ void FakeEEPROM::Write(uint32_t address, size_t n, void const * pBuffer)
   void * const pDest = spMem.get() + address;
   if (enableUndo)
     undoList.push_back(FakeEEPROMUndo(address, n, pDest));
-  memcpy(pDest, pBuffer, n);
+  if (n != 0U)
+    memcpy(pDest, pBuffer, n);
 }
 bool FakeEEPROM::WriteAndCheck(uint32_t address, size_t n, void const * pBuffer, void* pAuxBuffer)
 {

--- a/testcases/file_systems/eeprom_section_system/FakeEEPROMUndo.cpp
+++ b/testcases/file_systems/eeprom_section_system/FakeEEPROMUndo.cpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2011 Daniel Jerolm
+    Copyright (C) 2011, 2025 Daniel Jerolm
 */
 
 #include "FakeEEPROMUndo.hpp"
@@ -23,14 +23,16 @@ FakeEEPROMUndo::FakeEEPROMUndo(uint32_t const _startAddress, size_t const _size,
 , size(_size)
 , spMem(new uint8_t[_size])
 {
-  memcpy(spMem.get(), pData, size);
+  if (size != 0U)
+    memcpy(spMem.get(), pData, size);
 }
 FakeEEPROMUndo::FakeEEPROMUndo(FakeEEPROMUndo const & other)
 : startAddress(other.startAddress)
 , size(other.size)
 , spMem(new uint8_t[other.size])
 {
-  memcpy(spMem.get(), other.spMem.get(), size);
+  if (size != 0U)
+    memcpy(spMem.get(), other.spMem.get(), size);
 }
 FakeEEPROMUndo::FakeEEPROMUndo(FakeEEPROMUndo && other)
 : startAddress(other.startAddress)
@@ -50,7 +52,8 @@ FakeEEPROMUndo& FakeEEPROMUndo::operator=(FakeEEPROMUndo const & other)
       size = other.size;
     }
     startAddress = other.startAddress;
-    memcpy(spMem.get(), other.spMem.get(), size);
+    if (size != 0U)
+      memcpy(spMem.get(), other.spMem.get(), size);
   }
 
   return *this;
@@ -70,7 +73,8 @@ FakeEEPROMUndo& FakeEEPROMUndo::operator=(FakeEEPROMUndo && other)
 
 void FakeEEPROMUndo::Revert(void* const pMem) const
 {
-  memcpy(static_cast<uint8_t*>(pMem) + startAddress, spMem.get(), size);
+  if (size != 0U)
+    memcpy(static_cast<uint8_t*>(pMem) + startAddress, spMem.get(), size);
 }
 
 } // namespace file_systems


### PR DESCRIPTION
This PR will remove compiler warnings related to issues detected by GCC's Undefined Behaviour Sanitizer.