### PR TITLE
ci: Use fine-grained access token for ossf/scorecard

### DIFF
--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -37,6 +37,7 @@ jobs:
       - name: "Run analysis"
         uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
+          repo_token: ${{ secrets.SCORECARD_TOKEN }}
           results_file: results.sarif
           results_format: sarif
           # Scorecard team runs a weekly scan of public GitHub repos,

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -15,6 +15,9 @@ on:
   push:
     branches: [ "develop" ]
 
+  # Allows triggering this workflow manually from the Action tab
+  workflow_dispatch:
+
 # Declare default permissions as read only.
 permissions: read-all
 


### PR DESCRIPTION
OSSF scorecard can't inspect branch prediction due to lack of permissions.

- Permissions were setup by adding a fine-grained access token to the GPCC repo according to https://github.com/ossf/scorecard-action/blob/main/docs/authentication/fine-grained-auth-token.md
- A repository secret "SCORECARD_TOKEN" was setup containing the token.
- "SCORECARD_TOKEN" is passed to ossf/scorecard-action

By the way, is there any possibility to run the workflow from this branch instead of from develop-branch?