### PR TITLE
fix(osal/zephyr): Sanity checks

### DIFF
--- a/src/osal/os/zephyr/ConditionVariable.cpp
+++ b/src/osal/os/zephyr/ConditionVariable.cpp
@@ -57,11 +57,6 @@ ConditionVariable::ConditionVariable(void)
  */
 ConditionVariable::~ConditionVariable(void)
 {
-  // Lock for accessing the internals of 'condVar_' is not accessible.
-  // Testing without the required lock will not create false positives, but there is a small chance that a usage error
-  // is not detected. This is acceptable, since the altenative is to have no check at all.
-  if (condVar_.wait_q.waitq.head != nullptr)
-    Panic("ConditionVariable::~ConditionVariable: Thread blocked");
 }
 
 /**

--- a/src/osal/os/zephyr/Semaphore.cpp
+++ b/src/osal/os/zephyr/Semaphore.cpp
@@ -65,11 +65,6 @@ Semaphore::Semaphore(size_t const initialValue)
  */
 Semaphore::~Semaphore(void)
 {
-  // Lock for accessing the internals of 'sem_' is not accessible.
-  // Testing without the required lock will not create false positives, but there is a small chance that a usage error
-  // is not detected. This is acceptable, since the altenative is to have no check at all.
-  if (sem_.wait_q.waitq.head != nullptr)
-    Panic("Semaphore::~Semaphore: Thread blocked");
 }
 
 /**


### PR DESCRIPTION
This PR removes the sanity checks from the destructor of class
`ConditionVariable` and `Semaphore`. The check results in false
positives. Since there is no trivial check if a thread is still blocked
in any of these synchronization elements, the checks are removed.