### PR TITLE
fix(OSAL/Zephyr): Set thread's name in Zephyr-thread

### DIFF
--- a/src/osal/os/zephyr/Thread.cpp
+++ b/src/osal/os/zephyr/Thread.cpp
@@ -841,6 +841,8 @@ void Thread::InternalThreadEntry1(void* p1, void* p2, void* p3) noexcept
  */
 void Thread::InternalThreadEntry2(void) noexcept
 {
+  k_thread_name_set(nullptr, name_.c_str());
+
   // set threadState to ThreadState::running
   {
     MutexLocker mutexLocker(mutex_);


### PR DESCRIPTION
With this commit, names assigned to GPCC threads will be assigned to the underlying Zephyr threads. The names will then show up in Zephyr's log output etc.