### PR TITLE
fix: Use snprintf() instead of sniprintf()

### DIFF
--- a/include/gpcc/string/StringComposer.hpp
+++ b/include/gpcc/string/StringComposer.hpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2024 Daniel Jerolm
+    Copyright (C) 2024, 2025 Daniel Jerolm
 */
 
 #ifndef STRINGCOMPOSER_HPP_202407291957
@@ -268,8 +268,6 @@ class StringComposer final
     int width_;               ///<Configuration: Field with for any output appended to the composed string.
     int prec_;                ///<Configuration: Precision that shall be used in floating-point conversions.
 
-    template<typename T>
-    void PrintiToBuffer(char* const buffer, size_t const bufferSize, Type const type, T const value) const;
     template<typename T>
     void PrintToBuffer(char* const buffer, size_t const bufferSize, Type const type, T const value) const;
     bool SetupFormatString(char* pFMT, Type const type) const noexcept;

--- a/include/gpcc/string/tools.tcc
+++ b/include/gpcc/string/tools.tcc
@@ -65,19 +65,11 @@ std::string ToHex(T const value, uint8_t const digits)
   int status;
   if (sizeof(T) <= sizeof(unsigned long))
   {
-    #if defined(_NEWLIB_VERSION)
-      status = sniprintf(buffer, sizeof(buffer), "0x%0*lX", static_cast<int>(digits), static_cast<unsigned long>(value));
-    #else
-      status = snprintf(buffer, sizeof(buffer), "0x%0*lX", static_cast<int>(digits), static_cast<unsigned long>(value));
-    #endif
+    status = snprintf(buffer, sizeof(buffer), "0x%0*lX", static_cast<int>(digits), static_cast<unsigned long>(value));
   }
   else
   {
-    #if defined(_NEWLIB_VERSION)
-      status = sniprintf(buffer, sizeof(buffer), "0x%0*llX", static_cast<int>(digits), static_cast<unsigned long long>(value));
-    #else
-      status = snprintf(buffer, sizeof(buffer), "0x%0*llX", static_cast<int>(digits), static_cast<unsigned long long>(value));
-    #endif
+    status = snprintf(buffer, sizeof(buffer), "0x%0*llX", static_cast<int>(digits), static_cast<unsigned long long>(value));
   }
 
   if (status < 0)
@@ -210,19 +202,11 @@ std::string ToHexNoPrefix(T const value, uint8_t const digits)
   int status;
   if (sizeof(T) <= sizeof(unsigned long))
   {
-    #if defined(_NEWLIB_VERSION)
-      status = sniprintf(buffer, sizeof(buffer), "%0*lX", static_cast<int>(digits), static_cast<unsigned long>(value));
-    #else
-      status = snprintf(buffer, sizeof(buffer), "%0*lX", static_cast<int>(digits), static_cast<unsigned long>(value));
-    #endif
+    status = snprintf(buffer, sizeof(buffer), "%0*lX", static_cast<int>(digits), static_cast<unsigned long>(value));
   }
   else
   {
-    #if defined(_NEWLIB_VERSION)
-      status = sniprintf(buffer, sizeof(buffer), "%0*llX", static_cast<int>(digits), static_cast<unsigned long long>(value));
-    #else
-      status = snprintf(buffer, sizeof(buffer), "%0*llX", static_cast<int>(digits), static_cast<unsigned long long>(value));
-    #endif
+    status = snprintf(buffer, sizeof(buffer), "%0*llX", static_cast<int>(digits), static_cast<unsigned long long>(value));
   }
 
   if (status < 0)

--- a/src/string/StringComposer.cpp
+++ b/src/string/StringComposer.cpp
@@ -429,7 +429,7 @@ StringComposer& StringComposer::operator<<(short const rhv)
     return operator<<(static_cast<unsigned short>(rhv));
 
   char buffer[intConvBufSize];
-  PrintiToBuffer(buffer, sizeof(buffer), Type::s, rhv);
+  PrintToBuffer(buffer, sizeof(buffer), Type::s, rhv);
 
   str_ += buffer;
   width_ = 0;
