### PR TITLE
feat(FixCapFIFO): External locking for push/pop no longer required

### DIFF
--- a/history.txt
+++ b/history.txt
@@ -4,29 +4,6 @@ GPCC Implementation History and Current Activities
 
 Next to do:
 ===============================================================================
-- Add support for Zephyr
-  - [OK] Extend CMake files
-  - [OK] Add doxygen (normal+extract-all)
-    - [OK] doxyfile
-    - [OK] build script
-  - [OK] OSAL
-    - [OK] AdvancedMutexLocker
-    - [OK] ConditionVariable
-    - [OK] definitions.hpp
-    - [OK] IThreadRegistry
-    - [OK] Mutex
-    - [OK] MutexLocker
-    - [OK] Panic
-    - [OK] RWLock
-    - [OK] RWLockReadLocker
-    - [OK] RWLockWriteLocker
-    - [OK] Semaphore
-    - [OK] Thread
-    - [OK] ThreadRegistry
-    - [OK] clock
-  - [OK] Fix all TODO ZEPHYR
-  - [OK] Build against Zephyr & fix compiler issues
-
 - StringComposer::SetupFormatString contains a TODO
 
 - Use github's issue tracking instead of this file
@@ -225,6 +202,9 @@ Next to do:
 
 History:
 ===============================================================================
+2025-12-09
+- FixCapFIFO: External locking no longer required for push/pop
+
 2025-11-06
 - Generate doxygen documentation via CMake
 

