### PR TITLE
ci: Fix installation of valgrind in github-hosted runner

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -26,7 +26,9 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install valgrind
-      run: sudo apt-get -y install valgrind
+      run: |
+        sudo apt-get update
+        sudo apt-get -y install valgrind
 
     - name: CMake configure
       working-directory: ${{github.workspace}}/scripts


### PR DESCRIPTION
This PR fixes the failing installation of valgrind.
Github recommends, that `apt update` shall be invoked before anything is installed into a github-hosted runner.
Details: [Github docs: Customizing github hosted runners](https://docs.github.com/en/actions/how-tos/using-github-hosted-runners/customizing-github-hosted-runners)
