### PR TITLE
docs: Add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# GPCC Security Policy
+GPCC takes security issues seriously. We appreciate your efforts to disclose your findings responsibly.
+
+## Disclosing a security issue is different from reporting a bug
+
+In contrast to normal bugs, security issues can be exploited by malicious users or malicious organizations to attack or compromise a device or system. To avoid provision of knowledge and inspiration to an potential attacker, security issues should not be filed the same way as normal bugs. Technical details about vulnerabilities should not be visible to the public until they are fixed.
+
+GPCC uses github's private vulnerability reporting to provide you an option to report and disclose a security issue responsibly.
+
+## Reporting a vulnerability
+To report a vulnerability, please navigate to https://github.com/DanielJerolm/gpcc/security and click the "[Report a Vulnerability](https://github.com/DanielJerolm/gpcc/security/advisories/new)" button.
+
+Your report should include the following information:
+- A detailed description of the issue.
+- The version or the commit hash of GPCC that is affected by the issue.
+- A detailed description of the environment (e.g. which OS, productive/unittest etc).
+- Description of steps to reproduce the issue.
+- Proposal for mitigation (optional).
+
+GPCC is an open source project maintained by volunteers. We cannot guarantee a specific response time, but our goal is to check and triage any reported issue within 10 days and to give you first feedback within this timespan.


### PR DESCRIPTION
This PR adds a security policy that provides guide to users
who want to report a security issue/vulnerability.

Alongside with this commit, github's private vulnerability
reporting has been enabled.

The measure is inspired from https://www.scorecard.dev/ recommendations.