### PR TITLE
feat: add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## What is this PR about?

It uses dependabot mechanism to create PR's if one of the used GitHub actions will have updates. That is common usage e.G. on GitHub to automatically check for available dependencies updates. I think it is a good way to save time by not checking for updates manually. And maybe you get some points on  OpenSSF Scorecard for this.

## How to test

You can only test if it is merged into the default branch. After merge it can be manually triggered from here => Insights → Dependency graph → Dependabot.