### PR TITLE
fix: Check args of Thread::GetInfo on EPOS

### DIFF
--- a/src/osal/os/epos_arm/Thread.cpp
+++ b/src/osal/os/epos_arm/Thread.cpp
@@ -230,6 +230,9 @@ Thread::~Thread(void)
  */
 std::string Thread::GetInfo(size_t const nameFieldWidth) const
 {
+  if (nameFieldWidth < 4U)
+    throw std::invalid_argument("'nameFieldWidth' too small");
+
   using gpcc::string::StringComposer;
   StringComposer infoLine;
 


### PR DESCRIPTION
This PR adds a missing check to the parameter `nameFieldWidth` of `Thread::GetInfo()`, to enforce the minimum value of 4.