--- a/include/gpcc/container/FixCapFIFO.hpp
+++ b/include/gpcc/container/FixCapFIFO.hpp
@@ -27,11 +27,25 @@ namespace container {
  * interrupt context. The capacity is fixed in terms that push-operations will not increase the capacity when the FIFO
  * becomes full. However, copy- and move-assignment may change the FIFO's capacity.
  *
- * If the user applies the locking mechanisms for synchronization of thread and interrupt context offered by the
- * specific operating system properly, then this FIFO can be used to transfer data between interrupt and thread context.
- * Please refer to the thread-safety notes of each method to determine which methods of the FIFO can be used from
- * interrupt context.
+ * # Build-in Synchronization
+ * The push- and pop-methods internally use atomics. The FIFO can be used to transfer data from a producer in interrupt
+ * or thread context to an consumer in a different thread or interrupt context without the need for external
+ * synchronization measures.
  *
+ * However, the user __must__ apply proper external locking/synchronization if:
+ * - Methods other than @ref Push(), @ref Pop(), @ref PushMultiple(), or @ref PopMultiple() are used from different
+ *   contexts.
+ * - More than one producer uses @ref Push() and/or @ref PushMultiple()
+ * - More than one consumer uses @ref Pop() and/or @ref PopMultiple()
+ *
+ * If only thread context is used, then locking measures may incorporate an @ref gpcc::osal::Mutex for instance. If
+ * interrupt context is involved, then the user has to apply locking mechanisms for synchronization of thread and
+ * interrupt context provided by the specific operating system.
+ *
+ * Please refer to the thread-safety notes of each method to determine which methods of the FIFO can be used from
+ * interrupt context and if external synchronization is required.
+ *
+ * # Use in interrupt context
  * The following measures were applied to methods that can be invoked from interrupt context:
  * - No memory allocation.
  * - No exceptions are thrown, not even under the hood.
@@ -62,8 +76,10 @@ namespace container {
  * - - -
  *
  * __Thread safety:__\n
- * Not thread-safe, but non-modifying concurrent access is safe.\n
- * Selected member functions can be invoked from interrupt context, if the caller applies proper locking.
+ * - Not thread-safe. If used from different contexts, then the user has to apply proper locking. As an exception, push-
+ *   and pop-operations use atomics and can be invoked from different contexts.\n
+ * - Selected member functions can be invoked from interrupt context.\n
+ * - Pay attention to method's thread-safety notes.
  */
 template <typename T, typename SIZET = size_t>
 class FixCapFIFO final

--- a/include/gpcc/container/FixCapFIFO.hpp
+++ b/include/gpcc/container/FixCapFIFO.hpp
@@ -11,8 +11,9 @@
 #ifndef FIXCAPFIFO_HPP_202509081955
 #define FIXCAPFIFO_HPP_202509081955
 
-#include <cstddef>
+#include <atomic>
 #include <memory>
+#include <cstddef>
 
 namespace gpcc      {
 namespace container {
@@ -99,7 +100,7 @@ class FixCapFIFO final
     SIZET capacity_;
 
     /// Number of items currently stored in the FIFO.
-    SIZET size_;
+    std::atomic<SIZET> size_;
 
     /// Index of next element to be written in @ref spMemory_.
     SIZET wrIndex_;

--- a/include/gpcc/container/FixCapFIFO.hpp
+++ b/include/gpcc/container/FixCapFIFO.hpp
@@ -47,7 +47,7 @@ namespace container {
  *
  * # Use in interrupt context
  * The following measures were applied to methods that can be invoked from interrupt context:
- * - No memory allocation.
+ * - No dynamic memory allocation.
  * - No exceptions are thrown, not even under the hood.
  * - FIFO overflow/underflow awareness and report by return value.
  * - No use of functions from the C/C++ runtime that are unavailable or incompatible with interrupt context.\n
@@ -76,8 +76,8 @@ namespace container {
  * - - -
  *
  * __Thread safety:__\n
- * - Not thread-safe. If used from different contexts, then the user has to apply proper locking. As an exception, push-
- *   and pop-operations use atomics and can be invoked from different contexts.\n
+ * - Not thread-safe. If used from different contexts, then the user has to apply proper locking.\n
+ *   As an exception, push- and pop-operations use atomics and can be invoked from different contexts.\n
  * - Selected member functions can be invoked from interrupt context.\n
  * - Pay attention to method's thread-safety notes.
  */

--- a/include/gpcc/container/FixCapFIFO.tcc
+++ b/include/gpcc/container/FixCapFIFO.tcc
@@ -434,10 +434,10 @@ size_t FixCapFIFO<T, SIZET>::PushMultiple(T const * const pSrc, size_t const n) 
 
   // Fetch current number of items in the FIFO. "size_" might be decreased by a pop-operation during this function,
   // but that's not harmful because it increases the number of free slots.
-  size_t const level = size_.load(std::memory_order_acquire);
+  size_t const used = size_.load(std::memory_order_acquire);
 
   // calculate number of free slots and number of elements to be pushed
-  size_t const free = capacity_ - level;
+  size_t const free = capacity_ - used;
   size_t const tbp = std::min(free, n);
 
   // calculate number of elements that can be pushed until the write-index wraps around
@@ -503,10 +503,10 @@ size_t FixCapFIFO<T, SIZET>::PopMultiple(T* const pDest, size_t const n) noexcep
 
   // Fetch current number of items in the FIFO. "size_" might be increased by a push-operation during this function,
   // but that's not harmful, because it increases the number of available items.
-  size_t const level = size_.load(std::memory_order_acquire);
+  size_t const used = size_.load(std::memory_order_acquire);
 
   // calculate number of element that shall be popped from the FIFO
-  size_t const tbp = std::min(static_cast<size_t>(level), n);
+  size_t const tbp = std::min(used, n);
 
   // calculate number of elements that can be popped until the read-index wraps around
   size_t const untilWrap = capacity_ - rdIndex_;

--- a/include/gpcc/container/FixCapFIFO.tcc
+++ b/include/gpcc/container/FixCapFIFO.tcc
@@ -466,7 +466,7 @@ size_t FixCapFIFO<T, SIZET>::PushMultiple(T const * const pSrc, size_t const n) 
 /**
  * \brief Pops one or more elements from the FIFO.
  *
- * This method handles an empty FIFO or an insufficient number of elements in the FIFO gracefully.
+ * This method handles an empty FIFO or a too small number of elements in the FIFO gracefully.
  *
  * - - -
  *

--- a/include/gpcc/container/FixCapFIFO.tcc
+++ b/include/gpcc/container/FixCapFIFO.tcc
@@ -223,7 +223,11 @@ size_t FixCapFIFO<T, SIZET>::Capacity(void) const noexcept
  *
  * __Thread safety:__\n
  * The state of the object is not modified. Concurrent accesses are safe.\n
- * This can be invoked from thread and interrupt context.
+ * This can be invoked from thread and interrupt context.\n
+ * This method can be used in conjunction with @ref Push(), @ref PushMultiple(), @ref Pop(), and @ref PopMultiple()
+ * without external synchronization. The return value will be valid, but may be outdated immediately. Note that an
+ * outdated value is not harmful if this is invoked by the producer (consumer) before pushing (popping) elements.
+ * If an outdated value is not acceptable, then the caller must apply external synchronization.
  *
  * __Thread cancellation safety:__\n
  * No cancellation point included.
@@ -246,7 +250,9 @@ size_t FixCapFIFO<T, SIZET>::Size(void) const noexcept
  *
  * __Thread safety:__\n
  * The state of the object is not modified. Concurrent accesses are safe.\n
- * This can be invoked from thread and interrupt context.
+ * This can be invoked from thread and interrupt context if the caller applies proper synchronization.\n
+ * As an exception, a consumer may omit external synchronization measures, if false positives are acceptable (method
+ * returns `true`, although the FIFO is not empty).
  *
  * __Thread cancellation safety:__\n
  * No cancellation point included.
@@ -269,7 +275,9 @@ bool FixCapFIFO<T, SIZET>::IsEmpty(void) const noexcept
  *
  * __Thread safety:__\n
  * The state of the object is not modified. Concurrent accesses are safe.\n
- * This can be invoked from thread and interrupt context.
+ * This can be invoked from thread and interrupt context if the caller applies proper synchronization.\n
+ * As an exception, a producer may omit external synchronization measures, if false positives are acceptable (method
+ * returns `true`, although the FIFO is not full).
  *
  * __Thread cancellation safety:__\n
  * No cancellation point included.

--- a/include/gpcc/container/FixCapFIFO.tcc
+++ b/include/gpcc/container/FixCapFIFO.tcc
@@ -56,6 +56,9 @@ FixCapFIFO<T, SIZET>::FixCapFIFO(size_t const capacity)
                 && (sizeof(SIZET) <= sizeof(size_t)),
                 "SIZET must be an unsigned integral type. Its size must be equal to or less than 'size_t'.");
 
+  static_assert(std::atomic<SIZET>::is_always_lock_free,
+                "std::atomic must be lock-free for SIZET, but it is not");
+
   #pragma GCC diagnostic push
   #pragma GCC diagnostic ignored "-Wtype-limits"
   if (   (capacity == 0U)
@@ -90,8 +93,8 @@ template <typename T, typename SIZET>
 FixCapFIFO<T, SIZET>::FixCapFIFO(FixCapFIFO<T, SIZET> const & other)
 : spMemory_(new T[other.capacity_])
 , capacity_(other.capacity_)
-, size_(other.size_)
-, wrIndex_((size_ == capacity_) ? 0U : size_)
+, size_(other.size_.load(std::memory_order_relaxed))
+, wrIndex_((size_.load(std::memory_order_relaxed) == capacity_) ? 0U : size_.load(std::memory_order_relaxed))
 , rdIndex_(0U)
 {
   CopyFromOther(other);
@@ -138,8 +141,8 @@ FixCapFIFO<T, SIZET>& FixCapFIFO<T, SIZET>::operator=(FixCapFIFO<T, SIZET> const
       capacity_ = rhv.capacity_;
     }
 
-    size_    = rhv.size_;
-    wrIndex_ = (size_ == capacity_) ? 0U : size_;
+    size_.store(rhv.size_.load(std::memory_order_relaxed), std::memory_order_relaxed);
+    wrIndex_ = (size_.load(std::memory_order_relaxed) == capacity_) ? 0U : size_.load(std::memory_order_relaxed);
     rdIndex_ = 0U;
     CopyFromOther(rhv);
   }
@@ -178,11 +181,11 @@ FixCapFIFO<T, SIZET>& FixCapFIFO<T, SIZET>::operator=(FixCapFIFO<T, SIZET> && rh
     std::swap(spMemory_, rhv.spMemory_);
     std::swap(capacity_, rhv.capacity_);
 
-    size_    = rhv.size_;
+    size_.store(rhv.size_.load(std::memory_order_relaxed), std::memory_order_relaxed);
     wrIndex_ = rhv.wrIndex_;
     rdIndex_ = rhv.rdIndex_;
 
-    rhv.size_ = 0U;
+    rhv.size_.store(0U, std::memory_order_relaxed);
     rhv.wrIndex_ = 0U;
     rhv.rdIndex_ = 0U;
   }
@@ -233,7 +236,7 @@ size_t FixCapFIFO<T, SIZET>::Capacity(void) const noexcept
 template <typename T, typename SIZET>
 size_t FixCapFIFO<T, SIZET>::Size(void) const noexcept
 {
-  return size_;
+  return size_.load(std::memory_order_relaxed);
 }
 
 /**
@@ -256,7 +259,7 @@ size_t FixCapFIFO<T, SIZET>::Size(void) const noexcept
 template <typename T, typename SIZET>
 bool FixCapFIFO<T, SIZET>::IsEmpty(void) const noexcept
 {
-  return (size_ == 0U);
+  return (size_.load(std::memory_order_relaxed) == 0U);
 }
 
 /**
@@ -279,7 +282,7 @@ bool FixCapFIFO<T, SIZET>::IsEmpty(void) const noexcept
 template <typename T, typename SIZET>
 bool FixCapFIFO<T, SIZET>::IsFull(void) const noexcept
 {
-  return (size_ == capacity_);
+  return (size_.load(std::memory_order_relaxed) == capacity_);
 }
 
 /**
@@ -302,7 +305,7 @@ bool FixCapFIFO<T, SIZET>::IsFull(void) const noexcept
 template <typename T, typename SIZET>
 void FixCapFIFO<T, SIZET>::Clear(void) noexcept
 {
-  size_    = 0U;
+  size_.store(0U, std::memory_order_relaxed);
   rdIndex_ = 0U;
   wrIndex_ = 0U;
 }
@@ -333,7 +336,7 @@ void FixCapFIFO<T, SIZET>::Clear(void) noexcept
 template <typename T, typename SIZET>
 bool FixCapFIFO<T, SIZET>::Push(T const value) noexcept
 {
-  if (IsFull())
+  if (size_.load(std::memory_order_acquire) == capacity_)
     return false;
 
   spMemory_[wrIndex_++] = value;
@@ -341,7 +344,7 @@ bool FixCapFIFO<T, SIZET>::Push(T const value) noexcept
   if (wrIndex_ == capacity_)
     wrIndex_ = 0U;
 
-  size_++;
+  (void)size_.fetch_add(1U, std::memory_order_release);
 
   return true;
 }
@@ -372,7 +375,7 @@ bool FixCapFIFO<T, SIZET>::Push(T const value) noexcept
 template <typename T, typename SIZET>
 bool FixCapFIFO<T, SIZET>::Pop(T & value) noexcept
 {
-  if (IsEmpty())
+  if (size_.load(std::memory_order_acquire) == 0U)
     return false;
 
   value = spMemory_[rdIndex_++];
@@ -380,7 +383,7 @@ bool FixCapFIFO<T, SIZET>::Pop(T & value) noexcept
   if (rdIndex_ == capacity_)
     rdIndex_ = 0U;
 
-  size_--;
+  (void)size_.fetch_sub(1U, std::memory_order_release);
 
   return true;
 }
@@ -420,41 +423,34 @@ size_t FixCapFIFO<T, SIZET>::PushMultiple(T const * const pSrc, size_t const n) 
   if (n == 0U)
     return 0U;
 
+  // Fetch current number of items in the FIFO. "size_" might be decreased by a pop-operation during this function,
+  // but that's not harmful because it increases the number of free slots.
+  size_t const level = size_.load(std::memory_order_acquire);
+
   // calculate number of free slots and number of elements to be pushed
-  size_t const free = capacity_ - size_;
+  size_t const free = capacity_ - level;
   size_t const tbp = std::min(free, n);
 
-  if (wrIndex_ < rdIndex_)
+  // calculate number of elements that can be pushed until the write-index wraps around
+  size_t const untilWrap = capacity_ - wrIndex_;
+
+  if (tbp <= untilWrap)
   {
     memcpy(spMemory_.get() + wrIndex_, pSrc, tbp * sizeof(T));
     wrIndex_ += tbp;
-    size_ += tbp;
+    if (wrIndex_ == capacity_)
+      wrIndex_ = 0U;
   }
   else
   {
-    // calculate number of elements that can be pushed until the write-index wraps around
-    size_t const untilWrap = capacity_ - wrIndex_;
+    memcpy(spMemory_.get() + wrIndex_, pSrc, untilWrap * sizeof(T));
 
-    if (untilWrap >= tbp)
-    {
-      memcpy(spMemory_.get() + wrIndex_, pSrc, tbp * sizeof(T));
-      wrIndex_ += tbp;
-      if (wrIndex_ == capacity_)
-        wrIndex_ = 0U;
-      size_ += tbp;
-    }
-    else
-    {
-      size_ += tbp;
-
-      memcpy(spMemory_.get() + wrIndex_, pSrc, untilWrap * sizeof(T));
-
-      size_t const rest = tbp - untilWrap;
-      memcpy(spMemory_.get(), pSrc + untilWrap, rest * sizeof(T));
-      wrIndex_ = rest;
-    }
+    size_t const rest = tbp - untilWrap;
+    memcpy(spMemory_.get(), pSrc + untilWrap, rest * sizeof(T));
+    wrIndex_ = rest;
   }
 
+  (void)size_.fetch_add(tbp, std::memory_order_release);
   return tbp;
 }
 
@@ -493,40 +489,33 @@ size_t FixCapFIFO<T, SIZET>::PopMultiple(T* const pDest, size_t const n) noexcep
   if (n == 0U)
     return 0U;
 
-  // calculate number of element that shall be popped from the FIFO
-  size_t const tbp = std::min(static_cast<size_t>(size_), n);
+  // Fetch current number of items in the FIFO. "size_" might be increased by a push-operation during this function,
+  // but that's not harmful, because it increases the number of available items.
+  size_t const level = size_.load(std::memory_order_acquire);
 
-  if (rdIndex_ < wrIndex_)
+  // calculate number of element that shall be popped from the FIFO
+  size_t const tbp = std::min(static_cast<size_t>(level), n);
+
+  // calculate number of elements that can be popped until the read-index wraps around
+  size_t const untilWrap = capacity_ - rdIndex_;
+
+  if (tbp <= untilWrap)
   {
     memcpy(pDest, spMemory_.get() + rdIndex_, tbp * sizeof(T));
     rdIndex_ += tbp;
-    size_ -= tbp;
+    if (rdIndex_ == capacity_)
+      rdIndex_ = 0U;
   }
   else
   {
-    // calculate number of elements that can be popped until the read-index wraps around
-    size_t const untilWrap = capacity_ - rdIndex_;
+    memcpy(pDest, spMemory_.get() + rdIndex_, untilWrap * sizeof(T));
 
-    if (untilWrap >= tbp)
-    {
-      memcpy(pDest, spMemory_.get() + rdIndex_, tbp * sizeof(T));
-      rdIndex_ += tbp;
-      if (rdIndex_ == capacity_)
-        rdIndex_ = 0U;
-      size_ -= tbp;
-    }
-    else
-    {
-      size_ -= tbp;
-
-      memcpy(pDest, spMemory_.get() + rdIndex_, untilWrap * sizeof(T));
-
-      size_t const rest = tbp - untilWrap;
-      memcpy(pDest + untilWrap, spMemory_.get(), rest * sizeof(T));
-      rdIndex_ = rest;
-    }
+    size_t const rest = tbp - untilWrap;
+    memcpy(pDest + untilWrap, spMemory_.get(), rest * sizeof(T));
+    rdIndex_ = rest;
   }
 
+  (void)size_.fetch_sub(tbp, std::memory_order_release);
   return tbp;
 }
 
@@ -562,13 +551,13 @@ size_t FixCapFIFO<T, SIZET>::PopMultiple(T* const pDest, size_t const n) noexcep
 template <typename T, typename SIZET>
 void FixCapFIFO<T, SIZET>::CopyFromOther(FixCapFIFO const & other) noexcept
 {
-  if (size_ != 0U)
+  if (size_.load(std::memory_order_relaxed) != 0U)
   {
     if (other.rdIndex_ < other.wrIndex_)
     {
       // not full, no wrap: |     xxxx |
       //                       -->    <-- size_
-      memcpy(spMemory_.get(), other.spMemory_.get() + other.rdIndex_, size_ * sizeof(T));
+      memcpy(spMemory_.get(), other.spMemory_.get() + other.rdIndex_, size_.load(std::memory_order_relaxed) * sizeof(T));
     }
     else
     {
@@ -588,7 +577,7 @@ void FixCapFIFO<T, SIZET>::CopyFromOther(FixCapFIFO const & other) noexcept
       size_t const a = (other.capacity_ - other.rdIndex_);
       memcpy(spMemory_.get(), other.spMemory_.get() + other.rdIndex_, a * sizeof(T));
 
-      size_t const b = size_ - a;
+      size_t const b = size_.load(std::memory_order_relaxed) - a;
       if (b != 0U)
         memcpy(spMemory_.get() + a, other.spMemory_.get(), b * sizeof(T));
     }

--- a/include/gpcc/container/FixCapFIFO.tcc
+++ b/include/gpcc/container/FixCapFIFO.tcc
@@ -200,7 +200,7 @@ FixCapFIFO<T, SIZET>& FixCapFIFO<T, SIZET>::operator=(FixCapFIFO<T, SIZET> && rh
  *
  * __Thread safety:__\n
  * The state of the object is not modified. Concurrent accesses are safe.\n
- * This can be invoked from interrupt context if the caller applies proper synchronization.
+ * This can be invoked from thread and interrupt context.
  *
  * __Thread cancellation safety:__\n
  * No cancellation point included.
@@ -223,7 +223,7 @@ size_t FixCapFIFO<T, SIZET>::Capacity(void) const noexcept
  *
  * __Thread safety:__\n
  * The state of the object is not modified. Concurrent accesses are safe.\n
- * This can be invoked from interrupt context if the caller applies proper synchronization.
+ * This can be invoked from thread and interrupt context.
  *
  * __Thread cancellation safety:__\n
  * No cancellation point included.
@@ -246,7 +246,7 @@ size_t FixCapFIFO<T, SIZET>::Size(void) const noexcept
  *
  * __Thread safety:__\n
  * The state of the object is not modified. Concurrent accesses are safe.\n
- * This can be invoked from interrupt context if the caller applies proper synchronization.
+ * This can be invoked from thread and interrupt context.
  *
  * __Thread cancellation safety:__\n
  * No cancellation point included.
@@ -269,7 +269,7 @@ bool FixCapFIFO<T, SIZET>::IsEmpty(void) const noexcept
  *
  * __Thread safety:__\n
  * The state of the object is not modified. Concurrent accesses are safe.\n
- * This can be invoked from interrupt context if the caller applies proper synchronization.
+ * This can be invoked from thread and interrupt context.
  *
  * __Thread cancellation safety:__\n
  * No cancellation point included.
@@ -294,7 +294,7 @@ bool FixCapFIFO<T, SIZET>::IsFull(void) const noexcept
  *
  * __Thread safety:__\n
  * The state of the object is modified. Any concurrent accesses are not safe.\n
- * This can be invoked from interrupt context if the caller applies proper synchronization.
+ * This can be invoked from thread and interrupt context.
  *
  * __Exception safety:__\n
  * No-throw guarantee.
@@ -316,8 +316,11 @@ void FixCapFIFO<T, SIZET>::Clear(void) noexcept
  * - - -
  *
  * __Thread safety:__\n
- * The state of the object is modified. Any concurrent accesses are not safe.\n
- * This can be invoked from interrupt context if the caller applies proper synchronization.
+ * The state of the object is modified. Any concurrent accesses are not safe, except for the following methods:\n
+ * - @ref Pop()
+ * - @ref PopMultiple()
+ *
+ * This can be invoked from thread and interrupt context.
  *
  * __Exception safety:__\n
  * No-throw guarantee.
@@ -355,8 +358,11 @@ bool FixCapFIFO<T, SIZET>::Push(T const value) noexcept
  * - - -
  *
  * __Thread safety:__\n
- * The state of the object is modified. Any concurrent accesses are not safe.\n
- * This can be invoked from interrupt context if the caller applies proper synchronization.
+ * The state of the object is modified. Any concurrent accesses are not safe, except for the following methods:\n
+ * - @ref Push()
+ * - @ref PushMultiple()
+ *
+ * This can be invoked from thread and interrupt context.
  *
  * __Exception safety:__\n
  * No-throw guarantee.
@@ -396,8 +402,11 @@ bool FixCapFIFO<T, SIZET>::Pop(T & value) noexcept
  * - - -
  *
  * __Thread safety:__\n
- * The state of the object is modified. Any concurrent accesses are not safe.\n
- * This can be invoked from interrupt context if the caller applies proper synchronization.
+ * The state of the object is modified. Any concurrent accesses are not safe, except for the following methods:\n
+ * - @ref Pop()
+ * - @ref PopMultiple()
+ *
+ * This can be invoked from thread and interrupt context.
  *
  * __Exception safety:__\n
  * No-throw guarantee.
@@ -462,8 +471,11 @@ size_t FixCapFIFO<T, SIZET>::PushMultiple(T const * const pSrc, size_t const n) 
  * - - -
  *
  * __Thread safety:__\n
- * The state of the object is modified. Any concurrent accesses are not safe.\n
- * This can be invoked from interrupt context if the caller applies proper synchronization.
+ * The state of the object is modified. Any concurrent accesses are not safe, except for the following methods:\n
+ * - @ref Push()
+ * - @ref PushMultiple()
+ *
+ * This can be invoked from thread and interrupt context.
  *
  * __Exception safety:__\n
  * No-throw guarantee.


### PR DESCRIPTION
This PR removes the need for external locking when using push- and pop-operations of the gpcc::container::FixCapFIFO, even from different contexts.