### PR TITLE
doc: Do not include test sources in productive documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,11 +200,20 @@ if(Doxygen_FOUND)
   SetupDoxygenPredefinedTag(DOXYGEN_PREDEFINED_LIST)
   string(REPLACE ";"  ", " DOXYGEN_PREDEFINED "${DOXYGEN_PREDEFINED_LIST}")
 
+  list(APPEND DOXYGEN_INPUT_LIST "include/gpcc")
+  list(APPEND DOXYGEN_INPUT_LIST "src")
+  if(${GPCC_TargetEnvironment} STREQUAL "unittest")
+    list(APPEND DOXYGEN_INPUT_LIST "include/gpcc_test")
+    list(APPEND DOXYGEN_INPUT_LIST "test_src")
+    list(APPEND DOXYGEN_INPUT_LIST "testcases")
+  endif()
+  string(REPLACE ";"  " \\\n                         " DOXYGEN_INPUT "${DOXYGEN_INPUT_LIST}")
+
   configure_file(doc/doxygen/doxyfile.in ${GPCC_DOXYGEN_OUT}/doxyfile @ONLY)
 
   add_custom_target(gpcc_doxygen
                     COMMAND doxygen ${GPCC_DOXYGEN_OUT}/doxyfile
-                    WORKING_DIRECTORY ${GPCC_DOXYGEN_OUT}
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
                     COMMENT "Generating doxygen documentation for GPCC\nOutput location: ${GPCC_DOXYGEN_OUT}/html")
 
   add_custom_command(TARGET gpcc_doxygen

--- a/doc/doxygen/doxyfile.in
+++ b/doc/doxygen/doxyfile.in
@@ -951,10 +951,7 @@ WARN_LOGFILE           = @GPCC_DOXYGEN_OUT@/warnings.log
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = @GPCC_BASE@/include \
-                         @GPCC_BASE@/src \
-                         @GPCC_BASE@/test_src \
-                         @GPCC_BASE@/testcases
+INPUT                  = @DOXYGEN_INPUT@
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/doc/doxygen/doxyfile_chibios_arm
+++ b/doc/doxygen/doxyfile_chibios_arm
@@ -50,7 +50,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = GPCC
+PROJECT_NAME           = "GPCC (for chibios_arm)"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version

--- a/doc/doxygen/doxyfile_chibios_arm
+++ b/doc/doxygen/doxyfile_chibios_arm
@@ -952,10 +952,8 @@ WARN_LOGFILE           = ../../build_doxygen_chibios_arm/warnings.log
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ../../include \
-                         ../../src \
-                         ../../test_src \
-                         ../../testcases
+INPUT                  = ../../include/gpcc \
+                         ../../src
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/doc/doxygen/doxyfile_chibios_arm_extract_all
+++ b/doc/doxygen/doxyfile_chibios_arm_extract_all
@@ -50,7 +50,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = GPCC
+PROJECT_NAME           = "GPCC (for chibios_arm)"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version

--- a/doc/doxygen/doxyfile_epos_arm
+++ b/doc/doxygen/doxyfile_epos_arm
@@ -50,7 +50,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = GPCC
+PROJECT_NAME           = "GPCC (for epos_arm)"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version

--- a/doc/doxygen/doxyfile_epos_arm
+++ b/doc/doxygen/doxyfile_epos_arm
@@ -952,10 +952,8 @@ WARN_LOGFILE           = ../../build_doxygen_epos_arm/warnings.log
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ../../include \
-                         ../../src \
-                         ../../test_src \
-                         ../../testcases
+INPUT                  = ../../include/gpcc \
+                         ../../src
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/doc/doxygen/doxyfile_epos_arm_extract_all
+++ b/doc/doxygen/doxyfile_epos_arm_extract_all
@@ -50,7 +50,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = GPCC
+PROJECT_NAME           = "GPCC (for epos_arm)"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version

--- a/doc/doxygen/doxyfile_linux_arm
+++ b/doc/doxygen/doxyfile_linux_arm
@@ -50,7 +50,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = GPCC
+PROJECT_NAME           = "GPCC (for linux_arm)"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version

--- a/doc/doxygen/doxyfile_linux_arm
+++ b/doc/doxygen/doxyfile_linux_arm
@@ -952,10 +952,8 @@ WARN_LOGFILE           = ../../build_doxygen_linux_arm/warnings.log
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ../../include \
-                         ../../src \
-                         ../../test_src \
-                         ../../testcases
+INPUT                  = ../../include/gpcc \
+                         ../../src
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/doc/doxygen/doxyfile_linux_arm_extract_all
+++ b/doc/doxygen/doxyfile_linux_arm_extract_all
@@ -50,7 +50,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = GPCC
+PROJECT_NAME           = "GPCC (for linux_arm)"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version

--- a/doc/doxygen/doxyfile_linux_arm_tfc
+++ b/doc/doxygen/doxyfile_linux_arm_tfc
@@ -50,7 +50,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = GPCC
+PROJECT_NAME           = "GPCC (for linux_arm_tfc)"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version

--- a/doc/doxygen/doxyfile_linux_arm_tfc_extract_all
+++ b/doc/doxygen/doxyfile_linux_arm_tfc_extract_all
@@ -50,7 +50,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = GPCC
+PROJECT_NAME           = "GPCC (for linux_arm_tfc)"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version

--- a/doc/doxygen/doxyfile_linux_x64
+++ b/doc/doxygen/doxyfile_linux_x64
@@ -50,7 +50,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = GPCC
+PROJECT_NAME           = "GPCC (for linux_x64)"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version

--- a/doc/doxygen/doxyfile_linux_x64
+++ b/doc/doxygen/doxyfile_linux_x64
@@ -952,10 +952,8 @@ WARN_LOGFILE           = ../../build_doxygen_linux_x64/warnings.log
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ../../include \
-                         ../../src \
-                         ../../test_src \
-                         ../../testcases
+INPUT                  = ../../include/gpcc \
+                         ../../src
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/doc/doxygen/doxyfile_linux_x64_extract_all
+++ b/doc/doxygen/doxyfile_linux_x64_extract_all
@@ -50,7 +50,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = GPCC
+PROJECT_NAME           = "GPCC (for linux_x64)"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version

--- a/doc/doxygen/doxyfile_linux_x64_tfc
+++ b/doc/doxygen/doxyfile_linux_x64_tfc
@@ -50,7 +50,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = GPCC
+PROJECT_NAME           = "GPCC (for linux_x64_tfc)"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version

--- a/doc/doxygen/doxyfile_linux_x64_tfc_extract_all
+++ b/doc/doxygen/doxyfile_linux_x64_tfc_extract_all
@@ -50,7 +50,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = GPCC
+PROJECT_NAME           = "GPCC (for linux_x64_tfc)"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version

--- a/include/gpcc/cli/CLIColors.hpp
+++ b/include/gpcc/cli/CLIColors.hpp
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2019 Daniel Jerolm
+    Copyright (C) 2019, 2025 Daniel Jerolm
 */
 
 #ifndef CLICOLORS_HPP_201803282204
@@ -52,7 +52,7 @@
  *
  * # Unit tests
  * Font, color, and style control information should be disabled when building a unit test executable. Otherwise test
- * cases using a [CLI](@ref gpcc::cli::CLI) and a [FakeTerminal](@ref gpcc_tests::cli::FakeTerminal) could experience
+ * cases using a [CLI](@ref gpcc::cli::CLI) and a fake terminal (e.g. `gpcc_tests::cli::FakeTerminal`) could experience
  * difficulties when they have to deal with the control information instead of plain text only. The section below
  * describes how to disable font, color, and style control information.
  *

--- a/src/compiler/compiler.dox
+++ b/src/compiler/compiler.dox
@@ -5,7 +5,7 @@
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    Copyright (C) 2019, 2024 Daniel Jerolm
+    Copyright (C) 2019, 2024, 2025 Daniel Jerolm
 */
 
 /**
@@ -23,9 +23,6 @@
  * - Portable keywords for declaring non-returning functions
  * - `#defines` indicating the system's endian
  * - Overflow-aware arithmethic functions
- *
- * Note that there are additional abstractions for compiler-specific stuff, that are available in the unittest
- * environment only. See @ref GPCC_TESTS_COMPILER for details.
  *
  * # Usage
  * To access GPCC's compiler abstractions, the appropriate header files located in gpcc/compiler have to be


### PR DESCRIPTION
This PR prevents integration of documentation of _test-specific_ code and _test cases_ into doxygen documentation generated for _productive_ use.

For doxygen generation driven by CMake, the CMake cache variable `GPCC_TargetEnvironment` will control if test-sources shall be included in the documentation or not.

For documentation generated using the doxyfiles in doc/doxygen, doxyfiles including `_tfc_` in their name are considered for unittest environments and thus will include test-sources into the generated documentation. All other doxyfiles are considered for productive use and will not include test-sources any more.