### PR TITLE
ci: Use least-privileged GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -16,7 +16,8 @@ on:
   workflow_dispatch:
 
 permissions:
-  read-all
+  contents:
+    read
 
 jobs:
   build-and-test:

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -15,6 +15,9 @@ on:
   # Allows triggering this workflow manually from the Action tab
   workflow_dispatch:
 
+permissions:
+  read-all
+
 jobs:
   build-and-test:
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.


### PR DESCRIPTION
This PR updates the existing workflow for building and running unittests in that it uses minimum privileges when running.
Alongside with this PR, the repositories' configuration has been changed to grant minimum permissions to workflows by default.

The measures are inspired from https://www.scorecard.dev recommendations regarding [token permissions](https://github.com/ossf/scorecard/blob/ab2f6e92482462fe66246d9e32f642855a691dc1/docs/checks.md#token-permissions).

The goal is to increase the GPCC's scorecard rating.