### PR TITLE
fix(ZephyrFrontEnd): Handle LOG_LEVEL_NONE properly

### DIFF
--- a/history.txt
+++ b/history.txt
@@ -202,6 +202,9 @@ Next to do:
 
 History:
 ===============================================================================
+2026-01-15
+- Bugfix: gpcc::log::ZephyrFrontEnd did not handle Zephyr log type LOG_LEVEL_NONE properly
+
 2025-12-09
 - FixCapFIFO: External locking no longer required for push/pop
 - Add gpcc::log::ZephyrFrontEnd and a backend for Zephyr's log system

--- a/src/log/integration/zephyr/ZephyrFrontEnd.cpp
+++ b/src/log/integration/zephyr/ZephyrFrontEnd.cpp
@@ -6,6 +6,7 @@
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
     Copyright (C) 2025 WAGO GmbH & Co. KG
+    Copyright (C) 2026 Daniel Jerolm
 */
 
 #ifdef OS_ZEPHYR
@@ -185,10 +186,11 @@ void ZephyrFrontEnd::MessageComplete(uint8_t const level) noexcept
       gpcc::log::LogType type = gpcc::log::LogType::Error;
       switch (level)
       {
-        case LOG_LEVEL_DBG: type = gpcc::log::LogType::Debug;   break;
-        case LOG_LEVEL_INF: type = gpcc::log::LogType::Info;    break;
-        case LOG_LEVEL_WRN: type = gpcc::log::LogType::Warning; break;
-        case LOG_LEVEL_ERR: type = gpcc::log::LogType::Error;   break;
+        case LOG_LEVEL_NONE: type = gpcc::log::LogType::Info;    break;
+        case LOG_LEVEL_DBG:  type = gpcc::log::LogType::Debug;   break;
+        case LOG_LEVEL_INF:  type = gpcc::log::LogType::Info;    break;
+        case LOG_LEVEL_WRN:  type = gpcc::log::LogType::Warning; break;
+        case LOG_LEVEL_ERR:  type = gpcc::log::LogType::Error;   break;
       }
 
       // emit log message


### PR DESCRIPTION
With this bugfix applied, output generated by Zephyr via `printk()` (LOG_LEVEL_NONE) will be logged using `gpcc::log::logType::Info` instead of `gpcc::log::logType::Error`.