@@ -440,7 +440,7 @@ StringComposer& StringComposer::operator<<(short const rhv)
 StringComposer& StringComposer::operator<<(unsigned short const rhv)
 {
   char buffer[intConvBufSize];
-  PrintiToBuffer(buffer, sizeof(buffer), Type::us, rhv);
+  PrintToBuffer(buffer, sizeof(buffer), Type::us, rhv);
 
   str_ += buffer;
   width_ = 0;
@@ -454,7 +454,7 @@ StringComposer& StringComposer::operator<<(int const rhv)
     return operator<<(static_cast<unsigned int>(rhv));
 
   char buffer[intConvBufSize];
-  PrintiToBuffer(buffer, sizeof(buffer), Type::i, rhv);
+  PrintToBuffer(buffer, sizeof(buffer), Type::i, rhv);
 
   str_ += buffer;
   width_ = 0;
@@ -465,7 +465,7 @@ StringComposer& StringComposer::operator<<(int const rhv)
 StringComposer& StringComposer::operator<<(unsigned int const rhv)
 {
   char buffer[intConvBufSize];
-  PrintiToBuffer(buffer, sizeof(buffer), Type::ui, rhv);
+  PrintToBuffer(buffer, sizeof(buffer), Type::ui, rhv);
 
   str_ += buffer;
   width_ = 0;
@@ -479,7 +479,7 @@ StringComposer& StringComposer::operator<<(long const rhv)
     return operator<<(static_cast<unsigned long>(rhv));
 
   char buffer[intConvBufSize];
-  PrintiToBuffer(buffer, sizeof(buffer), Type::l, rhv);
+  PrintToBuffer(buffer, sizeof(buffer), Type::l, rhv);
 
   str_ += buffer;
   width_ = 0;
@@ -490,7 +490,7 @@ StringComposer& StringComposer::operator<<(long const rhv)
 StringComposer& StringComposer::operator<<(unsigned long const rhv)
 {
   char buffer[intConvBufSize];
-  PrintiToBuffer(buffer, sizeof(buffer), Type::ul, rhv);
+  PrintToBuffer(buffer, sizeof(buffer), Type::ul, rhv);
 
   str_ += buffer;
   width_ = 0;
@@ -504,7 +504,7 @@ StringComposer& StringComposer::operator<<(long long const rhv)
     return operator<<(static_cast<unsigned long long>(rhv));
 
   char buffer[intConvBufSize];
-  PrintiToBuffer(buffer, sizeof(buffer), Type::ll, rhv);
+  PrintToBuffer(buffer, sizeof(buffer), Type::ll, rhv);
 
   str_ += buffer;
   width_ = 0;
@@ -515,7 +515,7 @@ StringComposer& StringComposer::operator<<(long long const rhv)
 StringComposer& StringComposer::operator<<(unsigned long long const rhv)
 {
   char buffer[intConvBufSize];
-  PrintiToBuffer(buffer, sizeof(buffer), Type::ull, rhv);
+  PrintToBuffer(buffer, sizeof(buffer), Type::ull, rhv);
 
   str_ += buffer;
   width_ = 0;
@@ -918,71 +918,6 @@ std::string StringComposer::Get(void) const
 {
   return str_;
 }
-
-/**
- * \brief Prints a single integer value into a buffer.
- *
- * This makes use of `sniprintf()` if it is available.
- *
- * - - -
- *
- * __Thread safety:__\n
- * The state of the object is not modified. Concurrent accesses are safe.
- *
- * __Exception safety:__\n
- * Strong guarantee.
- *
- * __Thread cancellation safety:__\n
- * No cancellation point included.
- *
- * - - -
- *
- * \tparam T
- * Type of value.
- *
- * \param buffer
- * The converted value is written into the referenced buffer.
- *
- * \param bufferSize
- * Size of the buffer referenced by @p buffer.
- *
- * \param type
- * Type of @p value. Must match @p T.
- *
- * \param value
- * Value that shall be converted into a string.
- */
-#if defined(_NEWLIB_VERSION)
-template<typename T>
-void StringComposer::PrintiToBuffer(char* const buffer, size_t const bufferSize, Type const type, T const value) const
-{
-  int const width = CalcWidthForsnprintf(type);
-  char fmt[maxFmtStrBufSize];
-  int status;
-
-  // fmt is generated. Don't complain.
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wformat-nonliteral"
-
-  if (!SetupFormatString(fmt, type))
-    status = sniprintf(buffer, bufferSize, fmt, width, value);
-  else
-    status = sniprintf(buffer, bufferSize, fmt, width, prec_, value);
-
-  #pragma GCC diagnostic pop
-
-  if (status < 0)
-    throw std::logic_error("sniprintf failed");
-  else if (static_cast<size_t>(status) >= bufferSize)
-    throw std::logic_error("buffer too small");
-}
-#else
-template<typename T>
-void StringComposer::PrintiToBuffer(char* const buffer, size_t const bufferSize, Type const type, T const value) const
-{
-  PrintToBuffer(buffer, bufferSize, type, value);
-}
-#endif
 
 /**
  * \brief Prints a single integer or floating-point value into a buffer.


### PR DESCRIPTION
`sniprintf()` (and friends) are a newlib-specific extension to the standard C-library, which supports integer types only. The idea is to use only the i-variants if floating point data types are not used in a project and thus safe a few kB of code.

Before this PR, GPCC used `sniprintf()` in cases where only integer types are involved and where _newlib_ is the C-library. To detect if newlib is the C-library, presence of the preprocessor define `_NEWLIB_VERSION` was tested.

However, on Zephyr `_NEWLIB_VERSION` is defined, but the functions are not available resulting in compiler warnings (use of undefined function) and linker errors. The reason is unknown.

However, in _large projects_ (>150kB of code) there is no significant benefit from using `sniprintf()` (and friends) because:
- floating point types may simply be required
- there is plenty of flash and the few saved kB of code are not worth compared to the total size of the project

The PR removes any usage of `sniprintf()` (and friends) from GPCC and replaces it with `snprintf()` and friends.
Closes #31 